### PR TITLE
feat: ground PR writer claims in run record evidence (Milestone 6)

### DIFF
--- a/app/agents/evidence_guard.py
+++ b/app/agents/evidence_guard.py
@@ -158,13 +158,34 @@ This report contains claims that are not supported by the run record.
             ]
         return []
 
+    LINT_EXECUTION_WORDS = (
+        "passed",
+        "pass",
+        "ran",
+        "executed",
+        "completed",
+        "clean",
+        "no errors",
+        "succeeded",
+        "verified",
+    )
+    LINT_RECOMMENDATION_WORDS = (
+        "recommended",
+        "should run",
+        "not executed",
+        "planned",
+        "follow-up",
+        "to run",
+    )
+
     def _check_lint_claims(
         self,
         markdown: str,
         test_results: TestRunSummary,
     ) -> list[EvidenceFinding]:
-        lowered = markdown.lower()
-        claims_lint = "ruff" in lowered or "lint" in lowered
+        claims_lint = any(
+            self._line_claims_lint_executed(line) for line in markdown.splitlines()
+        )
         executed = {result.command for result in test_results.commands}
         ran_lint = any("ruff" in command or "lint" in command for command in executed)
         if claims_lint and not ran_lint:
@@ -339,6 +360,14 @@ This report contains claims that are not supported by the run record.
             )
             for command in unsupported
         ]
+
+    def _line_claims_lint_executed(self, line: str) -> bool:
+        lowered = line.lower()
+        if "ruff" not in lowered and "lint" not in lowered:
+            return False
+        if any(word in lowered for word in self.LINT_RECOMMENDATION_WORDS):
+            return False
+        return any(word in lowered for word in self.LINT_EXECUTION_WORDS)
 
     def _looks_like_change_claim(self, line: str) -> bool:
         lowered = line.lower()

--- a/app/agents/pr_writer.py
+++ b/app/agents/pr_writer.py
@@ -38,20 +38,22 @@ class PRWriter:
 
         files = "\n".join(f"- `{path}`" for path in changed_files) or "- No files changed"
         edit_summary = self._format_edit_summary(edit_result)
-        tests = "\n".join(
-            f"- `{result.command}`: exit {result.exit_code} in {result.duration_seconds:.3f}s"
-            for result in test_results.commands
-        )
+        tests = self._format_test_results(test_results)
         findings = "\n".join(
             f"- **{finding.severity.upper()}** {finding.title}: {finding.recommendation}"
             for finding in review_report.findings
         ) or "- No review findings"
         risk_factors = "\n".join(f"- {factor}" for factor in risk_report.factors)
 
+        summary_status = (
+            ""
+            if changed_files
+            else "\n\nAnalysis-only run: no files were changed."
+        )
         markdown = f"""# AgentOps Harness Report
 
 ## Summary
-{task}
+{task}{summary_status}
 
 ## What changed
 {plan.summary}
@@ -102,3 +104,17 @@ class PRWriter:
 
     def _format_edit_summary(self, edit_result: ExternalEditResult | None) -> str:
         return format_edit_summary(edit_result)
+
+    def _format_test_results(self, test_results: TestRunSummary) -> str:
+        if not test_results.commands:
+            return "- No validation commands were executed."
+        lines = [
+            f"- `{result.command}`: exit {result.exit_code} in {result.duration_seconds:.3f}s"
+            for result in test_results.commands
+        ]
+        status = (
+            "All executed validation commands passed."
+            if test_results.passed
+            else "Validation failed: one or more commands exited non-zero."
+        )
+        return "\n".join([*lines, "", status])

--- a/app/prompts/pr_writer.py
+++ b/app/prompts/pr_writer.py
@@ -33,6 +33,18 @@ def build_pr_writer_prompt(
 
 Write a professional GitHub-style PR report in Markdown.
 
+Grounding rules (hard constraints — every claim must be supported by the inputs below):
+- Only describe a command as executed if it appears in the Tests section, and report
+  its real exit code. Never mention lint/ruff/static analysis unless such a command
+  appears there.
+- Claim that tests pass only if every listed command exited 0. If any exit code is
+  non-zero, state that validation failed.
+- If the Changed files list is empty, state clearly that this was an analysis-only
+  run and describe the plan as proposed work, not completed work.
+- Keep risk wording consistent with the stated risk level; never describe medium or
+  higher risk as low or minimal.
+- Do not invent files, routes, tests, or commands that are not listed below.
+
 Required sections:
 - Summary
 - What changed

--- a/tests/test_pr_writer_grounding.py
+++ b/tests/test_pr_writer_grounding.py
@@ -1,0 +1,148 @@
+from app.agents.evidence_guard import EvidenceGuard
+from app.agents.pr_writer import PRWriter
+from app.core.repo_graph.impact import (
+    ChangedSubgraph,
+    ImpactedValidation,
+    render_changed_subgraph_markdown,
+)
+from app.prompts.pr_writer import build_pr_writer_prompt
+from app.schemas.plan import ImplementationPlan, PlanStep
+from app.schemas.report import FinalReport
+from app.schemas.review import ReviewReport
+from app.schemas.risk import RiskReport
+from app.schemas.test import CommandResult, TestRunSummary
+
+
+def sample_plan() -> ImplementationPlan:
+    return ImplementationPlan(
+        task="Add request logging middleware",
+        summary="Implement 'Add request logging middleware' in the detected FastAPI project.",
+        steps=[
+            PlanStep(
+                id=1,
+                title="Plan middleware",
+                description="Plan request logging middleware and tests.",
+            )
+        ],
+        acceptance_criteria=["Request logging behavior is covered."],
+        tests_to_run=["python -m pytest -q", "ruff check ."],
+    )
+
+
+def sample_review() -> ReviewReport:
+    return ReviewReport(summary="No review findings.", findings=[])
+
+
+def sample_risk() -> RiskReport:
+    return RiskReport(risk_score=10, risk_level="low", factors=["Small diff"])
+
+
+def command(cmd: str, exit_code: int) -> CommandResult:
+    return CommandResult(
+        command=cmd,
+        exit_code=exit_code,
+        duration_seconds=0.1,
+        stdout="",
+        stderr="",
+    )
+
+
+def write_report(
+    changed_files: list[str],
+    test_results: TestRunSummary,
+) -> FinalReport:
+    return PRWriter().write(
+        task="Add request logging middleware",
+        plan=sample_plan(),
+        changed_files=changed_files,
+        test_results=test_results,
+        review_report=sample_review(),
+        risk_report=sample_risk(),
+    )
+
+
+def test_pr_writer_states_analysis_only_when_no_files_changed() -> None:
+    report = write_report(
+        changed_files=[],
+        test_results=TestRunSummary(commands=[command("python -m pytest -q", 0)]),
+    )
+
+    assert "analysis-only run: no files were changed" in report.markdown.lower()
+
+
+def test_pr_writer_states_validation_passed_only_when_all_commands_passed() -> None:
+    report = write_report(
+        changed_files=["app/main.py"],
+        test_results=TestRunSummary(commands=[command("python -m pytest -q", 0)]),
+    )
+
+    assert "all executed validation commands passed" in report.markdown.lower()
+
+
+def test_pr_writer_states_validation_failed_when_any_command_failed() -> None:
+    report = write_report(
+        changed_files=["app/main.py"],
+        test_results=TestRunSummary(commands=[command("python -m pytest -q", 1)]),
+    )
+
+    lowered = report.markdown.lower()
+    assert "validation failed" in lowered
+    assert "all executed validation commands passed" not in lowered
+
+
+def test_pr_writer_states_when_no_validation_commands_were_executed() -> None:
+    report = write_report(
+        changed_files=["app/main.py"],
+        test_results=TestRunSummary(commands=[]),
+    )
+
+    assert "no validation commands were executed" in report.markdown.lower()
+
+
+def test_pr_writer_prompt_includes_grounding_rules() -> None:
+    prompt = build_pr_writer_prompt(
+        task="Add request logging middleware",
+        plan=sample_plan(),
+        changed_files=["app/main.py"],
+        test_results=TestRunSummary(commands=[command("python -m pytest -q", 0)]),
+        review_report=sample_review(),
+        risk_report=sample_risk(),
+    )
+
+    assert "Grounding rules" in prompt
+    assert "Only describe a command as executed" in prompt
+    assert "analysis-only" in prompt
+
+
+def test_evidence_guard_allows_lint_recommendation_without_execution() -> None:
+    changed_subgraph = ChangedSubgraph(
+        changed_files=["app/main.py"],
+        recommended_validation=[
+            ImpactedValidation(
+                command="uv run pytest tests/test_health.py -q",
+                reason="related_tests_from_repo_graph",
+            ),
+            ImpactedValidation(
+                command="uv run ruff check .",
+                reason="style_validation_from_planner",
+            ),
+        ],
+    )
+    report = write_report(
+        changed_files=["app/main.py"],
+        test_results=TestRunSummary(commands=[command("python -m pytest -q", 0)]),
+    )
+    report.markdown = report.markdown.rstrip() + render_changed_subgraph_markdown(
+        changed_subgraph
+    )
+
+    evidence = EvidenceGuard().check(
+        final_report=report,
+        changed_files=["app/main.py"],
+        test_results=TestRunSummary(commands=[command("python -m pytest -q", 0)]),
+        risk_report=sample_risk(),
+        changed_subgraph=changed_subgraph,
+    )
+
+    assert evidence.grounded is True
+    assert evidence.unsupported_claim_count == 0


### PR DESCRIPTION
## Summary

Milestone 6: stop report overclaims at the source, with Evidence Guard v2 (Milestone 5, #6) as the regression net.

- **Deterministic PRWriter** now emits an explicit validation status derived from `test_results.passed` ("All executed validation commands passed." / "Validation failed: one or more commands exited non-zero."), states when no validation commands were executed, and labels runs with no changed files as analysis-only.
- **PR writer LLM prompt** gains hard grounding rules: only describe commands from the Tests section as executed, no lint claims without a lint command, pass claims only on all-zero exit codes, risk wording bounded by the stated risk level, no invented files/routes/tests.
- **Evidence Guard lint check** is now line-scoped: a ruff/lint mention only counts as a claim when the same line asserts execution ("passed", "ran", "clean", …) and is not a recommendation ("recommended", "should run", …). This fixes the false positive where the changed-subgraph "Recommended targeted validation" section (Milestone 4) triggered `lint_claim_without_execution`. Genuine claims are still caught — the existing test for "Linting: ruff completed with no errors." remains red-flagged.

## Validation

- TDD: 6 new tests in `tests/test_pr_writer_grounding.py` written first and watched fail, then implementation.
- `uv run --extra dev python -m pytest -q` → 153 passed
- `uv run --extra dev ruff check .` → all checks passed
- Live smoke run on `examples/sample_fastapi_app` → `evidence_report.grounded=True`, zero findings (Milestone 6 success criterion).

🤖 Generated with [Claude Code](https://claude.com/claude-code)