### PR TITLE
[codex] add graphified repo scan

### DIFF
--- a/app/cli.py
+++ b/app/cli.py
@@ -25,6 +25,7 @@ from app.core.portfolio import (
     render_portfolio_episode_markdown,
     write_portfolio_episode,
 )
+from app.core.repo_graph import RepoGraphBuilder
 from app.core.storage import RunStorage
 from app.core.workload import evaluate_workload_gates, load_workload_manifest
 
@@ -61,7 +62,10 @@ def scan(
 ) -> None:
     """Profile a local repository."""
     profile = RepoScanner().scan(repo)
-    console.print_json(profile.model_dump_json())
+    repo_graph = RepoGraphBuilder().build(repo)
+    payload = profile.model_dump(mode="json")
+    payload["repo_graph"] = repo_graph.model_dump(mode="json")
+    console.print_json(data=payload)
 
 
 @app.command()

--- a/app/core/graph.py
+++ b/app/core/graph.py
@@ -21,6 +21,7 @@ from app.core.edit_runner import ExternalWorkerRunner
 from app.core.git_utils import collect_changed_files, collect_deleted_files, collect_diff_summary
 from app.core.llm import LLMClient
 from app.core.memory import ExperienceMemory
+from app.core.repo_graph import RepoGraphBuilder
 from app.core.state import AgentOpsGraphState
 from app.core.storage import RunStorage
 from app.core.test_runner import TestRunner
@@ -37,9 +38,16 @@ def append_logs(state: AgentOpsGraphState, *entries: str) -> list[str]:
 
 def scan_repo_node(state: AgentOpsGraphState) -> AgentOpsGraphState:
     profile = RepoScanner().scan(state["repo_path"])
+    repo_graph = RepoGraphBuilder().build(state["repo_path"])
     return {
         "repo_profile": profile,
-        "execution_logs": append_logs(state, "scan_repo:start", "scan_repo:complete"),
+        "repo_graph": repo_graph,
+        "execution_logs": append_logs(
+            state,
+            "scan_repo:start",
+            "repo_graph:complete",
+            "scan_repo:complete",
+        ),
     }
 
 
@@ -394,6 +402,7 @@ def run_harness(
         task=task,
         repo_path=str(repo_path.resolve()),
         repo_profile=graph_state["repo_profile"],
+        repo_graph=graph_state["repo_graph"],
         memory_report=graph_state.get("memory_report") or MemoryReport(),
         plan=graph_state["plan"],
         changed_files=graph_state["changed_files"],

--- a/app/core/repo_graph/__init__.py
+++ b/app/core/repo_graph/__init__.py
@@ -1,0 +1,10 @@
+from app.core.repo_graph.builder import RepoGraphBuilder
+from app.core.repo_graph.models import RepoGraph, RepoGraphEdge, RepoGraphNode, RepoGraphSummary
+
+__all__ = [
+    "RepoGraph",
+    "RepoGraphBuilder",
+    "RepoGraphEdge",
+    "RepoGraphNode",
+    "RepoGraphSummary",
+]

--- a/app/core/repo_graph/builder.py
+++ b/app/core/repo_graph/builder.py
@@ -1,0 +1,347 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from app.core.repo_graph.dependency_parser import DependencyParser
+from app.core.repo_graph.java_parser import JavaParser
+from app.core.repo_graph.models import RepoGraph, RepoGraphEdge, RepoGraphNode, RepoGraphSummary
+from app.core.repo_graph.python_parser import PythonParser
+from app.core.repo_graph.risk_mapper import RiskMapper
+from app.core.repo_graph.test_mapper import TestMapper
+
+
+class RepoGraphBuilder:
+    IGNORED_PARTS = {
+        ".git",
+        ".mypy_cache",
+        ".pytest_cache",
+        ".ruff_cache",
+        ".tox",
+        ".venv",
+        "__pycache__",
+        "build",
+        "dist",
+        "node_modules",
+        "target",
+    }
+    CONFIG_FILES = {
+        ".env.example",
+        "Dockerfile",
+        "Makefile",
+        "build.gradle",
+        "build.gradle.kts",
+        "docker-compose.yml",
+        "pom.xml",
+        "pyproject.toml",
+        "requirements.txt",
+        "setup.py",
+    }
+
+    def __init__(self) -> None:
+        self.python_parser = PythonParser()
+        self.java_parser = JavaParser()
+        self.dependency_parser = DependencyParser()
+        self.test_mapper = TestMapper()
+        self.risk_mapper = RiskMapper()
+        self._nodes: dict[str, RepoGraphNode] = {}
+        self._edges: dict[tuple[str, str, str], RepoGraphEdge] = {}
+
+    def build(self, repo_path: Path) -> RepoGraph:
+        resolved = repo_path.resolve()
+        if not resolved.exists():
+            raise FileNotFoundError(f"Repository path does not exist: {repo_path}")
+
+        self._nodes = {}
+        self._edges = {}
+        files = [
+            path
+            for path in resolved.rglob("*")
+            if path.is_file() and not self._is_ignored(path.relative_to(resolved))
+        ]
+        relative_files = sorted(path.relative_to(resolved).as_posix() for path in files)
+        source_files: list[str] = []
+        test_files: list[str] = []
+        languages: set[str] = set()
+        frameworks: set[str] = set()
+        build_tools: set[str] = set()
+        test_frameworks: set[str] = set()
+
+        for relative_path in relative_files:
+            language = self._language_for_path(relative_path)
+            if language:
+                languages.add(language)
+                source_files.append(relative_path)
+            file_type = "test" if self._looks_like_test(relative_path) else "file"
+            if file_type == "test":
+                test_files.append(relative_path)
+            file_node_id = self._add_file_node(relative_path, language, file_type)
+            self._add_folder_edges(relative_path, file_node_id)
+
+            if Path(relative_path).name in self.CONFIG_FILES:
+                self._nodes[file_node_id].type = "config"
+
+            for risk in self.risk_mapper.risks_for_path(relative_path):
+                self._add_risk(relative_path, risk)
+
+            if relative_path.endswith(".py"):
+                parsed = self.python_parser.parse(resolved, relative_path)
+                if parsed.is_test and relative_path not in test_files:
+                    test_files.append(relative_path)
+                    self._nodes[file_node_id].type = "test"
+                if parsed.uses_fastapi:
+                    frameworks.add("fastapi")
+                if parsed.is_test:
+                    test_frameworks.add("pytest")
+                self._add_python_parse(relative_path, parsed)
+            elif relative_path.endswith(".java"):
+                parsed = self.java_parser.parse(resolved, relative_path)
+                if parsed.is_test and relative_path not in test_files:
+                    test_files.append(relative_path)
+                    self._nodes[file_node_id].type = "test"
+                if parsed.is_spring:
+                    frameworks.add("spring")
+                self._add_java_parse(relative_path, parsed)
+
+        dependencies = self.dependency_parser.parse(resolved, relative_files)
+        frameworks.update(dependencies.frameworks)
+        build_tools.update(dependencies.build_tools)
+        for dependency in dependencies.dependencies:
+            self._add_dependency(
+                dependency.name,
+                dependency.ecosystem,
+                dependency.source,
+                dependency.version,
+            )
+        for risk in dependencies.risks:
+            self._add_risk(None, risk)
+
+        self._add_likely_test_edges(test_files, source_files)
+        risks = [node for node in self._nodes.values() if node.type == "migration_risk"]
+        graph = RepoGraph(
+            repo_path=str(resolved),
+            summary=RepoGraphSummary(
+                languages=sorted(languages),
+                frameworks=sorted(frameworks),
+                build_tools=sorted(build_tools),
+                test_frameworks=sorted(test_frameworks),
+                source_file_count=len(source_files),
+                test_file_count=len(set(test_files)),
+                dependency_count=len(
+                    [node for node in self._nodes.values() if node.type == "dependency"]
+                ),
+                risk_count=len(risks),
+            ),
+            nodes=sorted(self._nodes.values(), key=lambda node: node.id),
+            edges=sorted(
+                self._edges.values(),
+                key=lambda edge: (edge.source, edge.type, edge.target),
+            ),
+        )
+        return graph
+
+    def _add_python_parse(self, relative_path: str, parsed) -> None:
+        file_node_id = self._file_id(relative_path)
+        for imported in parsed.imports:
+            import_id = f"import:python:{imported.name}"
+            self._add_node(
+                RepoGraphNode(
+                    id=import_id,
+                    type="import",
+                    name=imported.name,
+                    language="python",
+                    metadata={"imported_from": imported.imported_from},
+                )
+            )
+            self._add_edge(file_node_id, import_id, "imports")
+        for symbol in parsed.symbols:
+            symbol_id = f"{symbol.symbol_type}:python:{symbol.qualified_name}"
+            self._add_node(
+                RepoGraphNode(
+                    id=symbol_id,
+                    type=symbol.symbol_type,
+                    name=symbol.name,
+                    path=relative_path,
+                    language="python",
+                    metadata={"qualified_name": symbol.qualified_name, "line": symbol.line},
+                )
+            )
+            self._add_edge(file_node_id, symbol_id, "defines")
+        for route in parsed.routes:
+            route_id = f"route:python:{route.method}:{route.path}"
+            self._add_node(
+                RepoGraphNode(
+                    id=route_id,
+                    type="route",
+                    name=f"{route.method} {route.path}",
+                    path=relative_path,
+                    language="python",
+                    metadata={"method": route.method, "path": route.path, "line": route.line},
+                )
+            )
+            module_name = self.python_parser._module_name(relative_path)
+            function_id = f"function:python:{module_name}.{route.function_name}"
+            self._add_edge(function_id, route_id, "exposes_route")
+
+    def _add_java_parse(self, relative_path: str, parsed) -> None:
+        file_node_id = self._file_id(relative_path)
+        for imported in parsed.imports:
+            import_id = f"import:java:{imported}"
+            self._add_node(
+                RepoGraphNode(id=import_id, type="import", name=imported, language="java")
+            )
+            self._add_edge(file_node_id, import_id, "imports")
+        for class_info in parsed.classes:
+            class_id = f"class:java:{class_info.qualified_name}"
+            self._add_node(
+                RepoGraphNode(
+                    id=class_id,
+                    type="class",
+                    name=class_info.name,
+                    path=relative_path,
+                    language="java",
+                    metadata={
+                        "qualified_name": class_info.qualified_name,
+                        "class_type": class_info.class_type,
+                        "annotations": class_info.annotations,
+                        "line": class_info.line,
+                    },
+                )
+            )
+            self._add_edge(file_node_id, class_id, "defines")
+        for route in parsed.routes:
+            route_id = f"route:java:{route.method}:{route.path}"
+            self._add_node(
+                RepoGraphNode(
+                    id=route_id,
+                    type="route",
+                    name=f"{route.method} {route.path}",
+                    path=relative_path,
+                    language="java",
+                    metadata={"method": route.method, "path": route.path, "line": route.line},
+                )
+            )
+            owner_id = f"class:java:{route.owner}"
+            self._add_edge(owner_id, route_id, "exposes_route")
+        for risk in parsed.risks:
+            self._add_risk(relative_path, risk)
+
+    def _add_dependency(
+        self,
+        name: str,
+        ecosystem: str,
+        source: str | None,
+        version: str | None,
+    ) -> None:
+        dependency_id = f"dependency:{ecosystem}:{name}"
+        self._add_node(
+            RepoGraphNode(
+                id=dependency_id,
+                type="dependency",
+                name=name,
+                language=ecosystem,
+                metadata={"source": source, "version": version},
+            )
+        )
+        if source:
+            config_path = source
+            if config_path in self._nodes_by_path():
+                self._add_edge(self._file_id(config_path), dependency_id, "declares_dependency")
+
+    def _add_likely_test_edges(self, test_files: list[str], source_files: list[str]) -> None:
+        production_files = [path for path in source_files if path not in set(test_files)]
+        for test_file in sorted(set(test_files)):
+            source = self.test_mapper.likely_source_for_test(test_file, production_files)
+            if source:
+                self._add_edge(self._file_id(test_file), self._file_id(source), "likely_tests")
+
+    def _add_file_node(self, relative_path: str, language: str | None, node_type: str) -> str:
+        node_id = self._file_id(relative_path)
+        self._add_node(
+            RepoGraphNode(
+                id=node_id,
+                type=node_type,
+                name=Path(relative_path).name,
+                path=relative_path,
+                language=language,
+            )
+        )
+        return node_id
+
+    def _add_folder_edges(self, relative_path: str, file_node_id: str) -> None:
+        parent_id = "folder:."
+        self._add_node(RepoGraphNode(id=parent_id, type="folder", name=".", path="."))
+        parts = Path(relative_path).parts[:-1]
+        current_parts: list[str] = []
+        for part in parts:
+            current_parts.append(part)
+            folder_path = "/".join(current_parts)
+            folder_id = f"folder:{folder_path}"
+            self._add_node(
+                RepoGraphNode(id=folder_id, type="folder", name=part, path=folder_path)
+            )
+            self._add_edge(parent_id, folder_id, "contains")
+            parent_id = folder_id
+        self._add_edge(parent_id, file_node_id, "contains")
+
+    def _add_risk(self, relative_path: str | None, risk_name: str) -> None:
+        risk = self.risk_mapper.describe(risk_name)
+        risk_id = f"risk:{risk.name}"
+        self._add_node(
+            RepoGraphNode(
+                id=risk_id,
+                type="migration_risk",
+                name=risk.name,
+                path=relative_path,
+                metadata={"severity": risk.severity, "reason": risk.reason},
+            )
+        )
+        if relative_path:
+            self._add_edge(self._file_id(relative_path), risk_id, "has_risk")
+
+    def _add_node(self, node: RepoGraphNode) -> None:
+        if node.id not in self._nodes:
+            self._nodes[node.id] = node
+
+    def _add_edge(
+        self,
+        source: str,
+        target: str,
+        edge_type: str,
+        metadata: dict | None = None,
+    ) -> None:
+        key = (source, target, edge_type)
+        if key not in self._edges:
+            self._edges[key] = RepoGraphEdge(
+                source=source,
+                target=target,
+                type=edge_type,
+                metadata=metadata or {},
+            )
+
+    def _language_for_path(self, relative_path: str) -> str | None:
+        suffix = Path(relative_path).suffix
+        if suffix == ".py":
+            return "python"
+        if suffix == ".java":
+            return "java"
+        return None
+
+    def _looks_like_test(self, relative_path: str) -> bool:
+        name = Path(relative_path).name
+        return (
+            relative_path.startswith("tests/")
+            or "/src/test/" in f"/{relative_path}"
+            or name.startswith("test_")
+            or name.endswith("_test.py")
+            or name.endswith("Test.java")
+            or name.endswith("Tests.java")
+        )
+
+    def _is_ignored(self, relative_path: Path) -> bool:
+        return bool(set(relative_path.parts).intersection(self.IGNORED_PARTS))
+
+    def _file_id(self, relative_path: str) -> str:
+        return f"file:{relative_path}"
+
+    def _nodes_by_path(self) -> set[str]:
+        return {node.path for node in self._nodes.values() if node.path}

--- a/app/core/repo_graph/dependency_parser.py
+++ b/app/core/repo_graph/dependency_parser.py
@@ -1,0 +1,160 @@
+from __future__ import annotations
+
+import re
+import tomllib
+import xml.etree.ElementTree as ET
+from dataclasses import dataclass, field
+from pathlib import Path
+
+
+@dataclass(frozen=True)
+class Dependency:
+    name: str
+    ecosystem: str
+    version: str | None = None
+    source: str | None = None
+    metadata: dict[str, str] = field(default_factory=dict)
+
+
+@dataclass
+class DependencyParseResult:
+    dependencies: list[Dependency] = field(default_factory=list)
+    frameworks: set[str] = field(default_factory=set)
+    build_tools: set[str] = field(default_factory=set)
+    risks: list[str] = field(default_factory=list)
+
+
+class DependencyParser:
+    def parse(self, repo_path: Path, relative_files: list[str]) -> DependencyParseResult:
+        result = DependencyParseResult()
+        if "pyproject.toml" in relative_files:
+            self._parse_pyproject(repo_path / "pyproject.toml", result)
+        if "requirements.txt" in relative_files:
+            self._parse_requirements(repo_path / "requirements.txt", result)
+        if "pom.xml" in relative_files:
+            self._parse_pom(repo_path / "pom.xml", result)
+        if "build.gradle" in relative_files:
+            self._parse_gradle(repo_path / "build.gradle", result)
+        if "build.gradle.kts" in relative_files:
+            self._parse_gradle(repo_path / "build.gradle.kts", result)
+        return result
+
+    def _parse_pyproject(self, path: Path, result: DependencyParseResult) -> None:
+        result.build_tools.add("pyproject")
+        try:
+            payload = tomllib.loads(path.read_text(encoding="utf-8"))
+        except tomllib.TOMLDecodeError:
+            return
+        project = payload.get("project", {})
+        dependencies = project.get("dependencies", [])
+        for dependency in dependencies:
+            name = self._python_dependency_name(dependency)
+            result.dependencies.append(
+                Dependency(name=name, ecosystem="python", source="pyproject.toml")
+            )
+            if name == "fastapi":
+                result.frameworks.add("fastapi")
+
+    def _parse_requirements(self, path: Path, result: DependencyParseResult) -> None:
+        result.build_tools.add("pip")
+        for line in path.read_text(encoding="utf-8", errors="ignore").splitlines():
+            stripped = line.strip()
+            if not stripped or stripped.startswith("#"):
+                continue
+            name = self._python_dependency_name(stripped)
+            result.dependencies.append(
+                Dependency(name=name, ecosystem="python", source="requirements.txt")
+            )
+            if name == "fastapi":
+                result.frameworks.add("fastapi")
+
+    def _parse_pom(self, path: Path, result: DependencyParseResult) -> None:
+        result.build_tools.add("maven")
+        try:
+            root = ET.fromstring(path.read_text(encoding="utf-8", errors="ignore"))
+        except ET.ParseError:
+            return
+        namespace = self._xml_namespace(root.tag)
+        parent = root.find(f"{namespace}parent")
+        if parent is not None:
+            artifact = self._xml_text(parent, "artifactId", namespace)
+            version = self._xml_text(parent, "version", namespace)
+            if artifact:
+                result.dependencies.append(
+                    Dependency(
+                        name=artifact,
+                        ecosystem="java",
+                        version=version,
+                        source="pom.xml",
+                        metadata={"scope": "parent"},
+                    )
+                )
+                if artifact == "spring-boot-starter-parent":
+                    result.frameworks.add("spring_boot")
+                    if version and version.startswith("2."):
+                        result.risks.append("spring_boot_2_detected")
+        java_version = self._pom_property(root, namespace, "java.version")
+        if java_version and self._major_version(java_version) < 17:
+            result.risks.append("java_version_below_17")
+
+        for dependency in root.findall(f".//{namespace}dependency"):
+            group = self._xml_text(dependency, "groupId", namespace)
+            artifact = self._xml_text(dependency, "artifactId", namespace)
+            version = self._xml_text(dependency, "version", namespace)
+            if not artifact:
+                continue
+            name = f"{group}:{artifact}" if group else artifact
+            result.dependencies.append(
+                Dependency(name=name, ecosystem="java", version=version, source="pom.xml")
+            )
+            if artifact.startswith("spring-boot-starter"):
+                result.frameworks.add("spring_boot")
+            if group and group.startswith("javax"):
+                result.risks.append("javax_dependency_detected")
+
+    def _parse_gradle(self, path: Path, result: DependencyParseResult) -> None:
+        result.build_tools.add("gradle")
+        text = path.read_text(encoding="utf-8", errors="ignore")
+        if "org.springframework.boot" in text:
+            result.frameworks.add("spring_boot")
+            version = re.search(
+                r'id\s+["\']org\.springframework\.boot["\']\s+version\s+["\']([^"\']+)',
+                text,
+            )
+            if version and version.group(1).startswith("2."):
+                result.risks.append("spring_boot_2_detected")
+        java_version = re.search(r"sourceCompatibility\s*=\s*['\"]?(\d+)", text)
+        if java_version and int(java_version.group(1)) < 17:
+            result.risks.append("java_version_below_17")
+        for match in re.finditer(r"['\"]([A-Za-z0-9_.-]+:[A-Za-z0-9_.-]+:[^'\"]+)['\"]", text):
+            parts = match.group(1).split(":")
+            name = ":".join(parts[:2])
+            version = parts[2] if len(parts) > 2 else None
+            result.dependencies.append(
+                Dependency(name=name, ecosystem="java", version=version, source=path.name)
+            )
+            if name.startswith("javax"):
+                result.risks.append("javax_dependency_detected")
+
+    def _python_dependency_name(self, dependency: str) -> str:
+        return re.split(r"[<>=!~\[\]\s]", dependency, maxsplit=1)[0].lower()
+
+    def _xml_namespace(self, tag: str) -> str:
+        if tag.startswith("{"):
+            return tag.split("}", 1)[0] + "}"
+        return ""
+
+    def _xml_text(self, element: ET.Element, name: str, namespace: str) -> str | None:
+        child = element.find(f"{namespace}{name}")
+        return child.text.strip() if child is not None and child.text else None
+
+    def _pom_property(self, root: ET.Element, namespace: str, name: str) -> str | None:
+        properties = root.find(f"{namespace}properties")
+        if properties is None:
+            return None
+        value = properties.find(f"{namespace}{name}")
+        return value.text.strip() if value is not None and value.text else None
+
+    def _major_version(self, version: str) -> int:
+        match = re.search(r"\d+", version)
+        return int(match.group(0)) if match else 0

--- a/app/core/repo_graph/java_parser.py
+++ b/app/core/repo_graph/java_parser.py
@@ -1,0 +1,153 @@
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+
+
+@dataclass(frozen=True)
+class JavaClass:
+    name: str
+    qualified_name: str
+    class_type: str
+    annotations: list[str]
+    line: int
+
+
+@dataclass(frozen=True)
+class JavaRoute:
+    method: str
+    path: str
+    owner: str
+    line: int
+
+
+@dataclass
+class JavaParseResult:
+    package: str | None = None
+    imports: list[str] = field(default_factory=list)
+    classes: list[JavaClass] = field(default_factory=list)
+    routes: list[JavaRoute] = field(default_factory=list)
+    risks: list[str] = field(default_factory=list)
+    annotations: list[str] = field(default_factory=list)
+    is_spring: bool = False
+    is_test: bool = False
+
+
+class JavaParser:
+    CLASS_RE = re.compile(r"\b(class|interface|enum)\s+([A-Za-z_][A-Za-z0-9_]*)")
+    IMPORT_RE = re.compile(r"^\s*import\s+([^;]+);", re.MULTILINE)
+    PACKAGE_RE = re.compile(r"^\s*package\s+([^;]+);", re.MULTILINE)
+    ANNOTATION_RE = re.compile(r"^\s*@([A-Za-z_][A-Za-z0-9_]*)(?:\((.*?)\))?", re.MULTILINE)
+    ROUTE_METHODS = {
+        "GetMapping": "GET",
+        "PostMapping": "POST",
+        "PutMapping": "PUT",
+        "PatchMapping": "PATCH",
+        "DeleteMapping": "DELETE",
+    }
+    SPRING_ANNOTATIONS = {
+        "RestController",
+        "Controller",
+        "Service",
+        "Repository",
+        "Entity",
+        "SpringBootApplication",
+        "GetMapping",
+        "PostMapping",
+        "PutMapping",
+        "PatchMapping",
+        "DeleteMapping",
+        "RequestMapping",
+    }
+
+    def parse(self, repo_path: Path, relative_path: str) -> JavaParseResult:
+        text = (repo_path / relative_path).read_text(encoding="utf-8", errors="ignore")
+        result = JavaParseResult(is_test=self._is_test_file(relative_path))
+
+        package_match = self.PACKAGE_RE.search(text)
+        if package_match:
+            result.package = package_match.group(1).strip()
+
+        result.imports = [match.group(1).strip() for match in self.IMPORT_RE.finditer(text)]
+        annotations = [
+            (match.group(1), match.group(2) or "", self._line_for(text, match.start()))
+            for match in self.ANNOTATION_RE.finditer(text)
+        ]
+        result.annotations = sorted({name for name, _, _ in annotations})
+        result.is_spring = bool(set(result.annotations).intersection(self.SPRING_ANNOTATIONS))
+
+        class_annotations = [name for name, _, _ in annotations if name in self.SPRING_ANNOTATIONS]
+        for match in self.CLASS_RE.finditer(text):
+            class_type = match.group(1)
+            name = match.group(2)
+            qualified = f"{result.package}.{name}" if result.package else name
+            result.classes.append(
+                JavaClass(
+                    name=name,
+                    qualified_name=qualified,
+                    class_type=class_type,
+                    annotations=class_annotations,
+                    line=self._line_for(text, match.start()),
+                )
+            )
+
+        owner = result.classes[0].qualified_name if result.classes else relative_path
+        for name, raw_args, line in annotations:
+            route = self._route_for_annotation(name, raw_args, owner, line)
+            if route is not None:
+                result.routes.append(route)
+
+        result.risks = self._detect_risks(text, result.imports)
+        return result
+
+    def _route_for_annotation(
+        self,
+        name: str,
+        raw_args: str,
+        owner: str,
+        line: int,
+    ) -> JavaRoute | None:
+        if name in self.ROUTE_METHODS:
+            return JavaRoute(
+                method=self.ROUTE_METHODS[name],
+                path=self._mapping_path(raw_args),
+                owner=owner,
+                line=line,
+            )
+        if name == "RequestMapping":
+            return JavaRoute(
+                method="ANY",
+                path=self._mapping_path(raw_args),
+                owner=owner,
+                line=line,
+            )
+        return None
+
+    def _mapping_path(self, raw_args: str) -> str:
+        quoted = re.search(r'"([^"]+)"', raw_args)
+        if quoted:
+            return quoted.group(1)
+        value_arg = re.search(r"value\s*=\s*\"([^\"]+)\"", raw_args)
+        if value_arg:
+            return value_arg.group(1)
+        return "/"
+
+    def _detect_risks(self, text: str, imports: list[str]) -> list[str]:
+        risks: set[str] = set()
+        if any(name.startswith("javax.") for name in imports) or "javax." in text:
+            risks.add("javax_to_jakarta_required")
+        if "WebSecurityConfigurerAdapter" in text:
+            risks.add("web_security_configurer_adapter_removed")
+        return sorted(risks)
+
+    def _is_test_file(self, relative_path: str) -> bool:
+        name = Path(relative_path).name
+        return (
+            "/src/test/" in f"/{relative_path}"
+            or name.endswith("Test.java")
+            or name.endswith("Tests.java")
+        )
+
+    def _line_for(self, text: str, index: int) -> int:
+        return text.count("\n", 0, index) + 1

--- a/app/core/repo_graph/models.py
+++ b/app/core/repo_graph/models.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+from typing import Any, Literal
+
+from pydantic import BaseModel, Field
+
+RepoNodeType = Literal[
+    "folder",
+    "file",
+    "module",
+    "class",
+    "function",
+    "method",
+    "dependency",
+    "import",
+    "route",
+    "config",
+    "test",
+    "migration_risk",
+]
+
+RepoEdgeType = Literal[
+    "contains",
+    "defines",
+    "imports",
+    "declares_dependency",
+    "exposes_route",
+    "tests",
+    "likely_tests",
+    "depends_on",
+    "has_risk",
+    "affects",
+]
+
+
+class RepoGraphNode(BaseModel):
+    id: str
+    type: RepoNodeType
+    name: str
+    path: str | None = None
+    language: str | None = None
+    metadata: dict[str, Any] = Field(default_factory=dict)
+
+
+class RepoGraphEdge(BaseModel):
+    source: str
+    target: str
+    type: RepoEdgeType
+    metadata: dict[str, Any] = Field(default_factory=dict)
+
+
+class RepoGraphSummary(BaseModel):
+    languages: list[str] = Field(default_factory=list)
+    frameworks: list[str] = Field(default_factory=list)
+    build_tools: list[str] = Field(default_factory=list)
+    test_frameworks: list[str] = Field(default_factory=list)
+    source_file_count: int = 0
+    test_file_count: int = 0
+    dependency_count: int = 0
+    risk_count: int = 0
+
+
+class RepoGraph(BaseModel):
+    repo_path: str
+    summary: RepoGraphSummary = Field(default_factory=RepoGraphSummary)
+    nodes: list[RepoGraphNode] = Field(default_factory=list)
+    edges: list[RepoGraphEdge] = Field(default_factory=list)

--- a/app/core/repo_graph/python_parser.py
+++ b/app/core/repo_graph/python_parser.py
@@ -1,0 +1,138 @@
+from __future__ import annotations
+
+import ast
+from dataclasses import dataclass, field
+from pathlib import Path
+
+
+@dataclass(frozen=True)
+class PythonImport:
+    name: str
+    imported_from: str | None = None
+
+
+@dataclass(frozen=True)
+class PythonSymbol:
+    name: str
+    qualified_name: str
+    symbol_type: str
+    line: int
+
+
+@dataclass(frozen=True)
+class PythonRoute:
+    method: str
+    path: str
+    function_name: str
+    line: int
+
+
+@dataclass
+class PythonParseResult:
+    imports: list[PythonImport] = field(default_factory=list)
+    symbols: list[PythonSymbol] = field(default_factory=list)
+    routes: list[PythonRoute] = field(default_factory=list)
+    is_test: bool = False
+    uses_fastapi: bool = False
+
+
+class PythonParser:
+    ROUTE_METHODS = {"get", "post", "put", "patch", "delete", "options", "head"}
+
+    def parse(self, repo_path: Path, relative_path: str) -> PythonParseResult:
+        file_path = repo_path / relative_path
+        result = PythonParseResult(is_test=self._is_test_file(relative_path))
+        try:
+            tree = ast.parse(file_path.read_text(encoding="utf-8", errors="ignore"))
+        except SyntaxError:
+            return result
+
+        module = self._module_name(relative_path)
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Import):
+                for alias in node.names:
+                    result.imports.append(PythonImport(name=alias.name))
+                    if alias.name == "fastapi" or alias.name.startswith("fastapi."):
+                        result.uses_fastapi = True
+            elif isinstance(node, ast.ImportFrom):
+                imported_from = node.module or ""
+                for alias in node.names:
+                    name = f"{imported_from}.{alias.name}" if imported_from else alias.name
+                    result.imports.append(PythonImport(name=name, imported_from=imported_from))
+                if imported_from == "fastapi" or imported_from.startswith("fastapi."):
+                    result.uses_fastapi = True
+            elif isinstance(node, ast.ClassDef):
+                result.symbols.append(
+                    PythonSymbol(
+                        name=node.name,
+                        qualified_name=f"{module}.{node.name}",
+                        symbol_type="class",
+                        line=node.lineno,
+                    )
+                )
+                for item in node.body:
+                    if isinstance(item, ast.FunctionDef | ast.AsyncFunctionDef):
+                        result.symbols.append(
+                            PythonSymbol(
+                                name=item.name,
+                                qualified_name=f"{module}.{node.name}.{item.name}",
+                                symbol_type="method",
+                                line=item.lineno,
+                            )
+                        )
+            elif isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef):
+                result.symbols.append(
+                    PythonSymbol(
+                        name=node.name,
+                        qualified_name=f"{module}.{node.name}",
+                        symbol_type="function",
+                        line=node.lineno,
+                    )
+                )
+                result.routes.extend(self._routes_for_function(node))
+                if node.name.startswith("test_"):
+                    result.is_test = True
+
+        return result
+
+    def _routes_for_function(
+        self,
+        node: ast.FunctionDef | ast.AsyncFunctionDef,
+    ) -> list[PythonRoute]:
+        routes: list[PythonRoute] = []
+        for decorator in node.decorator_list:
+            if not isinstance(decorator, ast.Call):
+                continue
+            method = self._route_method(decorator.func)
+            if method is None or not decorator.args:
+                continue
+            path_arg = decorator.args[0]
+            if isinstance(path_arg, ast.Constant) and isinstance(path_arg.value, str):
+                routes.append(
+                    PythonRoute(
+                        method=method.upper(),
+                        path=path_arg.value,
+                        function_name=node.name,
+                        line=node.lineno,
+                    )
+                )
+        return routes
+
+    def _route_method(self, func: ast.expr) -> str | None:
+        if isinstance(func, ast.Attribute) and func.attr in self.ROUTE_METHODS:
+            return func.attr
+        return None
+
+    def _is_test_file(self, relative_path: str) -> bool:
+        name = Path(relative_path).name
+        return (
+            relative_path.startswith("tests/")
+            or name.startswith("test_")
+            or name.endswith("_test.py")
+        )
+
+    def _module_name(self, relative_path: str) -> str:
+        path = Path(relative_path)
+        without_suffix = path.with_suffix("")
+        parts = [part for part in without_suffix.parts if part != "__init__"]
+        return ".".join(parts)

--- a/app/core/repo_graph/risk_mapper.py
+++ b/app/core/repo_graph/risk_mapper.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class GraphRisk:
+    name: str
+    severity: str
+    reason: str
+
+
+class RiskMapper:
+    RISK_DEFINITIONS = {
+        "spring_boot_2_detected": GraphRisk(
+            name="spring_boot_2_detected",
+            severity="medium",
+            reason="Spring Boot 2 projects need version-aware migration checks before Boot 3 work.",
+        ),
+        "java_version_below_17": GraphRisk(
+            name="java_version_below_17",
+            severity="high",
+            reason="Spring Boot 3 requires Java 17 or newer.",
+        ),
+        "javax_dependency_detected": GraphRisk(
+            name="javax_dependency_detected",
+            severity="high",
+            reason="Spring Boot 3 migrations usually require Jakarta dependency changes.",
+        ),
+        "javax_to_jakarta_required": GraphRisk(
+            name="javax_to_jakarta_required",
+            severity="high",
+            reason="Spring Boot 3 requires Jakarta namespace migration for javax APIs.",
+        ),
+        "web_security_configurer_adapter_removed": GraphRisk(
+            name="web_security_configurer_adapter_removed",
+            severity="high",
+            reason="WebSecurityConfigurerAdapter was removed in newer Spring Security versions.",
+        ),
+        "sensitive_file": GraphRisk(
+            name="sensitive_file",
+            severity="high",
+            reason="Sensitive files need explicit review before worker edits.",
+        ),
+    }
+
+    def describe(self, name: str) -> GraphRisk:
+        return self.RISK_DEFINITIONS.get(
+            name,
+            GraphRisk(name=name, severity="medium", reason="Detected by repo graph scan."),
+        )
+
+    def risks_for_path(self, relative_path: str) -> list[str]:
+        name = relative_path.lower()
+        if name in {".env", ".env.local"} or "secret" in name or "credential" in name:
+            return ["sensitive_file"]
+        return []

--- a/app/core/repo_graph/serializer.py
+++ b/app/core/repo_graph/serializer.py
@@ -1,0 +1,9 @@
+from __future__ import annotations
+
+import json
+
+from app.core.repo_graph.models import RepoGraph
+
+
+def repo_graph_json(graph: RepoGraph) -> str:
+    return json.dumps(graph.model_dump(mode="json"), indent=2, sort_keys=True) + "\n"

--- a/app/core/repo_graph/test_mapper.py
+++ b/app/core/repo_graph/test_mapper.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+class TestMapper:
+    def likely_source_for_test(self, test_path: str, source_files: list[str]) -> str | None:
+        test_name = Path(test_path).stem
+        candidates = self._candidate_names(test_name)
+        by_stem = {Path(path).stem.lower(): path for path in source_files}
+        for candidate in candidates:
+            if candidate in by_stem:
+                return by_stem[candidate]
+        non_init_sources = [path for path in source_files if Path(path).name != "__init__.py"]
+        if len(non_init_sources) == 1:
+            return non_init_sources[0]
+        return None
+
+    def _candidate_names(self, test_name: str) -> list[str]:
+        normalized = test_name.lower()
+        candidates = [normalized]
+        for prefix in ("test_", "test"):
+            if normalized.startswith(prefix):
+                candidates.append(normalized.removeprefix(prefix))
+        for suffix in ("_test", "test", "tests"):
+            if normalized.endswith(suffix):
+                candidates.append(normalized.removesuffix(suffix))
+        return [candidate for candidate in candidates if candidate]

--- a/app/core/state.py
+++ b/app/core/state.py
@@ -4,6 +4,7 @@ from pathlib import Path
 from typing import TypedDict
 
 from app.core.llm import LLMClient
+from app.core.repo_graph.models import RepoGraph
 from app.schemas.conflict import ConflictReport
 from app.schemas.edit import ExternalEditResult
 from app.schemas.evidence import EvidenceReport
@@ -47,3 +48,4 @@ class AgentOpsGraphState(TypedDict, total=False):
     verification_bundle: VerificationBundle
     conflict_report: ConflictReport
     execution_logs: list[str]
+    repo_graph: RepoGraph

--- a/app/mcp_server.py
+++ b/app/mcp_server.py
@@ -9,6 +9,7 @@ from app.agents.repo_scanner import RepoScanner
 from app.core.config import settings
 from app.core.graph import run_harness
 from app.core.llm import build_runtime_llm_client
+from app.core.repo_graph import RepoGraphBuilder
 from app.core.storage import RunStorage
 
 
@@ -17,9 +18,13 @@ def _storage_path(storage_path: str | None) -> Path:
 
 
 def agentops_scan(repo_path: str) -> dict[str, Any]:
-    """Profile a local repository for language, framework, tests, and entrypoints."""
-    profile = RepoScanner().scan(Path(repo_path))
-    return profile.model_dump(mode="json")
+    """Profile a local repository and produce its deterministic repo graph."""
+    path = Path(repo_path)
+    profile = RepoScanner().scan(path)
+    repo_graph = RepoGraphBuilder().build(path)
+    payload = profile.model_dump(mode="json")
+    payload["repo_graph"] = repo_graph.model_dump(mode="json")
+    return payload
 
 
 def agentops_run(

--- a/app/schemas/run.py
+++ b/app/schemas/run.py
@@ -3,6 +3,7 @@ from typing import Literal
 
 from pydantic import BaseModel, Field
 
+from app.core.repo_graph.models import RepoGraph
 from app.schemas.conflict import ConflictReport
 from app.schemas.edit import ExternalEditResult
 from app.schemas.evidence import EvidenceReport
@@ -25,6 +26,7 @@ class RunRecord(BaseModel):
     task: str
     repo_path: str
     repo_profile: RepoProfile
+    repo_graph: RepoGraph | None = None
     memory_report: MemoryReport = Field(default_factory=MemoryReport)
     plan: ImplementationPlan
     changed_files: list[str] = Field(default_factory=list)

--- a/tests/test_edit_mode.py
+++ b/tests/test_edit_mode.py
@@ -61,7 +61,8 @@ def test_run_harness_edit_mode_records_worker_diff(tmp_path: Path) -> None:
     assert record.edit_result is not None
     assert record.edit_result.status == "completed"
     assert "app/worker_marker.py" in record.changed_files
-    assert record.execution_logs[6:8] == [
+    worker_start = record.execution_logs.index("run_external_worker:start")
+    assert record.execution_logs[worker_start : worker_start + 2] == [
         "run_external_worker:start",
         "run_external_worker:complete",
     ]

--- a/tests/test_langgraph_workflow.py
+++ b/tests/test_langgraph_workflow.py
@@ -20,6 +20,7 @@ def test_langgraph_run_records_node_trace(tmp_path: Path) -> None:
 
     assert record.execution_logs == [
         "scan_repo:start",
+        "repo_graph:complete",
         "scan_repo:complete",
         "recall_experience:start",
         "recall_experience:miss",
@@ -46,4 +47,6 @@ def test_langgraph_run_records_node_trace(tmp_path: Path) -> None:
         "audit_conflicts:start",
         "audit_conflicts:complete",
     ]
+    assert record.repo_graph is not None
+    assert record.repo_graph.summary.languages == ["python"]
     assert record.status == "completed"

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -15,6 +15,7 @@ def test_mcp_scan_returns_repo_profile() -> None:
     assert result["language"] == "python"
     assert result["framework"] == "fastapi"
     assert "app/main.py" in result["entrypoints"]
+    assert result["repo_graph"]["summary"]["languages"] == ["python"]
 
 
 def test_mcp_run_report_and_list_round_trip(

--- a/tests/test_repo_graph_builder.py
+++ b/tests/test_repo_graph_builder.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from app.core.repo_graph import RepoGraphBuilder
+
+
+def test_repo_graph_builder_scans_sample_fastapi_app() -> None:
+    graph = RepoGraphBuilder().build(Path("examples/sample_fastapi_app"))
+
+    node_ids = {node.id for node in graph.nodes}
+    edge_types = {edge.type for edge in graph.edges}
+
+    assert graph.summary.languages == ["python"]
+    assert "fastapi" in graph.summary.frameworks
+    assert "file:app/main.py" in node_ids
+    assert any(node.type == "import" and "fastapi" in node.name for node in graph.nodes)
+    assert any(node.type == "dependency" and node.name == "fastapi" for node in graph.nodes)
+    assert any(node.type == "test" and node.path == "tests/test_health.py" for node in graph.nodes)
+    assert "likely_tests" in edge_types
+
+
+def test_repo_graph_builder_detects_java_spring_migration_risks(tmp_path: Path) -> None:
+    repo = tmp_path / "spring_app"
+    source = repo / "src/main/java/com/example/UserController.java"
+    source.parent.mkdir(parents=True)
+    source.write_text(
+        "package com.example;\n"
+        "import javax.persistence.Entity;\n"
+        "import org.springframework.web.bind.annotation.GetMapping;\n"
+        "import org.springframework.web.bind.annotation.RestController;\n"
+        "@RestController\n"
+        "public class UserController {\n"
+        "  @GetMapping(\"/users\")\n"
+        "  public String users() { return \"ok\"; }\n"
+        "}\n",
+        encoding="utf-8",
+    )
+    (repo / "pom.xml").write_text(
+        "<project>"
+        "<parent>"
+        "<groupId>org.springframework.boot</groupId>"
+        "<artifactId>spring-boot-starter-parent</artifactId>"
+        "<version>2.7.18</version>"
+        "</parent>"
+        "<properties><java.version>11</java.version></properties>"
+        "<dependencies>"
+        "<dependency>"
+        "<groupId>org.springframework.boot</groupId>"
+        "<artifactId>spring-boot-starter-web</artifactId>"
+        "</dependency>"
+        "</dependencies>"
+        "</project>",
+        encoding="utf-8",
+    )
+
+    graph = RepoGraphBuilder().build(repo)
+
+    node_ids = {node.id for node in graph.nodes}
+    risk_names = {node.name for node in graph.nodes if node.type == "migration_risk"}
+
+    assert "java" in graph.summary.languages
+    assert "spring" in graph.summary.frameworks
+    assert "spring_boot" in graph.summary.frameworks
+    assert "route:java:GET:/users" in node_ids
+    assert "javax_to_jakarta_required" in risk_names
+    assert "spring_boot_2_detected" in risk_names
+    assert "java_version_below_17" in risk_names


### PR DESCRIPTION
## What changed

Adds Milestone 1: Graphified Repo Scan as a deterministic foundation step for AgentOps Harness.

- Adds typed `RepoGraph` schemas and `RepoGraphBuilder`.
- Adds lightweight Python/FastAPI graph parsing using `ast`.
- Adds lightweight Java/Spring parsing for imports, classes, routes, and migration-risk patterns.
- Adds dependency parsing for `pyproject.toml`, `requirements.txt`, `pom.xml`, and Gradle files.
- Adds test detection and conservative `likely_tests` edges.
- Threads `repo_graph` into the harness scan node and persisted `RunRecord`.
- Extends CLI/MCP scan output with `repo_graph` while preserving existing profile fields.

## Why

The existing scanner produced a useful repo profile, but the harness needs a stronger deterministic truth layer before graph-aware planning, risk scoring, evidence checks, and worker handoff can become trustworthy.

This PR intentionally does not make the planner graph-aware yet. That belongs to the next milestone.

## Validation

- `uv run --extra dev pytest -q` -> `119 passed`
- `uv run --extra dev ruff check .` -> passed
- `uv run --extra dev agentops scan --repo examples/sample_fastapi_app` -> emitted profile plus `repo_graph` summary, nodes, and edges
