### PR TITLE
feat: CEO-layer v1 (intent graph + product reviewer) + harness hardening

### DIFF
--- a/agentops.goals.yaml
+++ b/agentops.goals.yaml
@@ -1,0 +1,41 @@
+north_star: >-
+  A local-first control harness that wraps any coding worker with planning,
+  validation, and evidence — so a CEO/CTO can govern what gets built.
+not_this:
+  - A hosted SaaS that stores your code or run history off your machine.
+  - A new coding agent / inner editing loop (we wrap existing workers).
+constraints:
+  - Local-first; the demo runs with no API key (mock provider).
+  - Anthropic SDK only; never the OpenAI SDK.
+  - Every shipped claim must be grounded in the run record.
+goals:
+  - id: G1
+    statement: Ground every worker run in deterministic repo + intent structure.
+    rationale: A grounded start makes runs traceable and judgeable, not vibes.
+    priority: now
+    success_when:
+      - Repo graph is built without an LLM call.
+      - The worker packet carries the plan-as-contract and impacted subgraph.
+      - Each run targets a stated goal from the intent graph.
+    scope_out:
+      - Model fine-tuning or training.
+      - Token-cost optimization.
+  - id: G2
+    statement: Make every run produce a usable evidence bundle, even on failure.
+    rationale: Governance requires inspectable proof, not just an outcome.
+    priority: now
+    success_when:
+      - A completed run writes the full artifact bundle to .agentops/runs/<id>/.
+      - Guards (risk, permission, report-quality, evidence) run on every pass.
+      - A timed-out or failing command is recorded, not crashed on.
+    scope_out:
+      - Cloud dashboards or hosted reporting.
+  - id: G3
+    statement: Judge each run against product intent at the CEO/CTO altitude.
+    rationale: Correct code is not the same as the right work done.
+    priority: next
+    success_when:
+      - Product Reviewer emits a cited verdict per alignment/completeness/value/priority lens.
+      - A run with no intent graph degrades to not_evaluated, never bluffs.
+    scope_out:
+      - Auto-assigning the next task (suggestions are deferred).

--- a/app/agents/product_reviewer.py
+++ b/app/agents/product_reviewer.py
@@ -1,0 +1,233 @@
+from __future__ import annotations
+
+import re
+
+from app.core.llm import LLMClient
+from app.schemas.goal_model import Goal, ProductGoalModel
+from app.schemas.plan import ImplementationPlan
+from app.schemas.product_review import ProductFinding, ProductReview
+from app.schemas.test import TestRunSummary
+
+_STOPWORDS = {"the", "a", "an", "is", "to", "and", "of", "for", "with", "added", "add"}
+
+
+def _planned_files(plan: ImplementationPlan) -> set[str]:
+    files: set[str] = set()
+    for step in plan.steps:
+        files.update(step.files_to_edit)
+    return files
+
+
+def _signal_met(signal: str, haystack: str) -> bool:
+    tokens = []
+    for raw in signal.lower().replace("/", " ").split():
+        token = raw.strip(".,;:#<>()[]\"'")
+        if token and token not in _STOPWORDS and len(token) > 2 and any(c.isalnum() for c in token):
+            tokens.append(token)
+    if not tokens:
+        return False
+    return all(bool(re.search(r"\b" + re.escape(t) + r"\b", haystack)) for t in tokens)
+
+
+class ProductReviewer:
+    def __init__(self, llm_client: LLMClient | None = None) -> None:
+        self.llm_client = llm_client
+
+    def review(
+        self,
+        *,
+        task: str,
+        plan: ImplementationPlan,
+        changed_files: list[str],
+        diff_summary: str,
+        changed_subgraph: object | None,
+        test_results: TestRunSummary,
+        goal_model: ProductGoalModel | None,
+        target_goal_id: str | None,
+    ) -> ProductReview:
+        if goal_model is None:
+            return self._not_evaluated()
+
+        # LLM path mirrors other agents. Exceptions propagate so the calling node
+        # can record a provider_fallback event (the deterministic path is the net).
+        if self.llm_client is not None:
+            from app.prompts.product_reviewer import build_product_reviewer_prompt
+
+            return self.llm_client.generate_structured(
+                build_product_reviewer_prompt(
+                    task=task, plan=plan, changed_files=changed_files,
+                    diff_summary=diff_summary, goal_model=goal_model,
+                    target_goal_id=target_goal_id,
+                ),
+                ProductReview,
+            )
+
+        return self._deterministic(
+            plan=plan, changed_files=changed_files, diff_summary=diff_summary,
+            test_results=test_results, goal_model=goal_model, target_goal_id=target_goal_id,
+        )
+
+    def _not_evaluated(self) -> ProductReview:
+        findings = [
+            ProductFinding(
+                lens=lens, verdict="not_evaluated",
+                observation="No intent graph found; product intent not evaluated.",
+                source_of_truth="goal_model", citation="no agentops.goals.yaml",
+                confidence="high",
+                recommendation="Author agentops.goals.yaml to enable product review.",
+            )
+            for lens in ("goal_alignment", "completeness", "value", "prioritization")
+        ]
+        return ProductReview(
+            overall_verdict="not_evaluated",
+            per_lens={f.lens: "not_evaluated" for f in findings},
+            findings=findings,
+            summary="Product review skipped: no intent graph (agentops.goals.yaml).",
+        )
+
+    def _deterministic(
+        self, *, plan: ImplementationPlan, changed_files: list[str], diff_summary: str,
+        test_results: TestRunSummary, goal_model: ProductGoalModel, target_goal_id: str | None,
+    ) -> ProductReview:
+        goal = goal_model.goal(target_goal_id) if target_goal_id else None
+        gid = goal.id if goal else "model"
+        planned = _planned_files(plan)
+        outside = [f for f in changed_files if planned and f not in planned]
+        lowered_paths = " ".join(changed_files).lower()
+        findings: list[ProductFinding] = []
+
+        # goal_alignment
+        scope_terms = list(goal.scope_out) if goal else []
+        scope_terms += goal_model.not_this
+        hit = next(
+            (
+                t for t in scope_terms
+                if t.strip()
+                and re.search(r"\b" + re.escape(t.lower()) + r"\b", lowered_paths)
+            ),
+            None,
+        )
+        if hit:
+            align = ProductFinding(
+                lens="goal_alignment", verdict="fail",
+                observation=f"Change touches excluded area: '{hit}'.",
+                source_of_truth=f"goal_model.{gid}.scope_out",
+                citation=f"agentops.goals.yaml#{gid}", confidence="medium",
+                recommendation="Stop and confirm this is intended product scope.",
+            )
+        elif outside:
+            align = ProductFinding(
+                lens="goal_alignment", verdict="concern",
+                observation=f"{len(outside)} changed file(s) outside the planned set.",
+                source_of_truth="plan.files_to_edit", citation="RunRecord.plan",
+                confidence="low", recommendation="Confirm the extra files serve the goal.",
+            )
+        else:
+            align = ProductFinding(
+                lens="goal_alignment", verdict="pass",
+                observation="Changes stay within the planned files.",
+                source_of_truth="plan.files_to_edit", citation="RunRecord.plan",
+                confidence="medium", recommendation="",
+            )
+        findings.append(align)
+
+        # completeness
+        haystack = (lowered_paths + " " + diff_summary.lower() + " " +
+                    " ".join(c.command for c in test_results.commands).lower())
+        signals = (
+            goal.success_when if goal
+            else [s for g in goal_model.goals for s in g.success_when]
+        )
+        unmet = [s for s in signals if not _signal_met(s, haystack)]
+        complete = ProductFinding(
+            lens="completeness",
+            verdict="pass" if (not unmet and test_results.passed) else "concern",
+            observation=f"{len(signals) - len(unmet)} of {len(signals)} success signals met"
+            + ("; validation failed." if not test_results.passed else "."),
+            source_of_truth=f"goal_model.{gid}.success_when",
+            citation=f"agentops.goals.yaml#{gid}", confidence="low",
+            recommendation="Address unmet success signals before marking done."
+            if unmet else "",
+        )
+        findings.append(complete)
+
+        # value (overbuilt)
+        value = ProductFinding(
+            lens="value",
+            verdict="concern" if (planned and len(outside) > len(planned)) else "pass",
+            observation="Diff scope exceeds the planned scope."
+            if (planned and len(outside) > len(planned)) else "Diff scope matches the plan.",
+            source_of_truth="plan.files_to_edit", citation="RunRecord.plan",
+            confidence="low",
+            recommendation="Trim gold-plating not tied to a success signal."
+            if (planned and len(outside) > len(planned)) else "",
+        )
+        findings.append(value)
+
+        # prioritization
+        findings.append(self._prioritization(goal, goal_model, gid))
+
+        return ProductReview(
+            overall_verdict=self._overall(findings),
+            per_lens={f.lens: f.verdict for f in findings},
+            findings=findings,
+            summary=self._summary(findings),
+        )
+
+    def _prioritization(
+        self, goal: Goal | None, goal_model: ProductGoalModel, gid: str
+    ) -> ProductFinding:
+        if goal is None:
+            return ProductFinding(
+                lens="prioritization", verdict="not_evaluated",
+                observation="No target goal supplied (--goal); priority not evaluated.",
+                source_of_truth="goal_model", citation="RunRecord.target_goal_id",
+                confidence="high", recommendation="Pass --goal <id> to ground prioritization.",
+            )
+        now_open = any(g.priority == "now" and g.id != goal.id for g in goal_model.goals)
+        if goal.priority != "now" and now_open:
+            return ProductFinding(
+                lens="prioritization", verdict="concern",
+                observation=f"Working {goal.priority}-priority {goal.id} while now-goals are open.",
+                source_of_truth=f"goal_model.{gid}.priority",
+                citation=f"agentops.goals.yaml#{gid}", confidence="medium",
+                recommendation="Confirm this is the right thing to build now.",
+            )
+        return ProductFinding(
+            lens="prioritization", verdict="pass",
+            observation=f"{goal.id} is a {goal.priority}-priority goal.",
+            source_of_truth=f"goal_model.{gid}.priority",
+            citation=f"agentops.goals.yaml#{gid}", confidence="medium", recommendation="",
+        )
+
+    def _overall(self, findings: list[ProductFinding]) -> str:
+        by = {f.lens: f.verdict for f in findings}
+        if by.get("goal_alignment") == "fail":
+            return "drifted"
+        if by.get("completeness") == "concern":
+            return "incomplete"
+        if by.get("value") == "concern":
+            return "overbuilt"
+        all_pass = all(
+            by.get(lens) in {"pass"}
+            for lens in ("goal_alignment", "completeness", "value")
+        )
+        if all_pass:
+            return "aligned"
+        return "unclear"
+
+    def _summary(self, findings: list[ProductFinding]) -> str:
+        return "; ".join(f"{f.lens}: {f.verdict}" for f in findings)
+
+    def append_to_report(self, final_report, review: ProductReview):
+        from app.schemas.report import FinalReport
+
+        lines = ["", "", "## Product Review", "",
+                 f"Overall verdict: **{review.overall_verdict}**", ""]
+        for f in review.findings:
+            lines.append(
+                f"- **{f.lens}** — {f.verdict}: {f.observation} "
+                f"(source: {f.source_of_truth}; cite: {f.citation})"
+            )
+        markdown = final_report.markdown.rstrip() + "\n".join(lines) + "\n"
+        return FinalReport(title=final_report.title, markdown=markdown)

--- a/app/cli.py
+++ b/app/cli.py
@@ -94,6 +94,9 @@ def run(
     ],
     task: Annotated[str, typer.Option(help="Engineering task to analyze.")],
     storage: Annotated[Path, typer.Option(help="Run history JSONL path.")] = settings.run_storage,
+    goal: Annotated[
+        str | None, typer.Option("--goal", help="Intent-graph goal id this run targets.")
+    ] = None,
 ) -> None:
     """Run the full AgentOps Harness pipeline."""
     record = run_harness(
@@ -101,6 +104,7 @@ def run(
         task=task,
         storage_path=storage,
         llm_client=build_runtime_llm_client(settings),
+        target_goal_id=goal,
     )
     console.print(Panel(record.final_report.markdown, title=f"Run {record.run_id}"))
 
@@ -129,6 +133,9 @@ def edit(
         bool,
         typer.Option(help="Allow worker runs when the target repo already has changes."),
     ] = False,
+    goal: Annotated[
+        str | None, typer.Option("--goal", help="Intent-graph goal id this run targets.")
+    ] = None,
 ) -> None:
     """Run an explicit external worker, then validate and report its diff.
 
@@ -148,6 +155,7 @@ def edit(
         worker_type=worker_type,
         worker_timeout_seconds=worker_timeout_seconds,
         allow_dirty=allow_dirty,
+        target_goal_id=goal,
     )
     console.print(Panel(record.final_report.markdown, title=f"Run {record.run_id}"))
 

--- a/app/core/goal_model.py
+++ b/app/core/goal_model.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+from pydantic import ValidationError
+
+from app.schemas.goal_model import ProductGoalModel
+
+GOAL_MODEL_FILENAME = "agentops.goals.yaml"
+
+
+class GoalModelError(ValueError):
+    """Raised when an intent graph file exists but cannot be parsed/validated."""
+
+
+def load_goal_model(repo_path: Path) -> ProductGoalModel | None:
+    path = repo_path / GOAL_MODEL_FILENAME
+    if not path.is_file():
+        return None
+    try:
+        raw = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+    except yaml.YAMLError as exc:
+        raise GoalModelError(f"Invalid YAML in {path}: {exc}") from exc
+    try:
+        return ProductGoalModel.model_validate(raw)
+    except ValidationError as exc:
+        raise GoalModelError(f"Invalid goal model in {path}: {exc}") from exc

--- a/app/core/graph.py
+++ b/app/core/graph.py
@@ -11,6 +11,7 @@ from app.agents.evidence_guard import EvidenceGuard
 from app.agents.permission_gate import PermissionGate
 from app.agents.planner import Planner
 from app.agents.pr_writer import PRWriter
+from app.agents.product_reviewer import ProductReviewer
 from app.agents.repo_scanner import RepoScanner
 from app.agents.report_quality_guard import ReportQualityGuard
 from app.agents.reviewer import Reviewer
@@ -19,6 +20,7 @@ from app.agents.verification_stack import VerificationStack
 from app.core.conflict import ConflictAuditor
 from app.core.edit_runner import ExternalWorkerRunner
 from app.core.git_utils import collect_changed_files, collect_deleted_files, collect_diff_summary
+from app.core.goal_model import GoalModelError, load_goal_model
 from app.core.llm import LLMClient
 from app.core.memory import ExperienceMemory
 from app.core.repo_graph import RepoGraphBuilder
@@ -41,13 +43,21 @@ def append_logs(state: AgentOpsGraphState, *entries: str) -> list[str]:
 def scan_repo_node(state: AgentOpsGraphState) -> AgentOpsGraphState:
     profile = RepoScanner().scan(state["repo_path"])
     repo_graph = RepoGraphBuilder().build(state["repo_path"])
+    try:
+        goal_model = load_goal_model(state["repo_path"])
+        goal_log = "goal_model:loaded" if goal_model else "goal_model:absent"
+    except GoalModelError:
+        goal_model = None
+        goal_log = "goal_model:invalid"
     return {
         "repo_profile": profile,
         "repo_graph": repo_graph,
+        "goal_model": goal_model,
         "execution_logs": append_logs(
             state,
             "scan_repo:start",
             "repo_graph:complete",
+            goal_log,
             "scan_repo:complete",
         ),
     }
@@ -178,10 +188,10 @@ def run_tests_node(state: AgentOpsGraphState) -> AgentOpsGraphState:
     # run the validation the planner selected (e.g. `uv run pytest` for a uv
     # project) instead of falling back to the hardcoded default.
     commands = state.get("test_commands") or state["plan"].tests_to_run or None
-    test_results = TestRunner().run(
-        state["repo_path"],
-        commands=commands,
-    )
+    runner_kwargs: dict = {"commands": commands}
+    if state.get("test_timeout_seconds"):
+        runner_kwargs["timeout_seconds"] = state["test_timeout_seconds"]
+    test_results = TestRunner().run(state["repo_path"], **runner_kwargs)
     return {
         "test_results": test_results,
         "execution_logs": append_logs(state, "run_tests:start", "run_tests:complete"),
@@ -317,6 +327,33 @@ def check_evidence_node(state: AgentOpsGraphState) -> AgentOpsGraphState:
     }
 
 
+def build_product_review_node(state: AgentOpsGraphState) -> AgentOpsGraphState:
+    logs = append_logs(state, "build_product_review:start")
+    kwargs = dict(
+        task=state["task"],
+        plan=state["plan"],
+        changed_files=state["changed_files"],
+        diff_summary=state["diff_summary"],
+        changed_subgraph=state.get("changed_subgraph"),
+        test_results=state["test_results"],
+        goal_model=state.get("goal_model"),
+        target_goal_id=state.get("target_goal_id"),
+    )
+    reviewer = ProductReviewer(llm_client=state.get("llm_client"))
+    try:
+        review = reviewer.review(**kwargs)
+    except Exception:
+        review = ProductReviewer().review(**kwargs)
+        logs.append("provider_fallback:build_product_review")
+    final_report = reviewer.append_to_report(state["final_report"], review)
+    logs.append("build_product_review:complete")
+    return {
+        "product_review": review,
+        "final_report": final_report,
+        "execution_logs": logs,
+    }
+
+
 def assemble_verification_node(state: AgentOpsGraphState) -> AgentOpsGraphState:
     verification_stack = VerificationStack()
     bundle = verification_stack.assemble(
@@ -375,6 +412,7 @@ def build_workflow_graph() -> CompiledStateGraph:
     graph.add_node("write_report", write_report_node)
     graph.add_node("check_report_quality", check_report_quality_node)
     graph.add_node("check_evidence", check_evidence_node)
+    graph.add_node("build_product_review", build_product_review_node)
     graph.add_node("assemble_verification", assemble_verification_node)
     graph.add_node("audit_conflicts", audit_conflicts_node)
 
@@ -391,7 +429,8 @@ def build_workflow_graph() -> CompiledStateGraph:
     graph.add_edge("classify_permissions", "write_report")
     graph.add_edge("write_report", "check_report_quality")
     graph.add_edge("check_report_quality", "check_evidence")
-    graph.add_edge("check_evidence", "assemble_verification")
+    graph.add_edge("check_evidence", "build_product_review")
+    graph.add_edge("build_product_review", "assemble_verification")
     graph.add_edge("assemble_verification", "audit_conflicts")
     graph.add_edge("audit_conflicts", END)
     return graph.compile()
@@ -407,6 +446,8 @@ def run_harness(
     worker_type: str | None = None,
     worker_timeout_seconds: int = 300,
     allow_dirty: bool = False,
+    target_goal_id: str | None = None,
+    test_timeout_seconds: int | None = None,
 ) -> RunRecord:
     started_at = datetime.now(UTC)
     run_id = uuid4().hex
@@ -422,6 +463,8 @@ def run_harness(
             "worker_type": worker_type,
             "worker_timeout_seconds": worker_timeout_seconds,
             "allow_dirty": allow_dirty,
+            "test_timeout_seconds": test_timeout_seconds,
+            "target_goal_id": target_goal_id,
             "execution_logs": [],
         },
         config={"configurable": {"thread_id": run_id}},
@@ -454,6 +497,7 @@ def run_harness(
         evidence_report=graph_state["evidence_report"],
         verification_bundle=graph_state["verification_bundle"],
         conflict_report=graph_state["conflict_report"],
+        product_review=graph_state["product_review"],
         edit_result=edit_result,
         execution_logs=graph_state["execution_logs"],
         token_usage={"tokens_in": 0, "tokens_out": 0},

--- a/app/core/graph.py
+++ b/app/core/graph.py
@@ -174,9 +174,13 @@ def build_changed_subgraph_node(state: AgentOpsGraphState) -> AgentOpsGraphState
 
 
 def run_tests_node(state: AgentOpsGraphState) -> AgentOpsGraphState:
+    # Honor the plan-as-contract: explicit test_commands override, otherwise
+    # run the validation the planner selected (e.g. `uv run pytest` for a uv
+    # project) instead of falling back to the hardcoded default.
+    commands = state.get("test_commands") or state["plan"].tests_to_run or None
     test_results = TestRunner().run(
         state["repo_path"],
-        commands=state.get("test_commands"),
+        commands=commands,
     )
     return {
         "test_results": test_results,

--- a/app/core/run_artifacts.py
+++ b/app/core/run_artifacts.py
@@ -45,6 +45,7 @@ class RunArtifactWriter:
         self._write_json(artifact_dir / "risk_report.json", record.risk_report)
         self._write_json(artifact_dir / "permission_report.json", record.permission_report)
         self._write_json(artifact_dir / "evidence_report.json", record.evidence_report)
+        self._write_json(artifact_dir / "product_review.json", record.product_review)
         self._write_json(artifact_dir / "verification_bundle.json", record.verification_bundle)
         self._write_json(artifact_dir / "conflict_report.json", record.conflict_report)
         self._write_text(artifact_dir / "final_report.md", record.final_report.markdown)

--- a/app/core/state.py
+++ b/app/core/state.py
@@ -9,9 +9,11 @@ from app.core.repo_graph.models import RepoGraph
 from app.schemas.conflict import ConflictReport
 from app.schemas.edit import ExternalEditResult
 from app.schemas.evidence import EvidenceReport
+from app.schemas.goal_model import ProductGoalModel
 from app.schemas.memory import MemoryReport
 from app.schemas.permission import PermissionReport
 from app.schemas.plan import ImplementationPlan
+from app.schemas.product_review import ProductReview
 from app.schemas.quality import ReportQualityReport
 from app.schemas.repo import RepoProfile
 from app.schemas.report import FinalReport
@@ -31,6 +33,7 @@ class AgentOpsGraphState(TypedDict, total=False):
     worker_command: str | None
     worker_type: str | None
     worker_timeout_seconds: int
+    test_timeout_seconds: int | None
     allow_dirty: bool
     repo_profile: RepoProfile
     memory_report: MemoryReport
@@ -51,3 +54,6 @@ class AgentOpsGraphState(TypedDict, total=False):
     execution_logs: list[str]
     repo_graph: RepoGraph
     changed_subgraph: ChangedSubgraph
+    goal_model: ProductGoalModel | None
+    target_goal_id: str | None
+    product_review: ProductReview

--- a/app/core/test_runner.py
+++ b/app/core/test_runner.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import os
 import shlex
+import signal
 import subprocess
 import sys
 import time
@@ -10,13 +11,17 @@ from pathlib import Path
 from app.core.security import validate_safe_command
 from app.schemas.test import CommandResult, TestRunSummary
 
+# Cold `uv run pytest` can spend over a minute resolving/building the
+# environment before tests even start, so the default is generous.
+DEFAULT_TIMEOUT_SECONDS = 300
+
 
 class TestRunner:
     def run(
         self,
         repo_path: Path,
         commands: list[str] | None = None,
-        timeout_seconds: int = 120,
+        timeout_seconds: int = DEFAULT_TIMEOUT_SECONDS,
     ) -> TestRunSummary:
         selected_commands = ["python -m pytest -q"] if commands is None else commands
         results: list[CommandResult] = []
@@ -25,29 +30,36 @@ class TestRunner:
             validate_safe_command(command)
             started = time.perf_counter()
             env = self._subprocess_env(repo_path)
+            # Run in a new session/process group so that on timeout we can kill
+            # the whole tree (e.g. uv -> pytest -> workers), not just the direct
+            # child — otherwise grandchildren leak as orphans.
+            process = subprocess.Popen(
+                self._resolve_argv(command),
+                cwd=repo_path,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+                env=env,
+                start_new_session=True,
+            )
             try:
-                completed = subprocess.run(
-                    self._resolve_argv(command),
-                    cwd=repo_path,
-                    capture_output=True,
-                    text=True,
-                    timeout=timeout_seconds,
-                    check=False,
-                    env=env,
-                )
-            except subprocess.TimeoutExpired as timed_out:
+                stdout, stderr = process.communicate(timeout=timeout_seconds)
+                exit_code = process.returncode
+            except subprocess.TimeoutExpired:
                 # A hung command must be recorded as a failure, not crash the
                 # run — the harness still has to produce usable evidence.
+                self._kill_process_group(process)
+                stdout, stderr = process.communicate()
                 duration = time.perf_counter() - started
                 results.append(
                     CommandResult(
                         command=command,
                         exit_code=124,
                         duration_seconds=round(duration, 3),
-                        stdout=self._decode(timed_out.stdout),
+                        stdout=self._decode(stdout),
                         stderr=(
-                            f"Command timed out after {timeout_seconds}s and was "
-                            f"terminated.\n{self._decode(timed_out.stderr)}"
+                            f"Command timed out after {timeout_seconds}s and the "
+                            f"process group was terminated.\n{self._decode(stderr)}"
                         ).strip(),
                     )
                 )
@@ -56,14 +68,20 @@ class TestRunner:
             results.append(
                 CommandResult(
                     command=command,
-                    exit_code=completed.returncode,
+                    exit_code=exit_code,
                     duration_seconds=round(duration, 3),
-                    stdout=completed.stdout,
-                    stderr=completed.stderr,
+                    stdout=self._decode(stdout),
+                    stderr=self._decode(stderr),
                 )
             )
 
         return TestRunSummary(commands=results)
+
+    def _kill_process_group(self, process: subprocess.Popen) -> None:
+        try:
+            os.killpg(os.getpgid(process.pid), signal.SIGKILL)
+        except (ProcessLookupError, PermissionError, OSError):
+            process.kill()
 
     def _decode(self, value: object) -> str:
         if value is None:

--- a/app/core/test_runner.py
+++ b/app/core/test_runner.py
@@ -25,15 +25,33 @@ class TestRunner:
             validate_safe_command(command)
             started = time.perf_counter()
             env = self._subprocess_env(repo_path)
-            completed = subprocess.run(
-                self._resolve_argv(command),
-                cwd=repo_path,
-                capture_output=True,
-                text=True,
-                timeout=timeout_seconds,
-                check=False,
-                env=env,
-            )
+            try:
+                completed = subprocess.run(
+                    self._resolve_argv(command),
+                    cwd=repo_path,
+                    capture_output=True,
+                    text=True,
+                    timeout=timeout_seconds,
+                    check=False,
+                    env=env,
+                )
+            except subprocess.TimeoutExpired as timed_out:
+                # A hung command must be recorded as a failure, not crash the
+                # run — the harness still has to produce usable evidence.
+                duration = time.perf_counter() - started
+                results.append(
+                    CommandResult(
+                        command=command,
+                        exit_code=124,
+                        duration_seconds=round(duration, 3),
+                        stdout=self._decode(timed_out.stdout),
+                        stderr=(
+                            f"Command timed out after {timeout_seconds}s and was "
+                            f"terminated.\n{self._decode(timed_out.stderr)}"
+                        ).strip(),
+                    )
+                )
+                continue
             duration = time.perf_counter() - started
             results.append(
                 CommandResult(
@@ -46,6 +64,13 @@ class TestRunner:
             )
 
         return TestRunSummary(commands=results)
+
+    def _decode(self, value: object) -> str:
+        if value is None:
+            return ""
+        if isinstance(value, bytes):
+            return value.decode("utf-8", errors="replace")
+        return str(value)
 
     def _resolve_argv(self, command: str) -> list[str]:
         """Split command and replace bare 'python'/'python3' with the active interpreter."""

--- a/app/prompts/product_reviewer.py
+++ b/app/prompts/product_reviewer.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+from app.schemas.goal_model import ProductGoalModel
+from app.schemas.plan import ImplementationPlan
+
+
+def build_product_reviewer_prompt(
+    *, task: str, plan: ImplementationPlan, changed_files: list[str],
+    diff_summary: str, goal_model: ProductGoalModel, target_goal_id: str | None,
+) -> str:
+    goal = goal_model.goal(target_goal_id) if target_goal_id else None
+    goal_block = (
+        f"Target goal {goal.id}: {goal.statement}\n"
+        f"  priority: {goal.priority}\n"
+        f"  success_when: {goal.success_when}\n"
+        f"  scope_out: {goal.scope_out}\n"
+        if goal else "No specific target goal; evaluate against the whole model."
+    )
+    files = "\n".join(f"- {f}" for f in changed_files) or "- none"
+    return f"""You are the Product Reviewer in AgentOps Harness — the CEO/CTO altitude.
+You do NOT re-check code correctness (other guards do). You judge whether the work
+served the product intent, across four lenses: goal_alignment, completeness, value,
+prioritization.
+
+Grounding rules (hard constraints):
+- Judge ONLY against the goal model and run artifacts below.
+- Every finding must cite a source_of_truth field (e.g. goal_model.G1.scope_out).
+- Never invent goals, success signals, or files.
+- Use verdict not_evaluated when the intent is absent rather than guessing.
+
+Product north star: {goal_model.north_star}
+Not this: {goal_model.not_this}
+{goal_block}
+
+Task: {task}
+Plan summary: {plan.summary}
+Changed files:
+{files}
+Diff summary: {diff_summary}
+"""

--- a/app/schemas/goal_model.py
+++ b/app/schemas/goal_model.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import BaseModel, Field
+
+GoalPriority = Literal["now", "next", "later"]
+
+
+class Goal(BaseModel):
+    id: str
+    statement: str
+    rationale: str = ""
+    priority: GoalPriority = "now"
+    success_when: list[str] = Field(default_factory=list)
+    scope_out: list[str] = Field(default_factory=list)
+
+
+class ProductGoalModel(BaseModel):
+    north_star: str = ""
+    not_this: list[str] = Field(default_factory=list)
+    constraints: list[str] = Field(default_factory=list)
+    goals: list[Goal] = Field(default_factory=list)
+
+    def goal(self, goal_id: str) -> Goal | None:
+        for goal in self.goals:
+            if goal.id == goal_id:
+                return goal
+        return None

--- a/app/schemas/product_review.py
+++ b/app/schemas/product_review.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import BaseModel, Field
+
+ProductLens = Literal["goal_alignment", "completeness", "value", "prioritization"]
+ProductVerdict = Literal["pass", "concern", "fail", "not_evaluated"]
+OverallVerdict = Literal[
+    "aligned", "drifted", "overbuilt", "incomplete", "unclear", "not_evaluated"
+]
+
+
+class ProductFinding(BaseModel):
+    lens: ProductLens
+    verdict: ProductVerdict
+    observation: str
+    source_of_truth: str = "goal_model"
+    citation: str = ""
+    confidence: Literal["low", "medium", "high"] = "medium"
+    recommendation: str = ""
+
+
+class ProductReview(BaseModel):
+    overall_verdict: OverallVerdict = "not_evaluated"
+    per_lens: dict[str, str] = Field(default_factory=dict)
+    findings: list[ProductFinding] = Field(default_factory=list)
+    summary: str = ""
+    suggested_next: list[str] = Field(default_factory=list)  # STUB — deferred to v2

--- a/app/schemas/run.py
+++ b/app/schemas/run.py
@@ -11,6 +11,7 @@ from app.schemas.evidence import EvidenceReport
 from app.schemas.memory import MemoryReport
 from app.schemas.permission import PermissionReport
 from app.schemas.plan import ImplementationPlan
+from app.schemas.product_review import ProductReview
 from app.schemas.quality import ReportQualityReport
 from app.schemas.repo import RepoProfile
 from app.schemas.report import FinalReport
@@ -43,6 +44,7 @@ class RunRecord(BaseModel):
     evidence_report: EvidenceReport = Field(default_factory=EvidenceReport)
     verification_bundle: VerificationBundle = Field(default_factory=VerificationBundle)
     conflict_report: ConflictReport = Field(default_factory=ConflictReport)
+    product_review: ProductReview = Field(default_factory=ProductReview)
     edit_result: ExternalEditResult | None = None
     execution_logs: list[str] = Field(default_factory=list)
     token_usage: dict[str, int] = Field(default_factory=dict)

--- a/docs/THREE_LAYER_FOUNDATION.md
+++ b/docs/THREE_LAYER_FOUNDATION.md
@@ -1,0 +1,100 @@
+# Flagship Foundation — The Three-Layer Harness
+
+> Architecture decision, 2026-06-10. The foundation of the AgentOps Harness flagship.
+> Reconciles the harness-deep-dive transcript, both explainer decks, and the
+> "Code as the Agent Harness" paper. See [reference/code-as-agent-harness/what-is-a-harness.md](reference/code-as-agent-harness/what-is-a-harness.md).
+
+## The decision
+
+A harness is everything *outside* a loop that makes it finish a task — and the
+pattern **nests**. The flagship is three nested layers the CEO/CTO owns, with the
+model rented in exactly one box:
+
+```
+┌─ CEO LAYER ───────────────────────────────────────────────┐
+│  holds GOALS + PRODUCT. starts the loop, closes it.        │  ← the gap; build this
+│  governs WHAT is done and WHETHER it served the goal       │
+├─ AGENTOPS LAYER (control harness) ─────────────────────────┤
+│  governs HOW: plan → assign → validate → guard → evidence  │  ← largely built
+├─ WORKER LAYER ─────────────────────────────────────────────┤
+│  does the editing: swappable inner-loop workers            │  ← built (codex/claude/opencode)
+│       └─ MODEL (rented, swappable) ─ answers once          │
+└────────────────────────────────────────────────────────────┘
+```
+
+- **AgentOps governs *how* work is done** — correctly, safely, with evidence. Built.
+- **The CEO layer governs *what* is done and *whether it served the goal*** — product
+  alignment, prioritization, ship-or-reassign. This is the missing half. The human
+  CEO/CTO lives here; the Product Reviewer and "suggested next work" are CEO-layer
+  components (not AgentOps guards).
+
+## Two owned deterministic graphs — the moat
+
+Each layer starts *grounded* because of a deterministic, inspectable, locally-owned
+primitive. The model is rented; the graphs are yours.
+
+```
+Worker layer  ← grounded by →  repo graph    (structure of the CODE)
+CEO layer     ← grounded by →  intent graph  (structure of the PURPOSE)
+AgentOps      = the translator: intent → governed run → evidence → back to the CEO
+```
+
+The repo graph (already built — 1,714 nodes on contextiq, 0 LLM tokens) keeps the
+worker from blindly exploring code. The **intent graph** is its symmetric twin for the
+CEO layer: it keeps the loop grounded in *what you're trying to build*, and gives the
+Product Reviewer ground truth to judge alignment against.
+
+## The intent graph — CEO-authored, v1 scope
+
+The CEO authors a structured goal model. Principle: **goals are durable; features are
+emergent.** The graph holds durable goals; the per-loop assignment supplies the
+emergent feature (mirrors repo-graph-durable vs plan-transient).
+
+**v1 schema (locked):**
+
+```
+NORTH STAR   — one sentence: what this product is, for whom
+NOT_THIS     — what this product is explicitly NOT (catches fundamental scope violations)
+CONSTRAINTS  — non-negotiables (stack, principles, what we never do)
+
+GOAL  G1  "<the why>"
+  rationale     — why this matters
+  priority      — now | next | later
+  success_when  — [ discrete, individually-checkable signals ]   ← each citable met/unmet
+  scope_out     — [ what this goal explicitly excludes ]
+```
+
+`success_when` is a list of **discrete checkable signals** (not a paragraph) so the
+Product Reviewer can report "criterion 2 of 3 met" with a citation even without a
+feature layer.
+
+## How v1 grounds the loop
+
+- **Initiate** — CEO picks a goal; AgentOps gets a task pre-grounded with `rationale`
+  (why), `success_when` (target), `scope_out` (constraints). The worker packet inherits
+  product intent, not just code structure.
+- **Review** (Product Reviewer) — judges the diff against `success_when` (completeness),
+  `scope_out` / `NOT_THIS` (drift, value/overbuilt), `priority` (right-thing-now).
+- **Assign next** — unmet `success_when` + `next`-priority goals are the suggestions.
+- A run's `plan.acceptance_criteria` is the **child** of a goal's `success_when`:
+  intent flows down to a run; evidence flows back up to the CEO.
+
+**Four Product Reviewer lenses grounded by v1:** goal-alignment ✅, prioritization ✅,
+value/overbuilt ✅, completeness ⚠️ (judged at goal level + per-loop criteria; sharper
+once features exist).
+
+## Explicitly deferred / out of scope
+
+- **Feature layer** (goals → features → done_when) and **cross-loop feature tracking**
+  ("F1 is 2 of 3 runs done") — clean post-event v2.
+- **Token economics** — out of scope entirely (dropped, not deferred).
+- **Safe self-mutation** of the harness (paper §5.2.3) — evolution.py only *proposes*;
+  applying changes with regression-guards is the moonshot frontier.
+
+## Why this is the code-as-harness line
+
+Two owned deterministic graphs (code + intent) with a governed loop between them is the
+paper's serious-harness rubric drawn at three layers: **Executable** (real diffs/tests),
+**Inspectable** (both graphs + evidence trail), **Stateful** (intent graph + run history
++ memory), **Governed** (CEO intent + AgentOps guards). The moat is not one model — it
+is the two graphs and the governed loop, local and owned.

--- a/tests/helpers_runrecord.py
+++ b/tests/helpers_runrecord.py
@@ -1,0 +1,36 @@
+from datetime import UTC, datetime
+
+from app.core.repo_graph.models import RepoGraph
+from app.schemas.memory import MemoryReport
+from app.schemas.plan import ImplementationPlan, PlanStep
+from app.schemas.repo import RepoProfile
+from app.schemas.report import FinalReport
+from app.schemas.review import ReviewReport
+from app.schemas.risk import RiskReport
+from app.schemas.run import RunRecord
+from app.schemas.test import TestRunSummary
+
+
+def minimal_run_record() -> RunRecord:
+    return RunRecord(
+        run_id="testrun",
+        task="t",
+        repo_path=".",
+        repo_profile=RepoProfile(repo_path="."),
+        repo_graph=RepoGraph(repo_path="."),
+        memory_report=MemoryReport(),
+        plan=ImplementationPlan(
+            task="t",
+            summary="s",
+            steps=[PlanStep(id=1, title="a", description="d")],
+            acceptance_criteria=["ok"],
+            tests_to_run=["python -m pytest -q"],
+        ),
+        test_results=TestRunSummary(commands=[]),
+        review_report=ReviewReport(summary="s", findings=[]),
+        risk_report=RiskReport(risk_score=0, risk_level="low", factors=[]),
+        final_report=FinalReport(title="t", markdown="# t"),
+        status="completed",
+        started_at=datetime.now(UTC),
+        completed_at=datetime.now(UTC),
+    )

--- a/tests/test_dogfood_goal_model.py
+++ b/tests/test_dogfood_goal_model.py
@@ -1,0 +1,12 @@
+from pathlib import Path
+
+from app.core.goal_model import load_goal_model
+
+
+def test_repo_ships_a_valid_goal_model():
+    model = load_goal_model(Path("."))
+    assert model is not None, "agentops.goals.yaml must exist at repo root"
+    assert model.north_star
+    assert len(model.goals) >= 1
+    for goal in model.goals:
+        assert goal.success_when, f"{goal.id} must list discrete success_when signals"

--- a/tests/test_edit_mode_attribution.py
+++ b/tests/test_edit_mode_attribution.py
@@ -1,0 +1,58 @@
+"""Track-1 hardening: prove edit-mode attribution end-to-end.
+
+Edit mode requires a clean git repo so every changed file is attributable to the
+worker command. This drives a real worker command against a fresh git repo and
+asserts the file it created shows up as a changed file on the run record.
+"""
+
+import subprocess
+from pathlib import Path
+
+from app.core.graph import run_harness
+
+
+def _init_repo(path: Path) -> None:
+    path.mkdir(parents=True, exist_ok=True)
+    subprocess.run(["git", "init", "-q"], cwd=path, check=True)
+    subprocess.run(["git", "config", "user.email", "t@t.test"], cwd=path, check=True)
+    subprocess.run(["git", "config", "user.name", "t"], cwd=path, check=True)
+    (path / "app.py").write_text("def f():\n    return 1\n")
+    subprocess.run(["git", "add", "-A"], cwd=path, check=True)
+    subprocess.run(["git", "commit", "-q", "-m", "init"], cwd=path, check=True)
+
+
+def test_edit_mode_attributes_worker_created_file(tmp_path: Path):
+    repo = tmp_path / "clean_repo"
+    _init_repo(repo)
+    # Sanity: the repo starts clean, so any change is the worker's.
+    assert subprocess.run(
+        ["git", "status", "--porcelain"], cwd=repo, capture_output=True, text=True
+    ).stdout.strip() == ""
+
+    record = run_harness(
+        repo_path=repo,
+        task="add a healthz module",
+        storage_path=tmp_path / "runs.db",
+        worker_command="bash -c 'echo \"def healthz(): return 200\" > healthz.py'",
+    )
+
+    assert record.edit_result is not None
+    assert record.edit_result.status == "completed"
+    assert "healthz.py" in record.changed_files
+
+
+def test_edit_mode_blocks_on_dirty_repo(tmp_path: Path):
+    repo = tmp_path / "dirty_repo"
+    _init_repo(repo)
+    (repo / "app.py").write_text("def f():\n    return 2\n")  # pre-existing dirt
+
+    record = run_harness(
+        repo_path=repo,
+        task="add a healthz module",
+        storage_path=tmp_path / "runs.db",
+        worker_command="bash -c 'echo x > healthz.py'",
+    )
+
+    # The worker must be blocked so changes are not misattributed.
+    assert record.edit_result is not None
+    assert record.edit_result.status == "blocked"

--- a/tests/test_goal_model_loader.py
+++ b/tests/test_goal_model_loader.py
@@ -1,0 +1,39 @@
+from pathlib import Path
+
+import pytest
+
+from app.core.goal_model import GoalModelError, load_goal_model
+
+GOALS_YAML = """\
+north_star: A local control harness for coding agents.
+not_this:
+  - A hosted SaaS that holds your code.
+constraints:
+  - Local-first
+goals:
+  - id: G1
+    statement: Ground every worker in deterministic repo structure.
+    rationale: Cuts blind exploration.
+    priority: now
+    success_when:
+      - repo graph built without an LLM call
+    scope_out:
+      - model fine-tuning
+"""
+
+
+def test_loads_goal_model_from_repo_root(tmp_path: Path):
+    (tmp_path / "agentops.goals.yaml").write_text(GOALS_YAML)
+    model = load_goal_model(tmp_path)
+    assert model is not None
+    assert model.goal("G1").priority == "now"
+
+
+def test_absent_file_returns_none(tmp_path: Path):
+    assert load_goal_model(tmp_path) is None
+
+
+def test_malformed_file_raises_goal_model_error(tmp_path: Path):
+    (tmp_path / "agentops.goals.yaml").write_text("north_star: [unterminated\n")
+    with pytest.raises(GoalModelError):
+        load_goal_model(tmp_path)

--- a/tests/test_goal_model_schema.py
+++ b/tests/test_goal_model_schema.py
@@ -1,0 +1,43 @@
+import pytest
+from pydantic import ValidationError
+
+from app.schemas.goal_model import Goal, ProductGoalModel
+
+
+def sample_model() -> ProductGoalModel:
+    return ProductGoalModel(
+        north_star="A local control harness for coding agents.",
+        not_this=["A hosted SaaS that holds your code."],
+        constraints=["Local-first", "No OpenAI SDK"],
+        goals=[
+            Goal(
+                id="G1",
+                statement="Ground every worker in deterministic repo structure.",
+                rationale="Cuts blind exploration.",
+                priority="now",
+                success_when=[
+                    "repo graph built without an LLM call",
+                    "worker packet includes impacted subgraph",
+                ],
+                scope_out=["model fine-tuning"],
+            )
+        ],
+    )
+
+
+def test_goal_lookup_returns_goal_by_id():
+    model = sample_model()
+    assert model.goal("G1").statement.startswith("Ground every worker")
+    assert model.goal("G404") is None
+
+
+def test_invalid_priority_is_rejected():
+    with pytest.raises(ValidationError):
+        Goal(
+            id="G2",
+            statement="x",
+            rationale="y",
+            priority="someday",  # not in now|next|later
+            success_when=["z"],
+            scope_out=[],
+        )

--- a/tests/test_langgraph_workflow.py
+++ b/tests/test_langgraph_workflow.py
@@ -21,6 +21,7 @@ def test_langgraph_run_records_node_trace(tmp_path: Path) -> None:
     assert record.execution_logs == [
         "scan_repo:start",
         "repo_graph:complete",
+        "goal_model:absent",
         "scan_repo:complete",
         "recall_experience:start",
         "recall_experience:miss",
@@ -44,6 +45,8 @@ def test_langgraph_run_records_node_trace(tmp_path: Path) -> None:
         "check_report_quality:complete",
         "check_evidence:start",
         "check_evidence:complete",
+        "build_product_review:start",
+        "build_product_review:complete",
         "assemble_verification:start",
         "assemble_verification:complete",
         "audit_conflicts:start",

--- a/tests/test_plan_contract_validation.py
+++ b/tests/test_plan_contract_validation.py
@@ -1,0 +1,54 @@
+"""Finding A: the executor must honor the plan's tests_to_run contract.
+
+The planner is graph-aware and may select `uv run pytest -q` for a uv project,
+but if the test runner ignores that and hardcodes `python -m pytest -q`, the
+plan-as-contract thesis (paper Section 3.4.2) is broken at the executor.
+"""
+
+from pathlib import Path
+
+from app.core.graph import run_tests_node
+from app.schemas.plan import ImplementationPlan, PlanStep
+
+
+def make_plan(tests_to_run: list[str]) -> ImplementationPlan:
+    return ImplementationPlan(
+        task="demo",
+        summary="demo plan",
+        steps=[PlanStep(id=1, title="step", description="d")],
+        acceptance_criteria=["ok"],
+        tests_to_run=tests_to_run,
+    )
+
+
+def write_passing_test(repo: Path) -> None:
+    (repo / "test_contract.py").write_text("def test_ok():\n    assert True\n")
+
+
+def test_run_tests_node_executes_plan_tests_to_run(tmp_path: Path) -> None:
+    write_passing_test(tmp_path)
+    state = {
+        "repo_path": tmp_path,
+        "plan": make_plan(["python -m pytest -q -k test_ok"]),
+        "execution_logs": [],
+    }
+
+    result = run_tests_node(state)
+
+    executed = [c.command for c in result["test_results"].commands]
+    assert executed == ["python -m pytest -q -k test_ok"]
+
+
+def test_explicit_test_commands_override_plan(tmp_path: Path) -> None:
+    write_passing_test(tmp_path)
+    state = {
+        "repo_path": tmp_path,
+        "plan": make_plan(["python -m pytest -q -k never_runs"]),
+        "test_commands": ["python -m pytest -q -k test_ok"],
+        "execution_logs": [],
+    }
+
+    result = run_tests_node(state)
+
+    executed = [c.command for c in result["test_results"].commands]
+    assert executed == ["python -m pytest -q -k test_ok"]

--- a/tests/test_product_review_persistence.py
+++ b/tests/test_product_review_persistence.py
@@ -1,0 +1,28 @@
+import json
+from pathlib import Path
+
+from app.core.run_artifacts import RunArtifactWriter
+from app.schemas.run import RunRecord
+
+
+def test_run_record_has_product_review_default():
+    fields = RunRecord.model_fields
+    assert "product_review" in fields
+
+
+def test_artifact_writer_writes_product_review_json(tmp_path: Path, monkeypatch):
+    # Build a minimal record via the existing test helper pattern is heavy; assert the
+    # writer emits product_review.json when given a record that has the field.
+    from app.schemas.product_review import ProductReview
+    record = _minimal_run_record()
+    record.product_review = ProductReview(overall_verdict="aligned", summary="ok")
+    artifact_dir = RunArtifactWriter().write(record, tmp_path / "runs.db")
+    payload = json.loads((artifact_dir / "product_review.json").read_text())
+    assert payload["overall_verdict"] == "aligned"
+
+
+def _minimal_run_record() -> RunRecord:
+    # Reuse the project's existing minimal-record factory if present; otherwise import
+    # from an existing test helper. Implemented inline here against current RunRecord.
+    from tests.helpers_runrecord import minimal_run_record  # see Step 3
+    return minimal_run_record()

--- a/tests/test_product_review_pipeline.py
+++ b/tests/test_product_review_pipeline.py
@@ -1,0 +1,65 @@
+from pathlib import Path
+
+from app.core.graph import run_harness
+
+GOALS = """\
+north_star: Local control harness.
+goals:
+  - id: G1
+    statement: Ground worker runs.
+    priority: now
+    success_when:
+      - healthz endpoint added
+    scope_out: []
+"""
+
+
+def test_run_harness_attaches_product_review_and_section(tmp_path: Path):
+    repo = tmp_path / "repo"
+    (repo).mkdir()
+    (repo / "agentops.goals.yaml").write_text(GOALS)
+    (repo / "main.py").write_text("def f():\n    return 1\n")
+
+    record = run_harness(
+        repo_path=repo, task="Add healthz endpoint",
+        storage_path=tmp_path / "runs.db", target_goal_id="G1",
+    )
+
+    assert record.product_review.overall_verdict != "not_evaluated"
+    assert "## Product Review" in record.final_report.markdown
+
+
+def test_run_harness_without_goal_file_is_not_evaluated(tmp_path: Path):
+    repo = tmp_path / "repo2"
+    repo.mkdir()
+    (repo / "main.py").write_text("def f():\n    return 1\n")
+    record = run_harness(repo_path=repo, task="x", storage_path=tmp_path / "runs.db")
+    assert record.product_review.overall_verdict == "not_evaluated"
+
+
+class _RaisingLLM:
+    """An LLM client whose product-review structured call always fails."""
+
+    def generate_structured(self, prompt: str, schema: type) -> object:
+        raise RuntimeError("provider unavailable")
+
+    def generate_text(self, prompt: str) -> str:
+        raise RuntimeError("provider unavailable")
+
+
+def test_product_review_llm_failure_logs_provider_fallback(tmp_path: Path):
+    repo = tmp_path / "repo3"
+    repo.mkdir()
+    (repo / "agentops.goals.yaml").write_text(GOALS)
+    (repo / "main.py").write_text("def f():\n    return 1\n")
+
+    record = run_harness(
+        repo_path=repo, task="Add healthz endpoint",
+        storage_path=tmp_path / "runs.db", target_goal_id="G1",
+        llm_client=_RaisingLLM(),
+    )
+
+    # The run still completes with a valid deterministic review, and the fallback
+    # is recorded (not silently swallowed).
+    assert record.product_review.overall_verdict != "not_evaluated"
+    assert "provider_fallback:build_product_review" in record.execution_logs

--- a/tests/test_product_review_schema.py
+++ b/tests/test_product_review_schema.py
@@ -1,0 +1,21 @@
+from app.schemas.product_review import ProductFinding, ProductReview
+
+
+def test_finding_carries_cited_claim_contract():
+    finding = ProductFinding(
+        lens="goal_alignment",
+        verdict="concern",
+        observation="Changed files fall outside the planned set.",
+        source_of_truth="plan.files_to_edit",
+        citation="RunRecord.plan",
+        confidence="medium",
+        recommendation="Confirm the extra files serve G1.",
+    )
+    assert finding.lens == "goal_alignment"
+    assert finding.citation
+
+
+def test_review_defaults_suggested_next_to_empty():
+    review = ProductReview(overall_verdict="aligned", summary="ok")
+    assert review.suggested_next == []
+    assert review.findings == []

--- a/tests/test_product_reviewer.py
+++ b/tests/test_product_reviewer.py
@@ -1,0 +1,89 @@
+from app.agents.product_reviewer import ProductReviewer
+from app.schemas.goal_model import Goal, ProductGoalModel
+from app.schemas.plan import ImplementationPlan, PlanStep
+from app.schemas.test import CommandResult, TestRunSummary
+
+
+def model() -> ProductGoalModel:
+    return ProductGoalModel(
+        north_star="Local control harness.",
+        not_this=["hosted saas"],
+        goals=[
+            Goal(
+                id="G1",
+                statement="Ground worker runs.",
+                priority="now",
+                success_when=["healthz endpoint added", "test added"],
+                scope_out=["billing"],
+            ),
+            Goal(id="G2", statement="Later thing.", priority="later", success_when=["x"]),
+        ],
+    )
+
+
+def plan(files_to_edit: list[str]) -> ImplementationPlan:
+    return ImplementationPlan(
+        task="t",
+        summary="s",
+        steps=[PlanStep(id=1, title="x", description="d", files_to_edit=files_to_edit)],
+        acceptance_criteria=["ok"],
+        tests_to_run=["python -m pytest -q"],
+    )
+
+
+def make_test_results(passed: bool) -> TestRunSummary:
+    return TestRunSummary(
+        commands=[CommandResult(command="python -m pytest -q", exit_code=0 if passed else 1,
+                                duration_seconds=0.1, stdout="", stderr="")]
+    )
+
+
+def test_no_goal_model_returns_not_evaluated():
+    review = ProductReviewer().review(
+        task="t", plan=plan(["app/main.py"]), changed_files=["app/main.py"],
+        diff_summary="", changed_subgraph=None, test_results=make_test_results(True),
+        goal_model=None, target_goal_id=None,
+    )
+    assert review.overall_verdict == "not_evaluated"
+    assert all(f.verdict == "not_evaluated" for f in review.findings)
+    assert all(f.citation for f in review.findings)
+
+
+def test_scope_out_touch_flags_drift():
+    review = ProductReviewer().review(
+        task="add billing hook", plan=plan(["app/billing.py"]),
+        changed_files=["app/billing.py"], diff_summary="", changed_subgraph=None,
+        test_results=make_test_results(True), goal_model=model(), target_goal_id="G1",
+    )
+    assert review.overall_verdict == "drifted"
+    assert any(f.lens == "goal_alignment" and f.verdict == "fail" for f in review.findings)
+
+
+def test_unmet_success_signal_flags_incomplete():
+    review = ProductReviewer().review(
+        task="add healthz", plan=plan(["app/main.py"]), changed_files=["app/main.py"],
+        diff_summary="added healthz endpoint", changed_subgraph=None,
+        test_results=make_test_results(True), goal_model=model(), target_goal_id="G1",
+    )
+    # "test added" signal is unmet (no tests/ file changed) -> completeness concern
+    assert any(f.lens == "completeness" and f.verdict == "concern" for f in review.findings)
+    assert review.overall_verdict in {"incomplete", "drifted", "overbuilt", "unclear"}
+
+
+def test_every_finding_is_cited():
+    review = ProductReviewer().review(
+        task="t", plan=plan(["app/main.py"]), changed_files=["app/main.py", "tests/test_x.py"],
+        diff_summary="healthz endpoint added; test added", changed_subgraph=None,
+        test_results=make_test_results(True), goal_model=model(), target_goal_id="G1",
+    )
+    assert review.findings
+    assert all(f.citation for f in review.findings)
+
+
+def test_later_goal_while_now_open_flags_prioritization():
+    review = ProductReviewer().review(
+        task="t", plan=plan(["app/main.py"]), changed_files=["app/main.py"],
+        diff_summary="x", changed_subgraph=None, test_results=make_test_results(True),
+        goal_model=model(), target_goal_id="G2",
+    )
+    assert any(f.lens == "prioritization" and f.verdict == "concern" for f in review.findings)

--- a/tests/test_product_reviewer_report.py
+++ b/tests/test_product_reviewer_report.py
@@ -1,0 +1,33 @@
+from app.agents.product_reviewer import ProductReviewer
+from app.prompts.product_reviewer import build_product_reviewer_prompt
+from app.schemas.goal_model import Goal, ProductGoalModel
+from app.schemas.plan import ImplementationPlan, PlanStep
+from app.schemas.product_review import ProductFinding, ProductReview
+from app.schemas.report import FinalReport
+
+
+def test_prompt_includes_grounding_rules():
+    model = ProductGoalModel(north_star="x", goals=[Goal(id="G1", statement="s")])
+    plan = ImplementationPlan(task="t", summary="s",
+                              steps=[PlanStep(id=1, title="a", description="d")],
+                              acceptance_criteria=["ok"], tests_to_run=["python -m pytest -q"])
+    prompt = build_product_reviewer_prompt(
+        task="t", plan=plan, changed_files=["app/main.py"], diff_summary="",
+        goal_model=model, target_goal_id="G1",
+    )
+    assert "Grounding rules" in prompt
+    assert "every finding must cite" in prompt.lower()
+    assert "not_evaluated" in prompt
+
+
+def test_append_to_report_adds_section():
+    review = ProductReview(
+        overall_verdict="drifted", summary="goal_alignment: fail",
+        findings=[ProductFinding(lens="goal_alignment", verdict="fail",
+                                 observation="touched billing", citation="agentops.goals.yaml#G1")],
+    )
+    report = FinalReport(title="t", markdown="# Report\n\nbody")
+    out = ProductReviewer().append_to_report(report, review)
+    assert "## Product Review" in out.markdown
+    assert "drifted" in out.markdown
+    assert "agentops.goals.yaml#G1" in out.markdown

--- a/tests/test_test_runner_timeout.py
+++ b/tests/test_test_runner_timeout.py
@@ -1,0 +1,40 @@
+"""Finding E: a command that exceeds its timeout must be recorded as a failed
+command, not crash the run.
+
+Surfaced by a real run: `uv run pytest` on a cold uv project exceeded the
+timeout, and the unhandled subprocess.TimeoutExpired killed the whole harness
+run before any evidence was persisted — the opposite of the harness's promise
+that a misbehaving step still yields usable evidence.
+"""
+
+from pathlib import Path
+
+from app.core.test_runner import TestRunner
+
+
+def test_timeout_is_recorded_as_failed_command_not_raised(tmp_path: Path) -> None:
+    summary = TestRunner().run(
+        tmp_path,
+        commands=['python -c "import time; time.sleep(5)"'],
+        timeout_seconds=1,
+    )
+
+    assert summary.passed is False
+    result = summary.commands[0]
+    assert result.exit_code != 0
+    assert "timed out" in result.stderr.lower()
+
+
+def test_timeout_does_not_block_subsequent_commands(tmp_path: Path) -> None:
+    summary = TestRunner().run(
+        tmp_path,
+        commands=[
+            'python -c "import time; time.sleep(5)"',
+            'python -c "print(\'ok\')"',
+        ],
+        timeout_seconds=1,
+    )
+
+    assert len(summary.commands) == 2
+    assert summary.commands[0].exit_code != 0
+    assert summary.commands[1].exit_code == 0


### PR DESCRIPTION
## Summary

Builds the missing **CEO layer** of the three-layer harness (CEO / AgentOps / Worker), grounded in `docs/THREE_LAYER_FOUNDATION.md`, plus harness robustness hardening. The harness can now judge whether a run served *product intent*, not just whether the code is correct.

This PR contains three commits:
1. **Findings A + E** — honor plan-as-contract (`run_tests` uses the planner's commands); a timed-out command is recorded (exit 124), not crashed on.
2. **CEO-layer v1** — intent graph + Product Reviewer (below).
3. **Track-1 hardening** — folded into the CEO-layer commit.

### CEO layer v1
- **Intent graph**: `ProductGoalModel`/`Goal` schema + a CEO-authored `agentops.goals.yaml` (dogfooded for this repo) + a graceful loader (absent → inactive; malformed → logged; never crashes).
- **Product Reviewer**: an advisory agent judging each run against the intent graph across four **evidence-cited** lenses (goal_alignment, completeness, value, prioritization), mirroring the `EvidenceFinding` cited-claim contract. Node between `check_evidence` and `assemble_verification`; appends a `## Product Review` section; writes `product_review.json`; degrades to `not_evaluated` (never bluffs); `suggested_next` is a deferred stub.
- `--goal <id>` targeting on both `run` and `edit`; `provider_fallback` logging on LLM failure.

### Harness hardening (Track-1)
- `TestRunner` kills the whole **process group** on timeout (no leaked uv/pytest orphans); default test timeout 120s → 300s, configurable.
- **Edit-mode attribution** proven by test (worker file attributed; dirty repo blocked).

## Process
brainstorming → spec → plan → subagent-driven implementation (3 units) → holistic code review (5 issues found & fixed) → Track-1 hardening.

## Validation
- `uv run --extra dev python -m pytest -q` → **179 passed**
- `uv run --extra dev ruff check .` → all checks passed
- Self-dogfood run → verdict `incomplete` with cited per-lens findings vs goal G3 (correctly flagged building a `next`-priority goal while `now`-goals are open).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR builds the CEO-layer of the three-layer harness: an intent graph (`agentops.goals.yaml` + Pydantic schemas) and a `ProductReviewer` that judges each run against product goals across four evidence-cited lenses, plus harness hardening (process-group kill on test timeout, plan-as-contract enforcement for test commands).

- **CEO layer**: `ProductGoalModel`/`Goal` schemas, graceful `load_goal_model` loader (absent → inactive, malformed → logged), `ProductReviewer` with deterministic and LLM paths, new `build_product_review` graph node inserted between `check_evidence` and `assemble_verification`, `product_review.json` artifact output, and `--goal` CLI flag on both `run` and `edit`.
- **Harness hardening**: `TestRunner` now uses `subprocess.Popen` + `start_new_session=True` to kill the whole process group on timeout; timed-out commands are recorded with exit code 124 instead of crashing the run; default timeout raised from 120s to 300s.
- **Two defects to fix before merging**: the `prioritization` lens is excluded from `_overall`'s `all_pass` check (a priority concern returns `"aligned"`), and `classify_permissions_node` still reads only `test_commands`, leaving plan-driven commands unclassified by `PermissionGate`.

<h3>Confidence Score: 3/5</h3>

Two real defects need to be fixed before merging: the `prioritization` concern from the CEO layer's own reviewer produces the wrong top-line verdict, and `PermissionGate` never sees plan-driven test commands.

The `_overall` method in `ProductReviewer` excludes the `prioritization` lens from the `all_pass` check — the exact scenario the CEO layer is designed to catch (working a non-`now`-priority goal while `now`-goals are open) returns `"aligned"` instead of signaling a concern. Separately, `classify_permissions_node` reads only `state.get("test_commands")`, so the plan-as-contract test commands that `run_tests_node` now executes are never classified by `PermissionGate`. Both bugs are on code paths exercised on every run with a goal model present.

app/agents/product_reviewer.py (`_overall` missing `prioritization` in `all_pass`) and app/core/graph.py (`classify_permissions_node` not using `plan.tests_to_run`).

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| app/agents/product_reviewer.py | New ProductReviewer agent: deterministic logic has two issues — `prioritization` concern is excluded from `_overall`'s `all_pass` check (wrong top-line verdict), and multi-word `not_this` entries never match file paths in the scope-out check. |
| app/core/graph.py | Adds CEO-layer nodes and plan-as-contract fix; `classify_permissions_node` still reads only `test_commands`, so plan-driven test commands bypass PermissionGate. |
| app/core/test_runner.py | Replaces `subprocess.run` with `Popen` + process-group kill on timeout; timeout is now recorded as exit 124, not raised; default increased to 300s. |
| app/core/goal_model.py | New `load_goal_model` loader: absent file returns `None`, malformed YAML/schema raises `GoalModelError`; clean and safe. |
| app/schemas/product_review.py | New `ProductFinding`/`ProductReview` schemas with strict literal types; `suggested_next` deferred stub is clearly annotated. |
| app/cli.py | Adds `--goal` option to both `run` and `edit` CLI commands and forwards `target_goal_id` to `run_harness`. |

</details>


</details>


<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant CLI
    participant scan_repo
    participant create_plan
    participant run_tests
    participant check_evidence
    participant build_product_review
    participant assemble_verification

    CLI->>scan_repo: repo_path, target_goal_id
    scan_repo->>scan_repo: load_goal_model() → goal_model or None
    scan_repo-->>create_plan: repo_profile, repo_graph, goal_model
    create_plan-->>run_tests: plan (tests_to_run)
    note over run_tests: commands = test_commands OR plan.tests_to_run OR ["python -m pytest -q"]
    run_tests-->>check_evidence: test_results
    check_evidence-->>build_product_review: final_report, evidence_report
    note over build_product_review: ProductReviewer.review()<br/>deterministic OR LLM path<br/>fallback logs provider_fallback
    build_product_review-->>assemble_verification: product_review, updated final_report
    assemble_verification-->>CLI: RunRecord (with product_review.json artifact)
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `app/core/graph.py`, line 234 ([link](https://github.com/ven-z8/agentops-harness/blob/72dc993c548c99832e0c8978fa8fdb3e155d3f42/app/core/graph.py#L234)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> `classify_permissions_node` still reads only `test_commands` (the override), so commands coming from `plan.tests_to_run` — which `run_tests_node` now executes when `test_commands` is absent — are never classified by `PermissionGate`. The gate sees an empty list in the common case where the planner's commands are used, effectively bypassing permission classification for every plan-driven run.

   

   <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20app%2Fcore%2Fgraph.py%0ALine%3A%20234%0A%0AComment%3A%0A%60classify_permissions_node%60%20still%20reads%20only%20%60test_commands%60%20%28the%20override%29%2C%20so%20commands%20coming%20from%20%60plan.tests_to_run%60%20%E2%80%94%20which%20%60run_tests_node%60%20now%20executes%20when%20%60test_commands%60%20is%20absent%20%E2%80%94%20are%20never%20classified%20by%20%60PermissionGate%60.%20The%20gate%20sees%20an%20empty%20list%20in%20the%20common%20case%20where%20the%20planner's%20commands%20are%20used%2C%20effectively%20bypassing%20permission%20classification%20for%20every%20plan-driven%20run.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20commands%3D%28state.get%28%22test_commands%22%29%20or%20state%5B%22plan%22%5D.tests_to_run%20or%20%5B%5D%29%2C%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=8&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3" height="20"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%204%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%204%0Aapp%2Fagents%2Fproduct_reviewer.py%3A203-217%0A**%60prioritization%60%20concern%20is%20silently%20ignored%20in%20%60_overall%60**%0A%0A%60_overall%60%20checks%20only%20three%20lenses%20%28%60goal_alignment%60%2C%20%60completeness%60%2C%20%60value%60%29%20in%20its%20%60all_pass%60%20guard%2C%20so%20when%20%60prioritization%3D%22concern%22%60%20%28i.e.%20working%20a%20non-%60now%60%20goal%20while%20%60now%60-goals%20are%20open%29%20but%20the%20other%20three%20lenses%20all%20pass%2C%20the%20method%20returns%20%60%22aligned%22%60.%20This%20is%20the%20exact%20scenario%20the%20CEO%20layer%20exists%20to%20catch%20%E2%80%94%20the%20self-dogfood%20case%20flags%20the%20correct%20prioritization%20concern%20at%20the%20lens%20level%2C%20but%20the%20top-line%20verdict%20is%20wrong%20and%20a%20CEO%20scanning%20only%20%60overall_verdict%60%20would%20miss%20it%20entirely.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20if%20by.get%28%22prioritization%22%29%20%3D%3D%20%22concern%22%3A%0A%20%20%20%20%20%20%20%20%20%20%20%20return%20%22unclear%22%0A%20%20%20%20%20%20%20%20all_pass%20%3D%20all%28%0A%20%20%20%20%20%20%20%20%20%20%20%20by.get%28lens%29%20in%20%7B%22pass%22%7D%0A%20%20%20%20%20%20%20%20%20%20%20%20for%20lens%20in%20%28%22goal_alignment%22%2C%20%22completeness%22%2C%20%22value%22%2C%20%22prioritization%22%29%0A%20%20%20%20%20%20%20%20%29%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%204%0Aapp%2Fagents%2Fproduct_reviewer.py%3A99-109%0A**%60not_this%60%20multi-word%20sentences%20never%20match%20file%20paths**%0A%0A%60scope_terms%60%20is%20built%20by%20appending%20the%20entire%20%60not_this%60%20list%20%28e.g.%20%60%22A%20hosted%20SaaS%20that%20stores%20your%20code%20or%20run%20history%20off%20your%20machine.%22%60%29%20to%20the%20%60scope_out%60%20terms%2C%20then%20matched%20against%20the%20space-joined%20lowercase%20file%20paths%20via%20a%20word-boundary%20regex.%20Multi-word%20phrases%20with%20internal%20spaces%20cannot%20match%20a%20path%20like%20%60app%2Fsaas_storage.py%60%20%E2%80%94%20the%20regex%20literal%20contains%20spaces%20that%20paths%20don't.%20The%20same%20problem%20applies%20to%20multi-word%20%60scope_out%60%20entries%20such%20as%20%60%22Model%20fine-tuning%20or%20training.%22%60%20in%20the%20repo's%20own%20%60agentops.goals.yaml%60.%20The%20%60not_this%60%20check%20in%20the%20deterministic%20path%20is%20therefore%20dead%20code%20in%20practice.%0A%0A%23%23%23%20Issue%203%20of%204%0Aapp%2Fcore%2Fgraph.py%3A234%0A%60classify_permissions_node%60%20still%20reads%20only%20%60test_commands%60%20%28the%20override%29%2C%20so%20commands%20coming%20from%20%60plan.tests_to_run%60%20%E2%80%94%20which%20%60run_tests_node%60%20now%20executes%20when%20%60test_commands%60%20is%20absent%20%E2%80%94%20are%20never%20classified%20by%20%60PermissionGate%60.%20The%20gate%20sees%20an%20empty%20list%20in%20the%20common%20case%20where%20the%20planner's%20commands%20are%20used%2C%20effectively%20bypassing%20permission%20classification%20for%20every%20plan-driven%20run.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20commands%3D%28state.get%28%22test_commands%22%29%20or%20state%5B%22plan%22%5D.tests_to_run%20or%20%5B%5D%29%2C%0A%60%60%60%0A%0A%23%23%23%20Issue%204%20of%204%0Aapp%2Fcore%2Fgraph.py%3A343-347%0AThe%20bare%20%60except%20Exception%3A%60%20in%20%60build_product_review_node%60%20swallows%20every%20exception%20including%20%60KeyError%60%2F%60AttributeError%60%2F%60TypeError%60%20that%20would%20indicate%20programming%20errors%20in%20the%20reviewer%20itself.%20Consider%20narrowing%20the%20catch%20to%20LLM-specific%20exception%20types%20to%20avoid%20silently%20hiding%20bugs.%0A%0A%60%60%60suggestion%0A%20%20%20%20try%3A%0A%20%20%20%20%20%20%20%20review%20%3D%20reviewer.review%28**kwargs%29%0A%20%20%20%20except%20Exception%20as%20exc%3A%0A%20%20%20%20%20%20%20%20if%20type%28exc%29.__name__%20in%20%28%22KeyError%22%2C%20%22AttributeError%22%2C%20%22TypeError%22%29%3A%0A%20%20%20%20%20%20%20%20%20%20%20%20raise%0A%20%20%20%20%20%20%20%20review%20%3D%20ProductReviewer%28%29.review%28**kwargs%29%0A%20%20%20%20%20%20%20%20logs.append%28%22provider_fallback%3Abuild_product_review%22%29%0A%60%60%60%0A%0A&pr=8&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<sub>Reviews (2): Last reviewed commit: ["feat: CEO-layer v1 (intent graph + produ..."](https://github.com/ven-z8/agentops-harness/commit/72dc993c548c99832e0c8978fa8fdb3e155d3f42) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36879113)</sub>

<!-- /greptile_comment -->