### PR TITLE
feat: Evidence Guard v2 with sourced findings (Milestone 5)

### DIFF
--- a/app/agents/evidence_guard.py
+++ b/app/agents/evidence_guard.py
@@ -2,8 +2,10 @@ from __future__ import annotations
 
 import re
 
+from app.core.repo_graph.impact import ChangedSubgraph
 from app.schemas.evidence import EvidenceFinding, EvidenceReport
 from app.schemas.report import FinalReport
+from app.schemas.risk import RiskReport
 from app.schemas.test import TestRunSummary
 
 
@@ -28,6 +30,15 @@ class EvidenceGuard:
         "added tests",
         "new tests",
         "comprehensive tests",
+        "tests changed",
+        "test changed",
+    )
+    TEST_UPDATE_CLAIM = re.compile(r"\b(updated|modified|changed)\b.*\btest\b")
+    ROUTE_CLAIM_PATTERN = re.compile(r"\b(GET|POST|PUT|PATCH|DELETE|ANY)\s+(/[A-Za-z0-9_./{}-]*)")
+    VALIDATION_RECOMMENDATION_WORDS = (
+        "recommended targeted validation",
+        "recommended validation",
+        "should run",
     )
 
     def check(
@@ -35,6 +46,8 @@ class EvidenceGuard:
         final_report: FinalReport,
         changed_files: list[str],
         test_results: TestRunSummary,
+        risk_report: RiskReport | None = None,
+        changed_subgraph: ChangedSubgraph | None = None,
     ) -> EvidenceReport:
         markdown = final_report.markdown
         findings: list[EvidenceFinding] = []
@@ -44,6 +57,17 @@ class EvidenceGuard:
         findings.extend(self._check_new_test_claims(markdown, changed_file_set))
         findings.extend(self._check_analysis_only(markdown, changed_files))
         findings.extend(self._check_test_pass_claims(markdown, test_results))
+        findings.extend(self._check_lint_claims(markdown, test_results))
+        findings.extend(self._check_risk_claims(markdown, risk_report))
+        findings.extend(self._check_route_claims(markdown, changed_subgraph))
+        findings.extend(
+            self._check_validation_execution_claims(
+                markdown,
+                test_results,
+                changed_subgraph,
+            )
+        )
+        findings = self._dedupe_findings(findings)
 
         return EvidenceReport(
             grounded=not findings,
@@ -62,7 +86,9 @@ class EvidenceGuard:
         findings = "\n".join(
             (
                 f"- **Unsupported claim** `{finding.claim}`: "
-                f"{finding.reason} Evidence: {finding.evidence}"
+                f"{finding.reason} "
+                f"Source: {finding.source_of_truth}. "
+                f"Observed: {finding.observed or finding.evidence}."
             )
             for finding in evidence_report.findings
         )
@@ -96,6 +122,11 @@ This report contains claims that are not supported by the run record.
                                 "does not include it."
                             ),
                             evidence=f"changed_files={sorted(changed_file_set)}",
+                            claim_type="file_changed_without_diff",
+                            source_of_truth="changed_files",
+                            expected=file_path,
+                            observed=str(sorted(changed_file_set)),
+                            citation="RunRecord.changed_files",
                         )
                     )
         return findings
@@ -106,7 +137,10 @@ This report contains claims that are not supported by the run record.
         changed_file_set: set[str],
     ) -> list[EvidenceFinding]:
         lowered = markdown.lower()
-        has_test_claim = any(pattern in lowered for pattern in self.TEST_CLAIM_PATTERNS)
+        has_test_claim = (
+            any(pattern in lowered for pattern in self.TEST_CLAIM_PATTERNS)
+            or self.TEST_UPDATE_CLAIM.search(lowered) is not None
+        )
         has_changed_tests = any(path.startswith("tests/") for path in changed_file_set)
         if has_test_claim and not has_changed_tests:
             return [
@@ -115,6 +149,38 @@ This report contains claims that are not supported by the run record.
                     claim="new tests added",
                     reason="Report claims tests were added, but no changed test file is present.",
                     evidence=f"changed_files={sorted(changed_file_set)}",
+                    claim_type="tests_added_without_test_diff",
+                    source_of_truth="changed_files",
+                    expected="at least one tests/ file",
+                    observed=str(sorted(changed_file_set)),
+                    citation="RunRecord.changed_files",
+                )
+            ]
+        return []
+
+    def _check_lint_claims(
+        self,
+        markdown: str,
+        test_results: TestRunSummary,
+    ) -> list[EvidenceFinding]:
+        lowered = markdown.lower()
+        claims_lint = "ruff" in lowered or "lint" in lowered
+        executed = {result.command for result in test_results.commands}
+        ran_lint = any("ruff" in command or "lint" in command for command in executed)
+        if claims_lint and not ran_lint:
+            return [
+                EvidenceFinding(
+                    severity="error",
+                    claim="linting passed",
+                    reason=(
+                        "Report claims lint/static validation ran, but no lint command executed."
+                    ),
+                    evidence=f"executed_commands={sorted(executed)}",
+                    claim_type="lint_claim_without_execution",
+                    source_of_truth="test_results.commands",
+                    expected="a ruff/lint command in executed validation",
+                    observed=str(sorted(executed)),
+                    citation="RunRecord.test_results.commands",
                 )
             ]
         return []
@@ -140,6 +206,11 @@ This report contains claims that are not supported by the run record.
                     "it is analysis-only."
                 ),
                 evidence="changed_files=[]",
+                claim_type="implementation_claim_without_diff",
+                source_of_truth="changed_files",
+                expected="analysis-only wording or changed files",
+                observed="[]",
+                citation="RunRecord.changed_files",
             )
         ]
 
@@ -157,10 +228,131 @@ This report contains claims that are not supported by the run record.
                     claim="tests pass",
                     reason="Report claims tests pass, but validation commands failed.",
                     evidence="test_results.passed=False",
+                    claim_type="tests_pass_claim_but_failed",
+                    source_of_truth="test_results",
+                    expected="all command exit codes are 0",
+                    observed="test_results.passed=False",
+                    citation="RunRecord.test_results.commands",
                 )
             ]
         return []
 
+    def _check_risk_claims(
+        self,
+        markdown: str,
+        risk_report: RiskReport | None,
+    ) -> list[EvidenceFinding]:
+        if risk_report is None:
+            return []
+        lowered = markdown.lower()
+        claims_low_risk = any(
+            phrase in lowered
+            for phrase in (
+                "no risk",
+                "low risk",
+                "minimal risk",
+                "risk level: low",
+                "level: low",
+            )
+        )
+        if claims_low_risk and risk_report.risk_level in {"medium", "high", "critical"}:
+            return [
+                EvidenceFinding(
+                    severity="error",
+                    claim="low risk",
+                    reason="Report claims low/no risk, but risk report is elevated.",
+                    evidence=f"risk_level={risk_report.risk_level}",
+                    claim_type="risk_level_understated",
+                    source_of_truth="risk_report",
+                    expected="low risk claim only when risk_report.risk_level is low",
+                    observed=f"risk_level={risk_report.risk_level}",
+                    citation="RunRecord.risk_report.risk_level",
+                )
+            ]
+        return []
+
+    def _check_route_claims(
+        self,
+        markdown: str,
+        changed_subgraph: ChangedSubgraph | None,
+    ) -> list[EvidenceFinding]:
+        if changed_subgraph is None:
+            return []
+        impacted = {
+            (route.method.upper(), route.path)
+            for route in changed_subgraph.impacted_routes
+        }
+        findings: list[EvidenceFinding] = []
+        for method, path in self.ROUTE_CLAIM_PATTERN.findall(markdown):
+            route = (method.upper(), path)
+            if route not in impacted:
+                findings.append(
+                    EvidenceFinding(
+                        severity="warning",
+                        claim=f"{method.upper()} {path}",
+                        reason=(
+                            "Report claims route/API impact, but changed subgraph "
+                            "does not include that route."
+                        ),
+                        evidence=f"impacted_routes={sorted(impacted)}",
+                        claim_type="route_claim_without_graph_impact",
+                        source_of_truth="changed_subgraph.impacted_routes",
+                        expected=f"{method.upper()} {path}",
+                        observed=str(sorted(impacted)),
+                        citation="RunRecord.changed_subgraph.impacted_routes",
+                    )
+                )
+        return findings
+
+    def _check_validation_execution_claims(
+        self,
+        markdown: str,
+        test_results: TestRunSummary,
+        changed_subgraph: ChangedSubgraph | None,
+    ) -> list[EvidenceFinding]:
+        if changed_subgraph is None:
+            return []
+        executed = {result.command for result in test_results.commands}
+        recommended = {item.command for item in changed_subgraph.recommended_validation}
+        if not recommended:
+            return []
+        lowered = markdown.lower()
+        if any(word in lowered for word in self.VALIDATION_RECOMMENDATION_WORDS):
+            return []
+        claimed_as_run = recommended.intersection(
+            command for command in recommended if command.lower() in lowered
+        )
+        unsupported = sorted(claimed_as_run - executed)
+        if not unsupported:
+            return []
+        return [
+            EvidenceFinding(
+                severity="error",
+                claim=command,
+                reason="Report presents recommended validation as executed.",
+                evidence=f"executed_commands={sorted(executed)}",
+                claim_type="recommended_validation_claimed_as_executed",
+                source_of_truth="test_results.commands",
+                expected="command appears in executed validation",
+                observed=str(sorted(executed)),
+                citation="RunRecord.test_results.commands",
+            )
+            for command in unsupported
+        ]
+
     def _looks_like_change_claim(self, line: str) -> bool:
         lowered = line.lower()
+        if "external worker" in lowered or "executed the change" in lowered:
+            return False
         return any(word in lowered for word in self.CHANGE_WORDS)
+
+    def _dedupe_findings(self, findings: list[EvidenceFinding]) -> list[EvidenceFinding]:
+        seen: set[tuple[str, str, str]] = set()
+        deduped: list[EvidenceFinding] = []
+        for finding in findings:
+            key = (finding.claim_type, finding.claim, finding.source_of_truth)
+            if key in seen:
+                continue
+            seen.add(key)
+            deduped.append(finding)
+        return deduped

--- a/app/core/graph.py
+++ b/app/core/graph.py
@@ -298,6 +298,8 @@ def check_evidence_node(state: AgentOpsGraphState) -> AgentOpsGraphState:
         final_report=state["final_report"],
         changed_files=state["changed_files"],
         test_results=state["test_results"],
+        risk_report=state["risk_report"],
+        changed_subgraph=state["changed_subgraph"],
     )
     final_report = evidence_guard.append_to_report(state["final_report"], evidence_report)
     return {

--- a/app/schemas/evidence.py
+++ b/app/schemas/evidence.py
@@ -10,10 +10,14 @@ class EvidenceFinding(BaseModel):
     claim: str
     reason: str
     evidence: str
+    claim_type: str = "unsupported_claim"
+    source_of_truth: str = "run_record"
+    expected: str = ""
+    observed: str = ""
+    citation: str = ""
 
 
 class EvidenceReport(BaseModel):
     grounded: bool = True
     unsupported_claim_count: int = 0
     findings: list[EvidenceFinding] = Field(default_factory=list)
-

--- a/tests/test_evidence_guard.py
+++ b/tests/test_evidence_guard.py
@@ -2,9 +2,11 @@ from pathlib import Path
 
 from app.agents.evidence_guard import EvidenceGuard
 from app.core.graph import run_harness
+from app.core.repo_graph.impact import ChangedSubgraph, ImpactedRoute, ImpactedValidation
 from app.schemas.plan import ImplementationPlan, PlanStep
 from app.schemas.report import FinalReport
 from app.schemas.review import ReviewReport
+from app.schemas.risk import RiskReport
 from app.schemas.test import CommandResult, TestRunSummary
 
 
@@ -85,6 +87,9 @@ def test_evidence_guard_flags_unsupported_file_claims() -> None:
     assert evidence.grounded is False
     assert evidence.unsupported_claim_count == 1
     assert evidence.findings[0].claim == "app/middleware/request_logging.py"
+    assert evidence.findings[0].claim_type == "file_changed_without_diff"
+    assert evidence.findings[0].source_of_truth == "changed_files"
+    assert evidence.findings[0].citation == "RunRecord.changed_files"
 
 
 def test_evidence_guard_flags_new_tests_claim_without_test_file_changes() -> None:
@@ -101,6 +106,134 @@ def test_evidence_guard_flags_new_tests_claim_without_test_file_changes() -> Non
 
     assert evidence.grounded is False
     assert any("tests" in finding.claim.lower() for finding in evidence.findings)
+
+
+def test_evidence_guard_flags_updated_test_claim_without_test_file_changes() -> None:
+    report = FinalReport(
+        title="PR Report",
+        markdown="All existing tests pass, including the updated health endpoint test.",
+    )
+
+    evidence = EvidenceGuard().check(
+        final_report=report,
+        changed_files=["app/main.py"],
+        test_results=passing_tests(),
+    )
+
+    assert evidence.grounded is False
+    assert any(
+        finding.claim_type == "tests_added_without_test_diff"
+        for finding in evidence.findings
+    )
+
+
+def test_evidence_guard_flags_lint_claim_without_lint_command() -> None:
+    report = FinalReport(
+        title="PR Report",
+        markdown="Linting: ruff completed with no errors.",
+    )
+
+    evidence = EvidenceGuard().check(
+        final_report=report,
+        changed_files=["app/main.py"],
+        test_results=passing_tests(),
+    )
+
+    assert evidence.grounded is False
+    finding = evidence.findings[0]
+    assert finding.claim_type == "lint_claim_without_execution"
+    assert finding.source_of_truth == "test_results.commands"
+
+
+def test_evidence_guard_does_not_treat_external_worker_command_as_changed_file() -> None:
+    report = FinalReport(
+        title="PR Report",
+        markdown="The external worker executed the change (`worker.py`) successfully.",
+    )
+
+    evidence = EvidenceGuard().check(
+        final_report=report,
+        changed_files=["app/main.py"],
+        test_results=passing_tests(),
+    )
+
+    assert evidence.grounded is True
+
+
+def test_evidence_guard_flags_route_claim_without_changed_subgraph_evidence() -> None:
+    report = FinalReport(
+        title="PR Report",
+        markdown="Changed GET /admin behavior.",
+    )
+
+    evidence = EvidenceGuard().check(
+        final_report=report,
+        changed_files=["app/main.py"],
+        test_results=passing_tests(),
+        changed_subgraph=ChangedSubgraph(
+            changed_files=["app/main.py"],
+            impacted_routes=[
+                ImpactedRoute(
+                    method="GET",
+                    path="/health",
+                    source_file="app/main.py",
+                    node_id="route:python:GET:/health",
+                )
+            ],
+        ),
+    )
+
+    assert evidence.grounded is False
+    finding = evidence.findings[0]
+    assert finding.claim == "GET /admin"
+    assert finding.claim_type == "route_claim_without_graph_impact"
+    assert finding.source_of_truth == "changed_subgraph.impacted_routes"
+
+
+def test_evidence_guard_flags_low_risk_claim_when_risk_is_high() -> None:
+    report = FinalReport(
+        title="PR Report",
+        markdown="This is low risk and safe.",
+    )
+
+    evidence = EvidenceGuard().check(
+        final_report=report,
+        changed_files=[".env"],
+        test_results=passing_tests(),
+        risk_report=RiskReport(risk_score=90, risk_level="high", factors=["Sensitive file"]),
+    )
+
+    assert evidence.grounded is False
+    finding = evidence.findings[0]
+    assert finding.claim_type == "risk_level_understated"
+    assert finding.source_of_truth == "risk_report"
+
+
+def test_evidence_guard_distinguishes_recommended_from_executed_validation() -> None:
+    report = FinalReport(
+        title="PR Report",
+        markdown="Tests run: uv run pytest tests/test_health.py -q",
+    )
+
+    evidence = EvidenceGuard().check(
+        final_report=report,
+        changed_files=["app/main.py"],
+        test_results=passing_tests(),
+        changed_subgraph=ChangedSubgraph(
+            changed_files=["app/main.py"],
+            recommended_validation=[
+                ImpactedValidation(
+                    command="uv run pytest tests/test_health.py -q",
+                    reason="related_tests_from_repo_graph",
+                )
+            ],
+        ),
+    )
+
+    assert evidence.grounded is False
+    finding = evidence.findings[0]
+    assert finding.claim_type == "recommended_validation_claimed_as_executed"
+    assert finding.source_of_truth == "test_results.commands"
 
 
 def test_evidence_guard_passes_analysis_only_report() -> None:


### PR DESCRIPTION
## Summary

Milestone 5: Evidence Guard findings now include source-of-truth fields and detect graph/diff/test/risk overclaims more specifically.

- Each finding carries `claim_type`, `source_of_truth`, `observed`, and `citation` fields so overclaims are refutable against the run record (e.g. a lint claim refuted by `RunRecord.test_results.commands`).
- Route/API claims are checked against `changed_subgraph.impacted_routes` (builds on Milestone 4).
- Understated-risk claims are checked against `risk_report.risk_level`.
- This makes overclaims explicit rather than rewriting PRWriter — tightening PRWriter is the planned follow-up (Milestone 6).

## Validation

- `uv run --extra dev python -m pytest -q` → 147 passed
- `uv run --extra dev ruff check .` → all checks passed
- Real smoke run `1ccef3d236da4aa28e8ae3f4c8620ec4` correctly flagged an unsupported linting claim with `claim_type=lint_claim_without_execution`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)