### PR TITLE
[codex] make planner graph-aware

### DIFF
--- a/app/agents/planner.py
+++ b/app/agents/planner.py
@@ -1,4 +1,5 @@
 from app.core.llm import LLMClient
+from app.core.repo_graph import RepoGraph, RepoGraphQuery
 from app.prompts.planner import build_planner_prompt
 from app.schemas.plan import ImplementationPlan, PlanStep
 from app.schemas.repo import RepoProfile
@@ -12,22 +13,93 @@ class Planner:
         self,
         task: str,
         repo_profile: RepoProfile,
+        repo_graph: RepoGraph | None = None,
         memory_lessons: list[str] | None = None,
     ) -> ImplementationPlan:
         lessons = memory_lessons or []
         if self.llm_client is not None:
             return self.llm_client.generate_structured(
-                self._build_prompt(task, repo_profile, lessons),
+                self._build_prompt(task, repo_profile, repo_graph, lessons),
                 ImplementationPlan,
             )
 
+        if repo_graph is not None:
+            return self._graph_aware_plan(task, repo_profile, repo_graph, lessons)
+        return self._profile_only_plan(task, repo_profile, lessons)
+
+    def _profile_only_plan(
+        self,
+        task: str,
+        repo_profile: RepoProfile,
+        lessons: list[str],
+    ) -> ImplementationPlan:
         likely_app_files = repo_profile.entrypoints or repo_profile.source_files[:3]
         likely_test_files = [
             path for path in repo_profile.source_files if path.startswith("tests/")
         ] or ["tests/test_health.py"]
-
         framework = self._display_framework(repo_profile.framework or repo_profile.language)
+        return self._build_plan(
+            task=task,
+            framework=framework,
+            likely_app_files=likely_app_files,
+            likely_test_files=likely_test_files,
+            tests_to_run=["python -m pytest -q", "ruff check ."],
+            lessons=lessons,
+            extra_risk_notes=[],
+        )
 
+    def _graph_aware_plan(
+        self,
+        task: str,
+        repo_profile: RepoProfile,
+        repo_graph: RepoGraph,
+        lessons: list[str],
+    ) -> ImplementationPlan:
+        query = RepoGraphQuery(repo_graph)
+
+        likely_app_files = (
+            query.entrypoint_candidates()
+            + query.route_files()
+            + query.source_files()[:3]
+        )
+        likely_app_files = _unique(likely_app_files) or (
+            repo_profile.entrypoints or repo_profile.source_files[:3]
+        )
+
+        graph_tests = query.likely_tests_for_files(likely_app_files) + query.test_files()
+        likely_test_files = _unique(graph_tests) or (
+            [path for path in repo_profile.source_files if path.startswith("tests/")]
+            or ["tests/test_health.py"]
+        )
+
+        tests_to_run = query.validation_commands() or ["python -m pytest -q", "ruff check ."]
+
+        graph_framework = next(iter(repo_graph.summary.frameworks), None)
+        framework = self._display_framework(
+            repo_profile.framework or graph_framework or repo_profile.language
+        )
+
+        return self._build_plan(
+            task=task,
+            framework=framework,
+            likely_app_files=likely_app_files,
+            likely_test_files=likely_test_files,
+            tests_to_run=tests_to_run,
+            lessons=lessons,
+            extra_risk_notes=query.risk_notes(),
+        )
+
+    def _build_plan(
+        self,
+        *,
+        task: str,
+        framework: str,
+        likely_app_files: list[str],
+        likely_test_files: list[str],
+        tests_to_run: list[str],
+        lessons: list[str],
+        extra_risk_notes: list[str],
+    ) -> ImplementationPlan:
         return ImplementationPlan(
             task=task,
             summary=f"Implement '{task}' in the detected {framework} project.",
@@ -55,7 +127,7 @@ class Planner:
                     ),
                     files_to_inspect=likely_test_files,
                     files_to_edit=likely_test_files,
-                    tests=["python -m pytest -q"],
+                    tests=tests_to_run,
                 ),
             ],
             acceptance_criteria=[
@@ -63,9 +135,10 @@ class Planner:
                 "Relevant tests pass locally.",
                 "The diff stays focused and avoids unrelated refactors.",
             ],
-            tests_to_run=["python -m pytest -q", "ruff check ."],
+            tests_to_run=tests_to_run,
             risk_notes=[
                 *(f"Past experience: {lesson}" for lesson in lessons),
+                *extra_risk_notes,
                 "Require approval before editing secrets, auth, payment, or dependency files.",
                 "Block destructive shell commands and direct force-push style operations.",
             ],
@@ -75,11 +148,13 @@ class Planner:
         self,
         task: str,
         repo_profile: RepoProfile,
+        repo_graph: RepoGraph | None = None,
         lessons: list[str] | None = None,
     ) -> str:
         return build_planner_prompt(
             task=task,
             repo_profile=repo_profile,
+            repo_graph=repo_graph,
             memory_lessons=lessons,
         )
 
@@ -89,3 +164,13 @@ class Planner:
         if framework.lower() == "fastapi":
             return "FastAPI"
         return framework
+
+
+def _unique(items: list[str]) -> list[str]:
+    seen: set[str] = set()
+    ordered: list[str] = []
+    for item in items:
+        if item not in seen:
+            seen.add(item)
+            ordered.append(item)
+    return ordered

--- a/app/cli.py
+++ b/app/cli.py
@@ -78,7 +78,8 @@ def plan(
 ) -> None:
     """Create a structured implementation plan."""
     profile = RepoScanner().scan(repo)
-    implementation_plan = Planner().create_plan(task, profile)
+    repo_graph = RepoGraphBuilder().build(repo)
+    implementation_plan = Planner().create_plan(task, profile, repo_graph=repo_graph)
     console.print_json(implementation_plan.model_dump_json())
 
 

--- a/app/core/graph.py
+++ b/app/core/graph.py
@@ -73,15 +73,20 @@ def create_plan_node(state: AgentOpsGraphState) -> AgentOpsGraphState:
     logs = append_logs(state, "create_plan:start")
     memory_report = state.get("memory_report") or MemoryReport()
     lessons = memory_report.lessons
+    repo_graph = state.get("repo_graph")
     try:
         plan = Planner(llm_client=state.get("llm_client")).create_plan(
             state["task"],
             state["repo_profile"],
+            repo_graph=repo_graph,
             memory_lessons=lessons,
         )
     except Exception:
         plan = Planner().create_plan(
-            state["task"], state["repo_profile"], memory_lessons=lessons
+            state["task"],
+            state["repo_profile"],
+            repo_graph=repo_graph,
+            memory_lessons=lessons,
         )
         logs.append("provider_fallback:create_plan")
     logs.append("create_plan:complete")

--- a/app/core/handoff.py
+++ b/app/core/handoff.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from app.agents.planner import Planner
 from app.agents.repo_scanner import RepoScanner
 from app.core.llm import LLMClient
+from app.core.repo_graph import RepoGraphBuilder
 from app.schemas.handoff import HandoffPlanStepBrief, WorkerHandoffPacket
 from app.schemas.plan import ImplementationPlan
 from app.schemas.run import RunRecord
@@ -75,7 +76,8 @@ def draft_worker_handoff(
     llm_client: LLMClient | None = None,
 ) -> WorkerHandoffPacket:
     profile = RepoScanner().scan(repo_path)
-    plan = Planner(llm_client=llm_client).create_plan(task, profile)
+    repo_graph = RepoGraphBuilder().build(repo_path)
+    plan = Planner(llm_client=llm_client).create_plan(task, profile, repo_graph=repo_graph)
     verification = _verification_from_plan(plan)
     return WorkerHandoffPacket(
         phase="draft_pre_worker",

--- a/app/core/repo_graph/__init__.py
+++ b/app/core/repo_graph/__init__.py
@@ -1,10 +1,13 @@
 from app.core.repo_graph.builder import RepoGraphBuilder
 from app.core.repo_graph.models import RepoGraph, RepoGraphEdge, RepoGraphNode, RepoGraphSummary
+from app.core.repo_graph.query import GraphPlannerContext, RepoGraphQuery
 
 __all__ = [
+    "GraphPlannerContext",
     "RepoGraph",
     "RepoGraphBuilder",
     "RepoGraphEdge",
     "RepoGraphNode",
+    "RepoGraphQuery",
     "RepoGraphSummary",
 ]

--- a/app/core/repo_graph/query.py
+++ b/app/core/repo_graph/query.py
@@ -1,0 +1,167 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from pydantic import BaseModel, Field
+
+from app.core.repo_graph.models import RepoGraph, RepoGraphNode
+
+_FILE_LIKE_TYPES = {"file", "test", "config"}
+_ENTRYPOINT_BASENAMES = {
+    "main.py",
+    "app.py",
+    "__main__.py",
+    "manage.py",
+    "wsgi.py",
+    "asgi.py",
+    "application.java",
+}
+
+
+class GraphPlannerContext(BaseModel):
+    """Compact, deterministic projection of a RepoGraph for planning prompts."""
+
+    languages: list[str] = Field(default_factory=list)
+    frameworks: list[str] = Field(default_factory=list)
+    build_tools: list[str] = Field(default_factory=list)
+    test_frameworks: list[str] = Field(default_factory=list)
+    entrypoint_candidates: list[str] = Field(default_factory=list)
+    route_files: list[str] = Field(default_factory=list)
+    routes: list[str] = Field(default_factory=list)
+    test_files: list[str] = Field(default_factory=list)
+    dependencies: list[str] = Field(default_factory=list)
+    risks: list[str] = Field(default_factory=list)
+    validation_commands: list[str] = Field(default_factory=list)
+
+
+class RepoGraphQuery:
+    """Deterministic read-side helpers over a RepoGraph.
+
+    This layer never calls an LLM and never re-reads the filesystem; every
+    answer is derived from nodes/edges produced by ``RepoGraphBuilder``. It
+    localizes candidate files, tests, routes, dependencies, and risks so the
+    planner can ground its plan in repository structure (LocAgent-style
+    deterministic localization).
+    """
+
+    def __init__(self, graph: RepoGraph) -> None:
+        self.graph = graph
+        self._nodes_by_id: dict[str, RepoGraphNode] = {node.id: node for node in graph.nodes}
+
+    def files(self) -> list[RepoGraphNode]:
+        return [node for node in self.graph.nodes if node.type in _FILE_LIKE_TYPES]
+
+    def source_files(self) -> list[str]:
+        return [
+            node.path
+            for node in self.graph.nodes
+            if node.type in {"file", "config"} and node.language is not None and node.path
+        ]
+
+    def test_files(self) -> list[str]:
+        return [node.path for node in self.graph.nodes if node.type == "test" and node.path]
+
+    def config_files(self) -> list[str]:
+        return [node.path for node in self.graph.nodes if node.type == "config" and node.path]
+
+    def routes(self) -> list[RepoGraphNode]:
+        return [node for node in self.graph.nodes if node.type == "route"]
+
+    def route_files(self) -> list[str]:
+        return _unique(node.path for node in self.routes() if node.path)
+
+    def route_names(self) -> list[str]:
+        return _unique(node.name for node in self.routes() if node.name)
+
+    def dependency_names(self) -> list[str]:
+        return _unique(node.name for node in self.graph.nodes if node.type == "dependency")
+
+    def risk_nodes(self) -> list[RepoGraphNode]:
+        return [node for node in self.graph.nodes if node.type == "migration_risk"]
+
+    def risk_notes(self) -> list[str]:
+        notes: list[str] = []
+        for node in self.risk_nodes():
+            severity = node.metadata.get("severity", "medium")
+            reason = node.metadata.get("reason", "Detected by repo graph scan.")
+            notes.append(f"Graph risk [{severity}] {node.name}: {reason}")
+        return notes
+
+    def likely_tests_for_files(self, files: list[str]) -> list[str]:
+        """Return test files whose ``likely_tests`` edge points at any of ``files``."""
+        targets = {self._file_id(path) for path in files}
+        tests: list[str] = []
+        for edge in self.graph.edges:
+            if edge.type != "likely_tests" or edge.target not in targets:
+                continue
+            test_node = self._nodes_by_id.get(edge.source)
+            if test_node and test_node.path:
+                tests.append(test_node.path)
+        return _unique(tests)
+
+    def entrypoint_candidates(self) -> list[str]:
+        candidates = list(self.route_files())
+        for node in self.graph.nodes:
+            if node.type not in {"file", "config"} or not node.path:
+                continue
+            if Path(node.path).name in _ENTRYPOINT_BASENAMES:
+                candidates.append(node.path)
+        return _unique(candidates)
+
+    def validation_commands(self) -> list[str]:
+        build_tools = set(self.graph.summary.build_tools)
+        languages = set(self.graph.summary.languages)
+
+        if "maven" in build_tools:
+            return ["mvn test"]
+        if "gradle" in build_tools:
+            if self._has_file_named("gradlew"):
+                return ["./gradlew test"]
+            return ["gradle test"]
+        if "python" in languages or {"pyproject", "pip"} & build_tools:
+            if self._is_uv_project(build_tools):
+                return ["uv run pytest -q", "uv run ruff check ."]
+            return ["python -m pytest -q", "ruff check ."]
+        return []
+
+    def planner_context(self) -> GraphPlannerContext:
+        return GraphPlannerContext(
+            languages=list(self.graph.summary.languages),
+            frameworks=list(self.graph.summary.frameworks),
+            build_tools=list(self.graph.summary.build_tools),
+            test_frameworks=list(self.graph.summary.test_frameworks),
+            entrypoint_candidates=self.entrypoint_candidates(),
+            route_files=self.route_files(),
+            routes=self.route_names(),
+            test_files=self.test_files(),
+            dependencies=self.dependency_names(),
+            risks=self.risk_notes(),
+            validation_commands=self.validation_commands(),
+        )
+
+    def _is_uv_project(self, build_tools: set[str]) -> bool:
+        if self._has_file_named("uv.lock"):
+            return True
+        # pyproject-managed repos default to uv per harness conventions; plain
+        # requirements.txt-only repos fall back to the stdlib invocation.
+        return "pyproject" in build_tools
+
+    def _has_file_named(self, name: str) -> bool:
+        return any(
+            node.path and Path(node.path).name == name
+            for node in self.graph.nodes
+            if node.type in _FILE_LIKE_TYPES
+        )
+
+    def _file_id(self, relative_path: str) -> str:
+        return f"file:{relative_path}"
+
+
+def _unique(items) -> list[str]:
+    seen: set[str] = set()
+    ordered: list[str] = []
+    for item in items:
+        if item not in seen:
+            seen.add(item)
+            ordered.append(item)
+    return ordered

--- a/app/prompts/planner.py
+++ b/app/prompts/planner.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from app.core.repo_graph import RepoGraph, RepoGraphQuery
 from app.schemas.repo import RepoProfile
 
 
@@ -7,6 +8,7 @@ def build_planner_prompt(
     *,
     task: str,
     repo_profile: RepoProfile,
+    repo_graph: RepoGraph | None = None,
     memory_lessons: list[str] | None = None,
 ) -> str:
     framework = _display_framework(repo_profile.framework or repo_profile.language)
@@ -18,6 +20,7 @@ def build_planner_prompt(
         if memory_lessons
         else "- None recalled"
     )
+    graph_block = _graph_section(repo_graph)
 
     return f"""You are the Planner Agent in AgentOps Harness.
 
@@ -41,7 +44,7 @@ Config files:
 
 Source files:
 {source_files or "- None detected"}
-
+{graph_block}
 Lessons recalled from similar past runs (experiential memory, §3.2.3):
 {lessons_block}
 
@@ -49,9 +52,40 @@ Planning rules:
 - Keep the plan small and implementation-oriented.
 - Include likely files to inspect and edit.
 - Include acceptance criteria.
-- Include exact validation commands.
+- Include exact validation commands. Prefer the recommended validation commands above.
 - Mention risk notes for secrets, auth, dependency, and broad refactor hazards.
 """
+
+
+def _graph_section(repo_graph: RepoGraph | None) -> str:
+    if repo_graph is None:
+        return ""
+    context = RepoGraphQuery(repo_graph).planner_context()
+    lines = [
+        "",
+        "Repository graph (deterministic scan, structure-grounded planning):",
+        f"- Languages: {_inline(context.languages)}",
+        f"- Frameworks: {_inline(context.frameworks)}",
+        f"- Build tools: {_inline(context.build_tools)}",
+        f"- Test frameworks: {_inline(context.test_frameworks)}",
+        f"- Entrypoint candidates: {_inline(context.entrypoint_candidates)}",
+        f"- Routes: {_inline(context.routes)}",
+        f"- Route files: {_inline(context.route_files)}",
+        f"- Likely test files: {_inline(context.test_files)}",
+        f"- Dependencies: {_inline(context.dependencies)}",
+        f"- Risks: {_inline(context.risks)}",
+        f"- Recommended validation commands: {_inline(context.validation_commands)}",
+        "",
+    ]
+    return "\n".join(lines)
+
+
+def _inline(items: list[str], limit: int = 20) -> str:
+    if not items:
+        return "none detected"
+    shown = items[:limit]
+    suffix = ", …" if len(items) > limit else ""
+    return ", ".join(shown) + suffix
 
 
 def _display_framework(framework: str | None) -> str:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -36,6 +36,28 @@ def init_git_repo(repo_path: Path) -> None:
     )
 
 
+def test_cli_plan_is_graph_aware() -> None:
+    runner = CliRunner()
+
+    result = runner.invoke(
+        app,
+        [
+            "plan",
+            "--repo",
+            "examples/sample_fastapi_app",
+            "--task",
+            "Add a /healthz endpoint",
+        ],
+    )
+
+    assert result.exit_code == 0
+    # uv repo (pyproject + uv.lock) -> graph-aware validation commands, not the
+    # profile-only "python -m pytest -q" fallback.
+    assert "uv run pytest -q" in result.output
+    assert "uv run ruff check ." in result.output
+    assert "app/main.py" in result.output
+
+
 def test_cli_edit_runs_external_worker(tmp_path: Path, monkeypatch) -> None:
     monkeypatch.setattr("app.cli.settings.llm_provider", "mock")
     repo_path = tmp_path / "sample_fastapi_app"

--- a/tests/test_graph_aware_planner.py
+++ b/tests/test_graph_aware_planner.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from app.agents.planner import Planner
+from app.core.repo_graph import RepoGraphBuilder
+from app.schemas.repo import RepoProfile
+
+
+def _fastapi_profile() -> RepoProfile:
+    return RepoProfile(
+        repo_path="examples/sample_fastapi_app",
+        language="python",
+        framework="fastapi",
+        entrypoints=["app/main.py"],
+        source_files=["app/main.py", "tests/test_health.py"],
+    )
+
+
+def test_planner_falls_back_without_graph() -> None:
+    plan = Planner().create_plan("Add a route", _fastapi_profile())
+
+    files = {path for step in plan.steps for path in step.files_to_inspect}
+    assert "app/main.py" in files
+    assert plan.tests_to_run == ["python -m pytest -q", "ruff check ."]
+
+
+def test_planner_uses_fastapi_graph_context() -> None:
+    graph = RepoGraphBuilder().build(Path("examples/sample_fastapi_app"))
+
+    plan = Planner().create_plan("Add a route", _fastapi_profile(), repo_graph=graph)
+
+    inspected = {path for step in plan.steps for path in step.files_to_inspect}
+    assert "app/main.py" in inspected
+    assert "uv run pytest -q" in plan.tests_to_run
+    assert "uv run ruff check ." in plan.tests_to_run
+
+
+def test_java_spring_risks_feed_planner(tmp_path: Path) -> None:
+    repo = tmp_path / "spring_app"
+    source = repo / "src/main/java/com/example/UserController.java"
+    source.parent.mkdir(parents=True)
+    source.write_text(
+        "package com.example;\n"
+        "import javax.persistence.Entity;\n"
+        "import org.springframework.web.bind.annotation.GetMapping;\n"
+        "import org.springframework.web.bind.annotation.RestController;\n"
+        "@RestController\n"
+        "public class UserController {\n"
+        '  @GetMapping("/users")\n'
+        '  public String users() { return "ok"; }\n'
+        "}\n",
+        encoding="utf-8",
+    )
+    (repo / "pom.xml").write_text(
+        "<project>"
+        "<parent>"
+        "<groupId>org.springframework.boot</groupId>"
+        "<artifactId>spring-boot-starter-parent</artifactId>"
+        "<version>2.7.18</version>"
+        "</parent>"
+        "<properties><java.version>11</java.version></properties>"
+        "<dependencies>"
+        "<dependency>"
+        "<groupId>org.springframework.boot</groupId>"
+        "<artifactId>spring-boot-starter-web</artifactId>"
+        "</dependency>"
+        "</dependencies>"
+        "</project>",
+        encoding="utf-8",
+    )
+
+    graph = RepoGraphBuilder().build(repo)
+    profile = RepoProfile(repo_path=str(repo), language="java", framework="spring")
+
+    plan = Planner().create_plan("Migrate to Spring Boot 3", profile, repo_graph=graph)
+
+    risk_text = "\n".join(plan.risk_notes)
+    assert "Spring Boot 2" in risk_text
+    assert "Java 17" in risk_text
+    assert "Jakarta" in risk_text or "javax" in risk_text
+    assert "mvn test" in plan.tests_to_run

--- a/tests/test_handoff.py
+++ b/tests/test_handoff.py
@@ -86,6 +86,15 @@ def test_draft_handoff_flags_pending(tmp_path: Path) -> None:
     assert "Draft (pre-worker)" in rendered
 
 
+def test_draft_handoff_uses_graph_aware_plan() -> None:
+    repo_path = Path("examples/sample_fastapi_app")
+    packet = draft_worker_handoff(repo_path=repo_path, task="Add a route")
+
+    assert "uv run pytest -q" in packet.tests_to_run
+    inspected = {path for step in packet.plan_steps for path in step.files_to_inspect}
+    assert "app/main.py" in inspected
+
+
 def test_handoff_documents_external_edit_status_when_present() -> None:
     record = _minimal_run(edit=ExternalEditResult(status="completed", command="codex exec"))
     markdown = render_handoff_markdown(worker_handoff_from_run(record))

--- a/tests/test_langgraph_workflow.py
+++ b/tests/test_langgraph_workflow.py
@@ -50,3 +50,17 @@ def test_langgraph_run_records_node_trace(tmp_path: Path) -> None:
     assert record.repo_graph is not None
     assert record.repo_graph.summary.languages == ["python"]
     assert record.status == "completed"
+
+
+def test_langgraph_plan_is_graph_aware(tmp_path: Path) -> None:
+    record = run_harness(
+        repo_path=Path("examples/sample_fastapi_app"),
+        task="Add request logging middleware",
+        storage_path=tmp_path / "runs.db",
+    )
+
+    # No LLM client -> deterministic graph-aware planner. uv commands prove the
+    # repo_graph flowed from scan_repo_node into create_plan_node.
+    assert "uv run pytest -q" in record.plan.tests_to_run
+    inspected = {path for step in record.plan.steps for path in step.files_to_inspect}
+    assert "app/main.py" in inspected

--- a/tests/test_llm_agents.py
+++ b/tests/test_llm_agents.py
@@ -4,6 +4,7 @@ from app.agents.planner import Planner
 from app.agents.pr_writer import PRWriter
 from app.agents.reviewer import Reviewer
 from app.core.graph import run_harness
+from app.core.repo_graph import RepoGraphBuilder
 from app.schemas.plan import ImplementationPlan, PlanStep
 from app.schemas.repo import RepoProfile
 from app.schemas.report import FinalReport
@@ -94,6 +95,26 @@ def test_planner_uses_llm_client_when_provided() -> None:
     assert plan.summary == "LLM plan for request logging middleware."
     assert llm_client.structured_prompts
     assert "FastAPI" in llm_client.structured_prompts[0]
+
+
+def test_planner_prompt_includes_graph_context_for_llm() -> None:
+    llm_client = FakeLLMClient()
+    graph = RepoGraphBuilder().build(Path("examples/sample_fastapi_app"))
+    profile = RepoProfile(
+        repo_path="examples/sample_fastapi_app",
+        language="python",
+        framework="fastapi",
+        entrypoints=["app/main.py"],
+        source_files=["app/main.py", "tests/test_health.py"],
+    )
+
+    Planner(llm_client=llm_client).create_plan("Add a route", profile, repo_graph=graph)
+
+    prompt = llm_client.structured_prompts[0]
+    assert "Repository graph" in prompt
+    assert "GET /health" in prompt
+    assert "app/main.py" in prompt
+    assert "uv run pytest -q" in prompt
 
 
 def test_reviewer_uses_llm_client_when_provided() -> None:

--- a/tests/test_repo_graph_query.py
+++ b/tests/test_repo_graph_query.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from app.core.repo_graph import RepoGraphBuilder, RepoGraphQuery
+
+
+def test_repo_graph_query_extracts_planner_context() -> None:
+    graph = RepoGraphBuilder().build(Path("examples/sample_fastapi_app"))
+    context = RepoGraphQuery(graph).planner_context()
+
+    assert "fastapi" in context.frameworks
+    assert "app/main.py" in context.entrypoint_candidates
+    assert "tests/test_health.py" in context.test_files
+    assert "fastapi" in context.dependencies
+    assert "uv run pytest -q" in context.validation_commands
+
+
+def test_repo_graph_query_localizes_routes_and_likely_tests() -> None:
+    query = RepoGraphQuery(RepoGraphBuilder().build(Path("examples/sample_fastapi_app")))
+
+    assert "app/main.py" in query.route_files()
+    assert "GET /health" in query.route_names()
+    likely = query.likely_tests_for_files(["app/main.py"])
+    assert all(path.startswith("tests/") for path in likely)
+
+
+def test_validation_commands_prefer_uv_for_pyproject_repo() -> None:
+    query = RepoGraphQuery(RepoGraphBuilder().build(Path("examples/sample_fastapi_app")))
+
+    assert query.validation_commands() == ["uv run pytest -q", "uv run ruff check ."]
+
+
+def test_validation_commands_plain_python_without_pyproject(tmp_path: Path) -> None:
+    repo = tmp_path / "plain"
+    repo.mkdir()
+    (repo / "app.py").write_text("x = 1\n", encoding="utf-8")
+    (repo / "requirements.txt").write_text("requests\n", encoding="utf-8")
+
+    query = RepoGraphQuery(RepoGraphBuilder().build(repo))
+
+    assert query.validation_commands() == ["python -m pytest -q", "ruff check ."]
+
+
+def test_validation_commands_maven(tmp_path: Path) -> None:
+    repo = tmp_path / "maven_app"
+    repo.mkdir()
+    (repo / "pom.xml").write_text(
+        "<project><dependencies></dependencies></project>", encoding="utf-8"
+    )
+
+    query = RepoGraphQuery(RepoGraphBuilder().build(repo))
+
+    assert query.validation_commands() == ["mvn test"]
+
+
+def test_validation_commands_gradle_wrapper(tmp_path: Path) -> None:
+    repo = tmp_path / "gradle_app"
+    repo.mkdir()
+    (repo / "build.gradle").write_text(
+        "plugins { id 'org.springframework.boot' version '3.2.0' }\n", encoding="utf-8"
+    )
+    (repo / "gradlew").write_text("#!/bin/sh\n", encoding="utf-8")
+
+    query = RepoGraphQuery(RepoGraphBuilder().build(repo))
+
+    assert query.validation_commands() == ["./gradlew test"]
+
+
+def test_validation_commands_gradle_without_wrapper(tmp_path: Path) -> None:
+    repo = tmp_path / "gradle_app"
+    repo.mkdir()
+    (repo / "build.gradle").write_text(
+        "plugins { id 'org.springframework.boot' version '3.2.0' }\n", encoding="utf-8"
+    )
+
+    query = RepoGraphQuery(RepoGraphBuilder().build(repo))
+
+    assert query.validation_commands() == ["gradle test"]


### PR DESCRIPTION
## What

Milestone 2 — Graph-Aware Planner. Makes the planner consume the `RepoGraph`
produced in Milestone 1 so planning is grounded in repository structure
instead of shallow profile heuristics (structure-grounded planning).

## Why

Milestone 1 built a deterministic `RepoGraph` but the planner never read it.
It always suggested `python -m pytest -q` / `ruff check .`, which broke on uv
repos (observed on ContextIQ: `ModuleNotFoundError` because the package only
resolves under `uv run`). M2 makes file/test/route/risk localization and
validation-command selection repo-aware.

## What changed

- **New `app/core/repo_graph/query.py`** — `RepoGraphQuery` + `GraphPlannerContext`.
  Deterministic, no LLM, no disk re-reads. Localizes entrypoints, routes, likely
  tests, dependencies, and risks, and selects validation commands:
  - uv Python (`uv.lock`/`pyproject`) → `uv run pytest -q`, `uv run ruff check .`
  - plain Python → `python -m pytest -q`, `ruff check .`
  - Maven → `mvn test`; Gradle wrapper → `./gradlew test`; Gradle → `gradle test`
- **`Planner.create_plan(..., repo_graph=None)`** — graph-aware deterministic plan
  when a graph is present; identical profile-only fallback when absent.
- **`build_planner_prompt(..., repo_graph=None)`** — compact graph context block for
  the LLM path (no full-graph JSON dump).
- **`create_plan_node`** passes `state["repo_graph"]` (primary + provider-fallback).
- **`draft_worker_handoff`** builds and passes a `RepoGraph`.
- **`agentops plan` CLI** now builds the graph and passes it (was profile-only).
- Java/Spring migration risks surface in `plan.risk_notes`.

## Compatibility

`repo_graph` is optional everywhere; when `None`, behavior is identical to the
pre-M2 planner. Existing prompt/planner call sites are unchanged.

## Tests

New: `tests/test_repo_graph_query.py`, `tests/test_graph_aware_planner.py`, plus
additions to `test_llm_agents.py`, `test_handoff.py`, `test_langgraph_workflow.py`,
`test_cli.py` (graph query + validation-command matrix, planner fallback, FastAPI
graph context, Java/Spring risks, LLM prompt context, draft handoff, CLI plan).

```
uv run --extra dev python -m pytest -q   -> 139 passed
uv run --extra dev ruff check .          -> All checks passed!
```

Smoke-tested read-only on a real external uv repo (nl2sql-viz): scan produced a
499-node / 634-edge graph; the planner emitted `uv run pytest -q` /
`uv run ruff check .` (vs the profile-only `python -m pytest -q`), localized
`app/main.py`, FastAPI routes, dependencies, and surfaced a high-severity
`sensitive_file` risk.

## Out of scope (deferred, as planned)

recipes, artifact folders, changed subgraph, search-based planning, multi-agent
orchestration, UI, Neo4j, Graphify adapter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)