### PR TITLE
feat: OpenHands SDK worker (W4) + README refresh (governance loop, 4 workers)

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,17 +26,18 @@ The inner box above is the **worker harness** — the well-understood anatomy ev
 
 ![The worker harness: the agent loop and the machinery around it](docs/assets/worker-harness-anatomy.png)
 
-**AgentOps does not run this loop.** It does not iterate a model 50–200 times, and it does not edit files — that is the worker's job, invoked inside one node (`run_external_worker`). AgentOps is the layer *above*: it hands the worker a grounded contract, then **governs** what comes back. Concretely:
+**AgentOps does not run the worker's tight inner loop** — it does not iterate a model 50–200 times, and it does not edit files. That is the worker's job, invoked inside one node (`run_external_worker`). AgentOps is the layer *above*: it hands the worker a grounded contract, then **governs** what comes back — including its *own* bounded outer loop (plan → worker → enforce → validate → retry). Concretely:
 
 | Worker-harness part | Who owns it |
 |---|---|
-| The agent loop (prompt → model → edit → test, 50–200×) | **Worker** (Claude Code / Codex / OpenHands) |
+| The agent loop (prompt → model → edit → test, 50–200×) | **Worker** (Claude Code / Codex / OpenHands / OpenCode) |
 | Execution engine (editing files, calling tools) | **Worker** |
 | Feedback ingestion (tests, diffs, logs, errors) | **AgentOps** |
+| Governance — enforce at dispatch (block / revert / sandbox), bounded retry loop | **AgentOps** |
 | Control (permissions, plan-as-contract, timeouts) | **AgentOps** |
 | System/state (repo graph, experiential memory, run history) | **AgentOps** (partial) |
 
-That boundary *is* the product: AgentOps governs the loop instead of reimplementing it.
+That boundary *is* the product: AgentOps governs the loop instead of reimplementing it — it blocks denied edits, reverts what slips through, can run the worker fully sandboxed, and retries on failed validation.
 
 ## Quickstart (no API key — mock provider by default)
 
@@ -93,15 +94,20 @@ flowchart LR
   T[Task + Repo + Goal] --> S[Repo Scanner]
   S --> M[Experience Recall]
   M --> P[Planner]
-  P --> W[Optional External Worker]
+  P --> PW[Prepare Workspace]
+  PW --> GATE[Pre-dispatch Gate]
+  GATE --> W[External Worker]
   W --> D[Diff Collector]
-  D --> CS[Changed Subgraph]
-  CS --> R[Test Runner]
-  R --> V[Reviewer]
+  D --> ENF[Enforce / Revert Denied]
+  ENF --> R[Test Runner]
+  R --> CONV{Converged?}
+  CONV -- retry --> W
+  CONV -- proceed --> CS[Changed Subgraph]
+  CS --> V[Reviewer]
   V --> RG[Risk Guard]
   RG --> PG[Permission Gate]
-  PG --> PR[PR Writer]
-  PR --> QG[Report Quality Guard]
+  PG --> PRw[PR Writer]
+  PRw --> QG[Report Quality Guard]
   QG --> EG[Evidence Guard]
   EG --> PRev[Product Reviewer]
   PRev --> VS[Verification Stack]
@@ -110,10 +116,12 @@ flowchart LR
 ```
 
 ```text
-scan_repo -> recall_experience -> create_plan -> run_external_worker -> collect_diff ->
-build_changed_subgraph -> run_tests -> review_diff -> assess_risk -> classify_permissions ->
-write_report -> check_report_quality -> check_evidence -> build_product_review ->
-assemble_verification -> audit_conflicts
+scan_repo -> recall_experience -> create_plan -> prepare_workspace -> pre_dispatch_gate ->
+run_external_worker -> collect_diff -> enforce_permissions -> run_tests ->
+check_convergence -{retry}-> run_external_worker   (bounded by --max-attempts)
+check_convergence -{proceed}-> build_changed_subgraph -> review_diff -> assess_risk ->
+classify_permissions -> write_report -> check_report_quality -> check_evidence ->
+build_product_review -> assemble_verification -> audit_conflicts
 ```
 
 Every run leaves an inspectable evidence bundle on disk under `.agentops/runs/<run_id>/` — repo graph, plan-as-contract, worker packet, diff, test results, risk/permission/evidence/product-review reports, verification bundle, a replayable trace, and the canonical run record.
@@ -132,7 +140,30 @@ uv run --extra dev agentops edit \
   --worker-command 'cursor-agent --repo {repo_path} --task {task}'
 ```
 
-The target repo must be clean unless `--allow-dirty` is passed, so every changed file is attributable to that worker. Built-in worker types: `--worker-type claude|codex|opencode`.
+The target repo must be clean unless `--allow-dirty` is passed, so every changed file is attributable to that worker. Built-in worker types — all verified end-to-end:
+
+```bash
+--worker-type codex|claude|opencode   # CLI workers (subprocess)
+--worker-type openhands               # a real OpenHands SDK agent loop (uv sync --extra openhands)
+```
+
+The OpenHands worker runs a genuine programmable agent loop (OpenHands SDK 1.28) under the harness — the slide-16 six-step SDK pattern, governed like any other worker.
+
+## Governance: enforced, not just reported
+
+AgentOps doesn't only *audit* the worker — it **enforces**, three ways, and **loops**:
+
+- **Pre-dispatch gate** — if the plan targets a sensitive path (secrets/auth/payment), the worker is **blocked before it runs**.
+- **Revert-on-deny** — a denied change the worker made is **git-reverted** so it never persists (`blocked` = *prevented*, not just labeled).
+- **Sandbox** (`--sandbox`) — the worker runs **inside a throwaway container**; only permitted changes are extracted back. Denied edits **physically never reach your host**.
+- **Bounded retry loop** (`--max-attempts`) — on failed validation the harness re-plans and retries, instead of stopping at one pass.
+
+Run validation in an isolated Docker workspace (no host pollution, fail-fast on a broken env):
+
+```bash
+uv run --extra dev agentops edit --repo /path/to/repo --task "…" \
+  --worker-type codex --workspace docker --sandbox --max-attempts 2
+```
 
 ### Worker packets and workloads
 
@@ -177,7 +208,7 @@ If a provider returns malformed output, the harness falls back to a deterministi
 
 ## Stack
 
-Python · LangGraph · Typer (CLI) · FastAPI (HTTP API) · SQLite + JSONL (run storage) · Pydantic · pytest · MCP stdio server · Anthropic Claude (recommended provider) · OpenRouter (OpenAI-compatible client) · mock provider by default — no paid API key required to run the demo.
+Python 3.12 · LangGraph · Typer (CLI) · FastAPI (HTTP API) · SQLite + JSONL (run storage) · Pydantic · pytest · Docker (isolated workspace / sandbox) · MCP stdio server · OpenHands SDK (optional `openhands` worker) · Anthropic Claude (recommended provider) · OpenRouter (OpenAI-compatible client) · mock provider by default — no paid API key required to run the demo.
 
 ## API
 

--- a/app/cli.py
+++ b/app/cli.py
@@ -139,7 +139,7 @@ def edit(
     ] = None,
     worker_type: Annotated[
         str | None,
-        typer.Option(help="Built-in worker type: claude, codex, or opencode."),
+        typer.Option(help="Built-in worker type: claude, codex, opencode, or openhands."),
     ] = None,
     storage: Annotated[Path, typer.Option(help="Run history JSONL path.")] = settings.run_storage,
     worker_timeout_seconds: Annotated[
@@ -165,7 +165,7 @@ def edit(
     """Run an explicit external worker, then validate and report its diff.
 
     Use --worker-command for arbitrary CLI workers (Cursor, Codex, etc.) or
-    --worker-type claude/codex/opencode to delegate to a built-in CLI worker.
+    --worker-type claude/codex/opencode/openhands to delegate to a built-in worker.
     Use --sandbox to run the worker inside a full-isolation Docker container so
     denied writes never reach the host filesystem.
     """

--- a/app/core/graph.py
+++ b/app/core/graph.py
@@ -38,6 +38,7 @@ from app.core.test_runner import TestRunner
 from app.core.workers.claude_worker import ClaudeCodeWorker
 from app.core.workers.codex_worker import CodexWorker
 from app.core.workers.opencode_worker import OpenCodeWorker
+from app.core.workers.openhands_worker import OpenHandsWorker
 from app.core.workspace.base import Workspace
 from app.core.workspace.docker import DockerWorkspace
 from app.core.workspace.local import LocalWorkspace
@@ -256,6 +257,13 @@ def run_external_worker_node(state: AgentOpsGraphState) -> AgentOpsGraphState:
         )
     elif worker_type == "opencode":
         edit_result = OpenCodeWorker().run(
+            repo_path=state["repo_path"],
+            task=task,
+            timeout_seconds=timeout,
+            allow_dirty=allow_dirty,
+        )
+    elif worker_type == "openhands":
+        edit_result = OpenHandsWorker().run(
             repo_path=state["repo_path"],
             task=task,
             timeout_seconds=timeout,

--- a/app/core/workers/openhands_runner.py
+++ b/app/core/workers/openhands_runner.py
@@ -1,0 +1,63 @@
+"""Subprocess entry point that runs one OpenHands SDK agent loop over a repo.
+
+Kept as a separate process so the heavy `openhands` import is lazy and the run is
+timeout-bounded by the parent worker (the same subprocess pattern the CLI workers use).
+Implements the slide-16 six steps against the real OpenHands SDK 1.28 API:
+LLM -> Agent(tools) -> Conversation(workspace=repo) -> send_message -> run; the harness
+reads the resulting git diff itself (step 6).
+
+Reads the task prompt from stdin (avoids CLI arg-length limits). argv: <repo_path> [model].
+Exit codes: 0 ok · 2 usage · 3 auth missing · 4 sdk not installed · 1 run error.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+DEFAULT_MODEL = "anthropic/claude-sonnet-4-5-20250929"
+
+
+def main() -> int:
+    if len(sys.argv) < 2:
+        print("usage: openhands_runner <repo_path> [model]  (task on stdin)", file=sys.stderr)
+        return 2
+    repo_path = sys.argv[1]
+    model = sys.argv[2] if len(sys.argv) > 2 else os.getenv("OPENHANDS_MODEL", DEFAULT_MODEL)
+    task = sys.stdin.read().strip()
+    if not task:
+        print("usage: task prompt must be provided on stdin", file=sys.stderr)
+        return 2
+
+    api_key = os.getenv("LLM_API_KEY") or os.getenv("ANTHROPIC_API_KEY")
+    if not api_key:
+        print("authentication_error: set ANTHROPIC_API_KEY or LLM_API_KEY", file=sys.stderr)
+        return 3
+
+    try:
+        from openhands.sdk import LLM, Agent, Conversation, Tool
+        from openhands.tools.file_editor import FileEditorTool
+        from openhands.tools.terminal import TerminalTool
+    except ImportError as exc:
+        print(f"openhands sdk not installed: {exc}", file=sys.stderr)
+        return 4
+
+    try:
+        llm = LLM(model=model, api_key=api_key)
+        agent = Agent(
+            llm=llm,
+            tools=[Tool(name=TerminalTool.name), Tool(name=FileEditorTool.name)],
+        )
+        conversation = Conversation(agent=agent, workspace=str(repo_path))
+        conversation.send_message(task)
+        conversation.run()
+    except Exception as exc:  # surface as a worker failure, not a crash
+        print(f"openhands run error: {exc}", file=sys.stderr)
+        return 1
+
+    print("openhands run complete")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/app/core/workers/openhands_worker.py
+++ b/app/core/workers/openhands_worker.py
@@ -1,0 +1,103 @@
+"""OpenHands SDK worker — runs a real OpenHands agent loop as a subprocess.
+
+Follows the slide-16 six-step SDK pattern (workspace -> agent -> conversation ->
+run -> extract diff) against the real OpenHands SDK 1.28 API. The agent runs in a
+child process (`app.core.workers.openhands_runner`) so the heavy import is lazy and
+the run is timeout-bounded, exactly like the CLI workers. The worker edits the repo
+in place; the harness reads the diff (step 6) via its existing collect_diff node.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+from app.core.git_utils import collect_status_lines, is_git_repo
+from app.core.workers.auth_errors import detect_auth_failure
+from app.prompts.workers import build_worker_prompt
+from app.schemas.edit import ExternalEditResult
+
+COMMAND_STR = "python -m app.core.workers.openhands_runner <repo> (task on stdin)"
+
+
+class OpenHandsWorker:
+    """Run an OpenHands SDK agent over a repository inside the harness."""
+
+    def run(
+        self,
+        repo_path: Path,
+        task: str,
+        timeout_seconds: int = 300,
+        allow_dirty: bool = False,
+    ) -> ExternalEditResult:
+        if not is_git_repo(repo_path):
+            return ExternalEditResult(
+                status="blocked",
+                command=COMMAND_STR,
+                stderr="Target path must be a git repository for edit attribution.",
+            )
+
+        if collect_status_lines(repo_path) and not allow_dirty:
+            return ExternalEditResult(
+                status="blocked",
+                command=COMMAND_STR,
+                stderr=(
+                    "Target repository is dirty. Commit, stash, or pass allow_dirty=True "
+                    "before running an OpenHands worker."
+                ),
+            )
+
+        prompt = build_worker_prompt(repo_path=repo_path, task=task)
+        argv = [sys.executable, "-m", "app.core.workers.openhands_runner", str(repo_path)]
+
+        started = time.perf_counter()
+        try:
+            completed = subprocess.run(
+                argv,
+                input=prompt,
+                cwd=repo_path,
+                capture_output=True,
+                text=True,
+                timeout=timeout_seconds,
+                check=False,
+            )
+        except subprocess.TimeoutExpired as exc:
+            return ExternalEditResult(
+                status="failed",
+                command=COMMAND_STR,
+                exit_code=None,
+                stdout=exc.stdout or "",
+                stderr=exc.stderr or f"OpenHands worker timed out after {timeout_seconds}s.",
+                duration_seconds=round(time.perf_counter() - started, 3),
+            )
+
+        duration = round(time.perf_counter() - started, 3)
+        code = completed.returncode
+
+        # Auth (exit 3) and missing-SDK (exit 4) are setup problems, not run failures.
+        if code in (3, 4) or detect_auth_failure(completed.stdout, completed.stderr):
+            reason = (
+                "OpenHands SDK not installed. Install: uv sync --extra openhands."
+                if code == 4
+                else detect_auth_failure(completed.stdout, completed.stderr)
+                or "OpenHands authentication failed; set ANTHROPIC_API_KEY and retry."
+            )
+            return ExternalEditResult(
+                status="blocked",
+                command=COMMAND_STR,
+                exit_code=code,
+                stdout=completed.stdout,
+                stderr=f"{reason}\n{completed.stderr}".strip(),
+                duration_seconds=duration,
+            )
+
+        return ExternalEditResult(
+            status="completed" if code == 0 else "failed",
+            command=COMMAND_STR,
+            exit_code=code,
+            stdout=completed.stdout,
+            stderr=completed.stderr,
+            duration_seconds=duration,
+        )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "agentops-harness"
 version = "0.1.0"
 description = "Local-first coding-agent orchestration and evaluation harness."
 readme = "README.md"
-requires-python = ">=3.11"
+requires-python = ">=3.12"
 dependencies = [
     "pyyaml>=6.0",
     "fastapi>=0.115.0",
@@ -23,6 +23,10 @@ dev = [
     "httpx>=0.27.0",
     "pytest>=8.2.0",
     "ruff>=0.6.0",
+]
+openhands = [
+    "openhands-sdk>=1.28.0",
+    "openhands-tools>=1.28.0",
 ]
 
 [project.scripts]

--- a/tests/test_openhands_worker.py
+++ b/tests/test_openhands_worker.py
@@ -1,0 +1,32 @@
+import subprocess
+import sys
+from pathlib import Path
+
+from app.core.workers.openhands_worker import OpenHandsWorker
+
+
+def test_blocks_on_non_git_repo(tmp_path: Path):
+    result = OpenHandsWorker().run(repo_path=tmp_path, task="x", timeout_seconds=5)
+    assert result.status == "blocked"
+    assert "git repository" in result.stderr
+
+
+def test_blocks_on_dirty_repo(tmp_path: Path):
+    subprocess.run(["git", "init", "-q"], cwd=tmp_path, check=True)
+    (tmp_path / "f.py").write_text("x=1\n")  # untracked -> dirty
+    result = OpenHandsWorker().run(repo_path=tmp_path, task="x", timeout_seconds=5)
+    assert result.status == "blocked"
+    assert "dirty" in result.stderr.lower()
+
+
+def test_runner_exits_2_without_a_task():
+    # The runner reads the task from stdin; an empty task is a usage error (exit 2),
+    # reached before any SDK import or auth — so this needs neither.
+    completed = subprocess.run(
+        [sys.executable, "-m", "app.core.workers.openhands_runner", "."],
+        input="",
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert completed.returncode == 2

--- a/tests/test_worker_auth_errors.py
+++ b/tests/test_worker_auth_errors.py
@@ -2,7 +2,10 @@ from app.core.workers.auth_errors import detect_auth_failure
 
 
 def test_detects_anthropic_401_envelope():
-    out = '{"type":"error","error":{"type":"authentication_error","message":"Invalid authentication credentials"}}'
+    out = (
+        '{"type":"error","error":{"type":"authentication_error",'
+        '"message":"Invalid authentication credentials"}}'
+    )
     msg = detect_auth_failure(out, "")
     assert msg is not None
     assert "credentials" in msg.lower()

--- a/uv.lock
+++ b/uv.lock
@@ -1,6 +1,23 @@
 version = 1
 revision = 3
-requires-python = ">=3.11"
+requires-python = ">=3.12"
+resolution-markers = [
+    "python_full_version >= '3.14'",
+    "python_full_version == '3.13.*'",
+    "python_full_version < '3.13'",
+]
+
+[[package]]
+name = "agent-client-protocol"
+version = "0.10.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/88/a0/3b96cd8374725c69bc3dae9fcc2082f3f6cafec1be35d24d7af0f8c3265f/agent_client_protocol-0.10.1.tar.gz", hash = "sha256:355c65ca19f0568344aafc2c1552b7066a8fc491df23ab28e7e253c6c9a85a25", size = 81924, upload-time = "2026-05-24T18:46:44.444Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7b/18/d8c7ff337cf621ea79a84006a7252ff057bfb5767549bb102cc6649f4ec2/agent_client_protocol-0.10.1-py3-none-any.whl", hash = "sha256:a03d3198f4d772f2e0ec012c00ac1cce131b4710220a3dc9fae3c991d047c750", size = 65401, upload-time = "2026-05-24T18:46:43.202Z" },
+]
 
 [[package]]
 name = "agentops-harness"
@@ -26,6 +43,10 @@ dev = [
     { name = "pytest" },
     { name = "ruff" },
 ]
+openhands = [
+    { name = "openhands-sdk" },
+    { name = "openhands-tools" },
+]
 
 [package.metadata]
 requires-dist = [
@@ -35,6 +56,8 @@ requires-dist = [
     { name = "langgraph", specifier = ">=1.0.0" },
     { name = "mcp", specifier = ">=1.16.0" },
     { name = "openai", specifier = ">=1.99.0" },
+    { name = "openhands-sdk", marker = "extra == 'openhands'", specifier = ">=1.28.0" },
+    { name = "openhands-tools", marker = "extra == 'openhands'", specifier = ">=1.28.0" },
     { name = "pydantic", specifier = ">=2.8.0" },
     { name = "pydantic-settings", specifier = ">=2.4.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.2.0" },
@@ -44,7 +67,150 @@ requires-dist = [
     { name = "typer", specifier = ">=0.12.0" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.30.0" },
 ]
-provides-extras = ["dev"]
+provides-extras = ["dev", "openhands"]
+
+[[package]]
+name = "aiofile"
+version = "3.11.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "caio" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/48/41/2fea7e193e061ce54eacc3b7bc0e6a99e4fcff43c78cf0a76dd781ed8334/aiofile-3.11.1.tar.gz", hash = "sha256:1f91912c6643d2a4e49ca4ae3514f0bf3867ce948a36d99a6411b8f4755f4cf9", size = 19342, upload-time = "2026-05-16T08:18:33.538Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/67/cd/0d76dfc5de72bde52f55f53e925c7d152d9c7906634ec1e0cbc7e8d4ad93/aiofile-3.11.1-py3-none-any.whl", hash = "sha256:ce77d14ac07f77bc2b757834a5c129321f3f705c474593deed5ab209079a52c9", size = 20446, upload-time = "2026-05-16T08:18:32.051Z" },
+]
+
+[[package]]
+name = "aiofiles"
+version = "25.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/41/c3/534eac40372d8ee36ef40df62ec129bee4fdb5ad9706e58a29be53b2c970/aiofiles-25.1.0.tar.gz", hash = "sha256:a8d728f0a29de45dc521f18f07297428d56992a742f0cd2701ba86e44d23d5b2", size = 46354, upload-time = "2025-10-09T20:51:04.358Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bc/8a/340a1555ae33d7354dbca4faa54948d76d89a27ceef032c8c3bc661d003e/aiofiles-25.1.0-py3-none-any.whl", hash = "sha256:abe311e527c862958650f9438e859c1fa7568a141b22abcd015e120e86a85695", size = 14668, upload-time = "2025-10-09T20:51:03.174Z" },
+]
+
+[[package]]
+name = "aiohappyeyeballs"
+version = "2.6.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/33/c6/61a2d7b7572279226bb2e7f61d7a19ca7c90da0329c93fa0d560cbf288d8/aiohappyeyeballs-2.6.2.tar.gz", hash = "sha256:e202810ee718bd01fc6ef49e8ea53d023d5cb6b581076d7925aa499fa55dbe64", size = 22591, upload-time = "2026-05-20T15:12:24.631Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5f/fc/a7bf5b6e4e617b45f90f2d9d2a68519c249c81dd4fc2658c7a2a61c4f4b7/aiohappyeyeballs-2.6.2-py3-none-any.whl", hash = "sha256:4708045e2d7a6c6bdf8aafa8ed39649eaf926a4543b54560659129e3365953c4", size = 15062, upload-time = "2026-05-20T15:12:23.328Z" },
+]
+
+[[package]]
+name = "aiohttp"
+version = "3.14.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "aiohappyeyeballs" },
+    { name = "aiosignal" },
+    { name = "attrs" },
+    { name = "frozenlist" },
+    { name = "multidict" },
+    { name = "propcache" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "yarl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/82/78/8ea7308cac6934de8c74a14f3d5f65d1c89287426688be79538d0e5c013d/aiohttp-3.14.1.tar.gz", hash = "sha256:307f2cff90a764d329e77040603fa032db89c5c24fdad50c4c15334cba744035", size = 7955794, upload-time = "2026-06-07T21:09:35.529Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1d/21/151624b51cd92553d95424daf4bf19f19ce9be9002d19253e7e7ce67197b/aiohttp-3.14.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:d35143e27778b4bb0fb189562d7f275bff79c62ab8e98459717c0ea617ff2480", size = 757402, upload-time = "2026-06-07T21:06:40.311Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/82/280619e0bd7bf2454987e19282616e84762255dd9c8468f62382e8c191f1/aiohttp-3.14.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:bcfb80a2cc36fba2534e5e5b5264dc7ae6fcd9bf15256da3e53d2f499e6fa29d", size = 512310, upload-time = "2026-06-07T21:06:42.207Z" },
+    { url = "https://files.pythonhosted.org/packages/55/b2/2aac325583aaa1353045f96dffa586d8a34e8322e14a7ba49cffeb103ab4/aiohttp-3.14.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:27fd7c91e51729b4f7e1577865fa6d34c9adccbc39aabe9000285b48af9f0ec2", size = 512448, upload-time = "2026-06-07T21:06:43.813Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/72/a60607cb849faa8af8a356c9329ea2eb6f395d49e82cc82ccba1fd8deb8f/aiohttp-3.14.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:64c567bf9eaf664280116a8688f63016e6b32db2505908e2bdaca1b6438142f2", size = 1766854, upload-time = "2026-06-07T21:06:45.391Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/d3/d9fe1c9ec7557ab4d0d82bebaa728c6418f0b93295ec2f4ab015f7710cc7/aiohttp-3.14.1-cp312-cp312-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:f5e6ff2bdbb8f4cd3fbe41f99e25bbcd58e3bf9f13d3dd31a11e7917251cc77a", size = 1740884, upload-time = "2026-06-07T21:06:47.413Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/dc/f2cecfaf9337ba3e63f181500814ff502aa3d00d9c7ec93a9d23d10a27b2/aiohttp-3.14.1-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:2f73e01dc37122325caf079982621262f96d74823c179038a82fddfc50359264", size = 1810034, upload-time = "2026-06-07T21:06:50.165Z" },
+    { url = "https://files.pythonhosted.org/packages/66/d7/2ff65c5e65c0d7476daf7e15c032e0805e36811185b9623e3238ad6c763e/aiohttp-3.14.1-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:bb2c0c80d431c0d03f2c7dbf125150fedd4f0de17366a7ca33f7ccb822391842", size = 1904054, upload-time = "2026-06-07T21:06:52.035Z" },
+    { url = "https://files.pythonhosted.org/packages/20/9c/d445818389df371f56d141d881153ba23183c4735a03f7356ffb43f7757d/aiohttp-3.14.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3e6fc1a85fa7194a1a7d19f44e8609180f4a8eb5fa4c7ed8b4355f080fad235c", size = 1790278, upload-time = "2026-06-07T21:06:54.049Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/aa/bf04cb4d865fc6101c2229a294ad744973b72e513fdc5a6b791e6983d72a/aiohttp-3.14.1-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:686b6c0d3911ec387b444ddf5dc62fb7f7c0a7d5186a7861626496a5ab4aff95", size = 1591795, upload-time = "2026-06-07T21:06:55.911Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/b4/4dac0038960427ba832f6609dfb4ea5437d7fd80c72001b9e48f834f428b/aiohttp-3.14.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:c6fa4dc7ad6f8109c70bb1499e589f76b0b792baf39f9b017eb92c8a81d0a199", size = 1728397, upload-time = "2026-06-07T21:06:57.777Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/f9/7cd4e8ad7aa3b75f17d56bb5498dd604a93d4e6eece822ba0568c413fff0/aiohttp-3.14.1-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:87a5eea1b2a5e21e1ebdbb33ad4165359189327e63fc4e4894693e7f821ac817", size = 1766504, upload-time = "2026-06-07T21:07:00.009Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/df/fc01d9fcad0f73fed3f3d361f1f94f975947b50dff82919f6dc2bf4316cc/aiohttp-3.14.1-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:1c1421eb01d4fd608d88cc8290211d177a58532b55ad94076fb349c5bf467f0a", size = 1777806, upload-time = "2026-06-07T21:07:02.064Z" },
+    { url = "https://files.pythonhosted.org/packages/41/09/47e2d090bddcc8fb4ccb4c314aadc32d7c5d9bb55f50f6ad1c92fc15d501/aiohttp-3.14.1-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:34b257ec41345c1e8f2df68fa908a7952f5de932723871eb633ecbbff396c9a4", size = 1580707, upload-time = "2026-06-07T21:07:03.942Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/36/f1a4ce904ae0b6930cfe9afc96d0896f7ec1a620c400405d63783bb95a9c/aiohttp-3.14.1-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:de538791a80e5d862addbc183f70f0158ac9b9bb872bb147f1fd2a683691e087", size = 1798121, upload-time = "2026-06-07T21:07:05.987Z" },
+    { url = "https://files.pythonhosted.org/packages/70/0a/e0075ce9ca0279ee1d4f0c0b85f54fea02ebc83c3007651a72bece658fec/aiohttp-3.14.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:6f71173be42d3241d428f760122febb748de0623f44308a6f120d0dd9ec572e3", size = 1767580, upload-time = "2026-06-07T21:07:07.873Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/61/a0c0a8f327a9c52095cdd8e312391b00d3ed64ab6c72bb5c33d8ec251cf7/aiohttp-3.14.1-cp312-cp312-win32.whl", hash = "sha256:ec8dc383ee57ea3e883477dcca3f11b65d58199f1080acaf4cd6ad9a99698be4", size = 452771, upload-time = "2026-06-07T21:07:09.669Z" },
+    { url = "https://files.pythonhosted.org/packages/df/d9/ea367c75f16ac9c6cdc8febb25e8318fa21a2b1bc8d6514d4b2d890bface/aiohttp-3.14.1-cp312-cp312-win_amd64.whl", hash = "sha256:2aa92c87868cd13674989f9ee83e5f9f7ea4237589b728048e1f0c8f6caa3271", size = 479873, upload-time = "2026-06-07T21:07:11.538Z" },
+    { url = "https://files.pythonhosted.org/packages/03/64/8d96784a7851156db8a4c6c3f6f91042fdf39fb15a4cc38c8b3c14833c45/aiohttp-3.14.1-cp312-cp312-win_arm64.whl", hash = "sha256:2c840c90759922cb5e6dda94596e079a30fb5a5ba548e7e0dc00574703940847", size = 448073, upload-time = "2026-06-07T21:07:13.637Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/97/bd137012dd97e1649162b099135a80e1fd59aaa807b2430fc448d1029aff/aiohttp-3.14.1-cp313-cp313-android_21_arm64_v8a.whl", hash = "sha256:b3a03285a7f9c7b016324574a6d92a1c895da6b978cb8f1deee3ac72bc6da178", size = 506882, upload-time = "2026-06-07T21:07:15.501Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/79/e5cc690e9d922a66887ceeaca53a8ffd5a7b0be3816142b7abc433742d89/aiohttp-3.14.1-cp313-cp313-android_21_x86_64.whl", hash = "sha256:2a73f487ab8ef5abbb24b7aa9b73e98eaba9e9e031804ff2416f02eca315ccaf", size = 515270, upload-time = "2026-06-07T21:07:17.53Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/22/a73ccbf9dbd6e26dda0b24d5fd5db7da92ee3383a79f47677ffb834c5c5b/aiohttp-3.14.1-cp313-cp313-ios_13_0_arm64_iphoneos.whl", hash = "sha256:915fbb7b41b115192259f8c9ae58f3ddc444d2b5579917270211858e606a4afd", size = 485841, upload-time = "2026-06-07T21:07:19.555Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/b9/57ed8eaf596321c2ad747bd480fb1700dbd7177c60dfc9e4c187f629662e/aiohttp-3.14.1-cp313-cp313-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:7fb4bdf95b0561a79f259f9d28fbc109728c5ee7f27aff6391f0ca703a329abe", size = 492088, upload-time = "2026-06-07T21:07:21.581Z" },
+    { url = "https://files.pythonhosted.org/packages/78/c0/5ebe5270a7c140d7c6f79dcb018640225f14d406c149e4eec04a7d82fe71/aiohttp-3.14.1-cp313-cp313-ios_13_0_x86_64_iphonesimulator.whl", hash = "sha256:1b9748363260121d2927704f5d4fc498150669ca3ae93625986ee89c8f80dcd4", size = 501564, upload-time = "2026-06-07T21:07:23.388Z" },
+    { url = "https://files.pythonhosted.org/packages/75/7f/8cdaa24fc7983865e0915153b96a9ac5bcdd3548d64c5a27d17cecccad2d/aiohttp-3.14.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:86a6dab78b0e43e2897a3bbe15745aa60dc5423ca437b7b0b164c069bf91b876", size = 751998, upload-time = "2026-06-07T21:07:25.046Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/f4/c4227aacfacc5cb0cc2d119b65301d177912a6842cd64e120c47af76064f/aiohttp-3.14.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:4dfd6e47d3c44c2279907607f73a4240b88c69eb8b90da7e2441a8045dfd21da", size = 510918, upload-time = "2026-06-07T21:07:27.28Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/01/a2d5f96cd4e74424864d30bc0a7e44d0a12dacdcfa91b5b2d1bd3dca6bf3/aiohttp-3.14.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:317acd9f8602858dc7d59679812c376c7f0b97bcbbf16e0d6237f54141d8a8a6", size = 508657, upload-time = "2026-06-07T21:07:29.252Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/ed/3c0fb5c500fdd8e7ebc10d1889c04384fffa1a9163eac1356088ca9da1b1/aiohttp-3.14.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:bd869c427324e5cb15195793de951295710db28be7d818247f3097b4ab5d4b96", size = 1757907, upload-time = "2026-06-07T21:07:31.03Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/ab/d4c924d9bd5be3050c226612413ce68cb54c70d2c31b661bfc8d9a5b6a70/aiohttp-3.14.1-cp313-cp313-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:93b032b5ec3255473c143627d21a69ac74ae12f7f33974cb587c564d11b1066f", size = 1737565, upload-time = "2026-06-07T21:07:33.031Z" },
+    { url = "https://files.pythonhosted.org/packages/19/2a/37326821ff779084020cdc33224d20b19f42f4183a500ff92022a739eda7/aiohttp-3.14.1-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:f234b4deb12f3ad59127e037bc57c40c21e45b45282df7d3a55a0f409f595296", size = 1799018, upload-time = "2026-06-07T21:07:35.003Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/4f/6e947ba73e4ce09070761c05ed3a8ceb7c21f5e46798671d8b2aac0e4626/aiohttp-3.14.1-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:9af6779bfb46abf124068327abcdf9ce95c9ef8287a3e8da76ccf2d0f16c28fa", size = 1894416, upload-time = "2026-06-07T21:07:36.956Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/6e/dbf1d0625dc711fb2851f4f3c3055c39ed58bae92082d8c627dbe6013736/aiohttp-3.14.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:faccab372e66bc76d5731525e7f1143c922271725b9d38c9f97edcc66266b451", size = 1783881, upload-time = "2026-06-07T21:07:39.063Z" },
+    { url = "https://files.pythonhosted.org/packages/44/c2/5e25098a67268ed369483ae7d1a58bd0a13d03aab860d2a0e4a6eb25b046/aiohttp-3.14.1-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:f380468b09d2a81633ee863b0ec5648d364bd17bb8ecfb8c2f387f7ac1faf42c", size = 1587572, upload-time = "2026-06-07T21:07:41.058Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/bd/cf9cee17e140f942a3de73e658a543aa8fbf35a5fc67a9d2538d52d77f0b/aiohttp-3.14.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:97e704dcd26271f5bda3fa07c3ce0fb76d6d3f8659f4baa1a24442cc9ba177ca", size = 1722137, upload-time = "2026-06-07T21:07:43.014Z" },
+    { url = "https://files.pythonhosted.org/packages/89/6d/5684f8c59045c96f81a18cefbc1fbbd79d25b88f1c622f2a5c5c08fcb632/aiohttp-3.14.1-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:269b76ac5394092b95bc4a098f4fc6c191c083c3bd12775d1e30e663132f6a09", size = 1755953, upload-time = "2026-06-07T21:07:45.933Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/40/35caf3170f8359760740a7d9aa0fff2e344bef98e1d1186f5a0f6dec17e6/aiohttp-3.14.1-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:5c0b3e614340c889d575451696374c9d17affd54cd607ca0babed8f8c37b9397", size = 1766479, upload-time = "2026-06-07T21:07:48.047Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/a1/b0c61e7a137f0d81de49a82023a6df73c3c16d6fefb0f8e4a93d21639002/aiohttp-3.14.1-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:5663ee9257cfa1add7253a7da3035a02f31b6600ec48261585e1800a81533080", size = 1580077, upload-time = "2026-06-07T21:07:50.069Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/41/194ea4623693009fcefebef7aef63c141754f153e9cd0d39d3b9e36c175c/aiohttp-3.14.1-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:603a2c834142172ffddc054067f5ec0ca65d57a0aa98a71bc81952573208e345", size = 1791688, upload-time = "2026-06-07T21:07:52.106Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/45/4de841f005cfe1fd63e2a2fe011262c515e2a62aa6994b15947e7d717ac9/aiohttp-3.14.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:cb21957bb8aca671c1765e32f58164cf0c50e6bf41c0bbbd16da20732ecaf588", size = 1761094, upload-time = "2026-06-07T21:07:54.113Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/ae/dbce10533d3896d544d5053939ed75b7dc31a1b0973d959b1b5ae21028d6/aiohttp-3.14.1-cp313-cp313-win32.whl", hash = "sha256:e509a55f681e6158c20f70f102f9cf61fb20fbc382272bc6d94b7343f2582780", size = 452662, upload-time = "2026-06-07T21:07:56.06Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/d9/0bf1a19362c32f06229da5e7ddfcec91f93474d6307f7a2d3135e9c674dc/aiohttp-3.14.1-cp313-cp313-win_amd64.whl", hash = "sha256:1ac8531b638959718e18c2207fbfe297819875da46a740b29dfa29beba64355a", size = 479748, upload-time = "2026-06-07T21:07:58.319Z" },
+    { url = "https://files.pythonhosted.org/packages/22/0a/62e7232dc9484fbec112ceb32efb6a624cc7994ec6e2b019286f17c4e8f2/aiohttp-3.14.1-cp313-cp313-win_arm64.whl", hash = "sha256:250d14af67f6b6a1a4a811049b1afa69d61d617fca6bf33149b3ab1a6dbcf7b8", size = 447723, upload-time = "2026-06-07T21:08:00.154Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/a1/5fafa04e1ca91ddb47608699d60649c1c6db3cf41c99e78fc4056f9513db/aiohttp-3.14.1-cp314-cp314-android_24_arm64_v8a.whl", hash = "sha256:7c106c26852ca1c2047c6b80384f17100b4e439af276f21ef3d4e2f450ae7e15", size = 508531, upload-time = "2026-06-07T21:08:02.093Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/2e/bfa02f699d87ffc86d5959270b28f1cb410add3ccaced8ed2e0b8a5238fc/aiohttp-3.14.1-cp314-cp314-android_24_x86_64.whl", hash = "sha256:20205f7f5ade7aaec9f4b500549bbc071b046453aed72f9c06dcab87896a83e8", size = 514718, upload-time = "2026-06-07T21:08:04.476Z" },
+    { url = "https://files.pythonhosted.org/packages/85/a5/9594ad6289eebbc97d167c44213d557807f90e59115caad24de21ad2c3b1/aiohttp-3.14.1-cp314-cp314-ios_13_0_arm64_iphoneos.whl", hash = "sha256:62a759436b29e677181a9e76bab8b8f689a29cb9c535f45f7c48c9c830d3f8c3", size = 487918, upload-time = "2026-06-07T21:08:06.377Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/61/16a32c36c3c49edec122a3dc811f2057df2f94d3b14aa107c8017d981618/aiohttp-3.14.1-cp314-cp314-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:2964cbf553df4d7a57348da44d961d871895fc1ee4e8c322b2a95612c7b17fba", size = 494014, upload-time = "2026-06-07T21:08:08.263Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/89/3ebcf96ed99c05bec9c434aaac6963fd3cbab4a786ae739908a144d9ce44/aiohttp-3.14.1-cp314-cp314-ios_13_0_x86_64_iphonesimulator.whl", hash = "sha256:237651caadc3a59badd39319c54642b5299e9cc98a3a194310e55d5bb9f5e397", size = 502398, upload-time = "2026-06-07T21:08:10.244Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/3d/b74870a0c2d40c355928cd5b96c7a11fa821b8a40fc41365e64479b151fb/aiohttp-3.14.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:896e12dfdbbab9d8f7e16d2b28c6769a60126fa92095d1ebf9473d02593a2448", size = 758018, upload-time = "2026-06-07T21:08:12.447Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/66/f42f5c984d99e49c6cff5f26f590750f2e2f7ef1fcfb99966ab5be1b632e/aiohttp-3.14.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:d03f281ed22579314ba00821ce20115a7c0ac430660b4cc05704a3f818b3e004", size = 512462, upload-time = "2026-06-07T21:08:14.624Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/a7/248e1aebe0c7810b0271e021a0f2a5eb6e78a051885b3c9df49f42a5802d/aiohttp-3.14.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:07eabb979d236335fed927e137a928c9adfb7df3b9ec7aa31726f133a62be983", size = 512824, upload-time = "2026-06-07T21:08:16.572Z" },
+    { url = "https://files.pythonhosted.org/packages/26/97/2aa0e5ba0727dc3bd5aaebb7ccbc510f7dfb7fb961ec87497cd496635ab1/aiohttp-3.14.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4fe1f1087cbadb280b5e1bb054a4f00d1423c74d6626c5e48400d871d34ecefe", size = 1749898, upload-time = "2026-06-07T21:08:18.635Z" },
+    { url = "https://files.pythonhosted.org/packages/00/8d/e97f6c96c891d457c8479d92a514ba194d0412f981d72c70341ee18488ed/aiohttp-3.14.1-cp314-cp314-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:367a9314fdc79dab0fac96e216cb41dd73c85bdca85306ce8999118ba7e0f333", size = 1710114, upload-time = "2026-06-07T21:08:20.892Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/e6/aa8d7e863048c8fceb5cd6ce74017311cec3ead07847387e12265fb4444e/aiohttp-3.14.1-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a24f677ebe83749039e7bdf862ff0bbb16818ae4193d4ef96505e269375bcce0", size = 1802541, upload-time = "2026-06-07T21:08:23.044Z" },
+    { url = "https://files.pythonhosted.org/packages/83/a8/72193137de57fda4ebfae4563182d082c8856e3b6e9871d0b46f028fb369/aiohttp-3.14.1-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:c83afe0ba876be7e943d2e0ba645809ad441575d2840c895c21ee5de93b9377a", size = 1875776, upload-time = "2026-06-07T21:08:25.288Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/18/938441025db6769a3464596b2410af3afde0b21eb2f204c6f766f68af4bd/aiohttp-3.14.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:634e385930fb6d2d479cf3aa66515955863b77a5e3c2b5894ca259a25b308602", size = 1760329, upload-time = "2026-06-07T21:08:27.363Z" },
+    { url = "https://files.pythonhosted.org/packages/60/29/bf2496b4065e76e09fe48015aaffe5ce161d8f089b06ac6982070f653076/aiohttp-3.14.1-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:eeea07c4397bbc57719c4eed8f9c284874d4f175f9b6d57f7a1546b976d455ca", size = 1587293, upload-time = "2026-06-07T21:08:29.805Z" },
+    { url = "https://files.pythonhosted.org/packages/49/a2/2136674d52123b1354bd05dd5753c318db47dc0c927cc70b27bab3755456/aiohttp-3.14.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:335c0cc3e3545ce98dcb9cfcb836f40c3411f43fa03dab757597d80c89af8a35", size = 1714756, upload-time = "2026-06-07T21:08:32.094Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/b9/e5fd2e6f915503081c0f9b1e8540947037929c70c191da2e4d54b31a21a1/aiohttp-3.14.1-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:ae6be797afdef264e8a84864a85b196ca06045586481b3df8a967322fd2fa844", size = 1721052, upload-time = "2026-06-07T21:08:34.167Z" },
+    { url = "https://files.pythonhosted.org/packages/63/5a/2833e324a2263e104e31e2e91bc5bbee81bc499afd32203faee048a883f0/aiohttp-3.14.1-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:8560b4d712474335d08907db7973f71912d3a9a8f1dee992ec06b5d2fe359496", size = 1766888, upload-time = "2026-06-07T21:08:36.95Z" },
+    { url = "https://files.pythonhosted.org/packages/57/fa/dea6511870913162f3b2e8c42a7614eb203a4540b8c2da43e0bfb0548f3c/aiohttp-3.14.1-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:2b7edd08e0a5deb1e8564a2fcd8f4561014a3f05252334671bbf55ddd47db0e5", size = 1581679, upload-time = "2026-06-07T21:08:39.292Z" },
+    { url = "https://files.pythonhosted.org/packages/14/bd/3cf0d55e71784b33534e9710a67d382d900598b4787fbce6cc7317f8c42a/aiohttp-3.14.1-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:b6ff7fcee63287ae57b5df3e4f5957ce032122802509246dec1a5bcc55904c95", size = 1782021, upload-time = "2026-06-07T21:08:41.407Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/af/14bb5843eccbe234f4dfb78ab73e549d99727247e62ae5d62cbd22eaf5b0/aiohttp-3.14.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:6ffbb2f4ec1ceaff7e07d43922954da26b223d188bf30658e561b98e23089444", size = 1742574, upload-time = "2026-06-07T21:08:43.795Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/1e/fbeb7af9210a67ac0f9c9bec0f8f4568497924e33137a3d5b48e1cf85f3f/aiohttp-3.14.1-cp314-cp314-win32.whl", hash = "sha256:a9875b46d910cff3ea2f5962f9d266b465459fe634e22556ab9bd6fc1192eea0", size = 457773, upload-time = "2026-06-07T21:08:46.168Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/2b/13e8d741a9ec5db7d900c060554cf8352ab85e44e2a4469ebb9d377bda17/aiohttp-3.14.1-cp314-cp314-win_amd64.whl", hash = "sha256:af8b4b81a960eeaf1234971ac3cd0ba5901f3cd42eae42a46b4d089a8b492719", size = 485001, upload-time = "2026-06-07T21:08:48.401Z" },
+    { url = "https://files.pythonhosted.org/packages/df/30/491acfa2c4d6c3ff59c49a14fc1b50be3241e25bbb0c84c09e2da4d11395/aiohttp-3.14.1-cp314-cp314-win_arm64.whl", hash = "sha256:cf4491381b1b57425c315a56a439251b1bdac07b2275f19a8c44bc57744532ec", size = 453809, upload-time = "2026-06-07T21:08:50.7Z" },
+    { url = "https://files.pythonhosted.org/packages/34/e3/19dbe1a1f4cc6230eb9e314de7fe68053b0992f9302b27d12141a0b5db53/aiohttp-3.14.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:819c054312f1af92947e6a55883d1b66feefab11531a7fc45e0fb9b63880b5c2", size = 793320, upload-time = "2026-06-07T21:08:52.775Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/20/1b7182219ba1b108430d6e4dc53d25ae02dcfcf5a045b33af4e8c5167527/aiohttp-3.14.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:10ee9c1753a8f706345b22496c79fbddb5be0599e0823f3738b1534058e25340", size = 529077, upload-time = "2026-06-07T21:08:55Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/c8/14ce60ec31a2e5f5274bb17d383a6f7a3aabca31ac04eee05585bbadab16/aiohttp-3.14.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:1601cc37baf5750ccacae618ec2daf020769581695550e3b654a911f859c563d", size = 532476, upload-time = "2026-06-07T21:08:57.176Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/02/9ac85e081e53da2e061b02fa7758fe0a12d17b8ce2d1f5e6c7cb76730328/aiohttp-3.14.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4d6e0ac9da31c9c04c84e1c0182ad8d6df35965a85cae29cd71d089621b3ae94", size = 1922347, upload-time = "2026-06-07T21:08:59.563Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/3e/d3ba07a0ab38b5389e10bec4362d21e10a4f667cba2d79ba30837b3a5059/aiohttp-3.14.1-cp314-cp314t-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:9e8f2d660c350b3d0e259c7a7e3d9b7fc8b41210cbcc3d4a7076ff0a5e5c2fdc", size = 1786465, upload-time = "2026-06-07T21:09:01.909Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/cb/e2ee978a00cfb2df829704a69528b18154eba5939f45bc1efa8f33aee4c5/aiohttp-3.14.1-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:4691802dda97be727f79d86818acaad7eb8e9252626a1d6b519fedbb92d5e251", size = 1909423, upload-time = "2026-06-07T21:09:04.357Z" },
+    { url = "https://files.pythonhosted.org/packages/73/5d/1430334858b1022b58ae50399a918f0bd6fe8fa7fa183598d657ff61e040/aiohttp-3.14.1-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:c389c482a7e9b9dc3ee2701ac46c4125297a3818875b9c305ddb603c04828fd1", size = 2001906, upload-time = "2026-06-07T21:09:06.722Z" },
+    { url = "https://files.pythonhosted.org/packages/66/4e/560c7472d3d198a23aa5c8b19a5115bf6a9b77b7d3e4bb363da320430ad2/aiohttp-3.14.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:fc0cacab7ba4e56f0f81c82a98c09bed2f39c940107b03a34b168bdf7597edd3", size = 1877095, upload-time = "2026-06-07T21:09:09.011Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/f1/4745806578d447db4a784a8591e2dae3afdfc2bcb96f8f81271b13df6543/aiohttp-3.14.1-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:979ed4717f59b8bb12e3963378fa285d93d367e15bcd66c721311826d3c44a6c", size = 1676222, upload-time = "2026-06-07T21:09:11.461Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/c9/48255813cca749a229ef0ab476004ec623728ad79a9c0840616f6c076325/aiohttp-3.14.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:38e1e7daaea81df51c952e18483f323d878499a1e2bfe564790e0f9701d6f203", size = 1842922, upload-time = "2026-06-07T21:09:14.118Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/c0/bbd054e2bee909f529523a5af3891052606af5143c09f5f183ec3b234676/aiohttp-3.14.1-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:4132e72c608fe9fecb8f409113567605915b83e9bdd3ea56538d2f9cd35002f1", size = 1825035, upload-time = "2026-06-07T21:09:16.447Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/ae/90395d4376deceb74e09ec26b6adf7d2015a6f8802d6d84446af860fef04/aiohttp-3.14.1-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:eefd9cc9b6d4a2db5f00a26bc3e4f9acf71926a6ec557cd56c9c6f27c290b665", size = 1849512, upload-time = "2026-06-07T21:09:18.742Z" },
+    { url = "https://files.pythonhosted.org/packages/93/bd/fb25f3049957553d4ce0ba6ae480aa2f592a6985497fca590837d16c1be0/aiohttp-3.14.1-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:b165790117eea512d7f3fb22f1f6dad3d55a7189571993eb015591c1401276d1", size = 1668571, upload-time = "2026-06-07T21:09:21.458Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/22/7f73303d64dd567ff3addca90b556690ed1233a47b8f55d242fb90af3681/aiohttp-3.14.1-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:ed09c7eb1c391271c2ed0314a51903e72a3acb653d5ccfc264cdf3ef11f8269d", size = 1881159, upload-time = "2026-06-07T21:09:23.813Z" },
+    { url = "https://files.pythonhosted.org/packages/44/be/0474c5a8b5640e1e4aa1923430a91f4151be82e511373fe764189b89aef5/aiohttp-3.14.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:99abd37084b82f5830c635fddd0b4993b9742a66eb746dacf433c8590e8f9e3c", size = 1841409, upload-time = "2026-06-07T21:09:26.207Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/3c/bb4a7cba26956cb3da4553cc2056cf67be5b5ff6e6d8fa4fbdff73bfb7ae/aiohttp-3.14.1-cp314-cp314t-win32.whl", hash = "sha256:47ddf841cdecc810749921d25606dee45857d12d2ad5ddb7b5bd7eab12e4b365", size = 494166, upload-time = "2026-06-07T21:09:28.505Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/84/ec80c2c1f66a952555a9f86df6b33af65108a6febfa0471b69013a12f807/aiohttp-3.14.1-cp314-cp314t-win_amd64.whl", hash = "sha256:5e78b522b7a6e27e0b25d19b247b75039ac4c94f99823e3c9e53ae1603a9f7e9", size = 530255, upload-time = "2026-06-07T21:09:30.843Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/71/6e22be134a4061ada85a92951b842f2657f17d926b727f3f94c56ae963d6/aiohttp-3.14.1-cp314-cp314t-win_arm64.whl", hash = "sha256:90d53f1609c29ccc2193945ef732428382a28f78d0456ae4d3daf0d48b74f0f6", size = 469640, upload-time = "2026-06-07T21:09:33.028Z" },
+]
+
+[[package]]
+name = "aiosignal"
+version = "1.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "frozenlist" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/61/62/06741b579156360248d1ec624842ad0edf697050bbaf7c3e46394e106ad1/aiosignal-1.4.0.tar.gz", hash = "sha256:f47eecd9468083c2029cc99945502cb7708b082c232f9aca65da147157b251c7", size = 25007, upload-time = "2025-07-03T22:54:43.528Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fb/76/641ae371508676492379f16e2fa48f4e2c11741bd63c48be4b12a6b09cba/aiosignal-1.4.0-py3-none-any.whl", hash = "sha256:053243f8b92b990551949e63930a839ff0cf0b0ebbe0597b0f3fb19e1a0fe82e", size = 7490, upload-time = "2025-07-03T22:54:42.156Z" },
+]
 
 [[package]]
 name = "annotated-doc"
@@ -62,6 +228,25 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/ee/67/531ea369ba64dcff5ec9c3402f9f51bf748cec26dde048a2f973a4eea7f5/annotated_types-0.7.0.tar.gz", hash = "sha256:aff07c09a53a08bc8cfccb9c85b05f1aa9a2a6f23728d790723543408344ce89", size = 16081, upload-time = "2024-05-20T21:33:25.928Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/78/b6/6307fbef88d9b5ee7421e68d78a9f162e0da4900bc5f5793f6d3d0e34fb8/annotated_types-0.7.0-py3-none-any.whl", hash = "sha256:1f02e8b43a8fbbc3f3e0d4f0f4bfc8131bcb4eebe8849b8e5c773f3a1c582a53", size = 13643, upload-time = "2024-05-20T21:33:24.1Z" },
+]
+
+[[package]]
+name = "anthropic"
+version = "0.109.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "distro" },
+    { name = "docstring-parser" },
+    { name = "httpx" },
+    { name = "jiter" },
+    { name = "pydantic" },
+    { name = "sniffio" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/54/0b/ce24a4f275573f5e436ca954faca60c759d58ed152b8fa36a1e3b888e261/anthropic-0.109.1.tar.gz", hash = "sha256:83e06b3d9d40ff5898f588020e0cc4e42187de954549a3b5fbe6e2685a09c785", size = 927569, upload-time = "2026-06-09T23:55:24.884Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/91/0f/a6110d713370bc92f074a622f8a5ebdec7e92360149b1048dca258a07b2f/anthropic-0.109.1-py3-none-any.whl", hash = "sha256:ce7d94a7657f2aa29338cca448945eac621b4f62c1794cf461cb32847223e9b8", size = 923851, upload-time = "2026-06-09T23:55:23.348Z" },
 ]
 
 [[package]]
@@ -87,6 +272,181 @@ wheels = [
 ]
 
 [[package]]
+name = "authlib"
+version = "1.7.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography" },
+    { name = "joserfc" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/36/98/7d93f30d029643c0275dbc0bd6d5a6f670661ee6c9a94d93af7ab4887600/authlib-1.7.2.tar.gz", hash = "sha256:2cea25fefcd4e7173bdf1372c0afc265c8034b23a8cd5dcb6a9164b826c64231", size = 176511, upload-time = "2026-05-06T08:10:23.116Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fb/95/adcb68e20c34162e9135f370d6e31737719c2b6f94bc953fe7ed1f10fe21/authlib-1.7.2-py2.py3-none-any.whl", hash = "sha256:3e1faedc9d87e7d56a164eca3ccb6ace0d61b94abe83e92242f8dc8bba9b4a9f", size = 259548, upload-time = "2026-05-06T08:10:21.436Z" },
+]
+
+[[package]]
+name = "backoff"
+version = "2.2.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/47/d7/5bbeb12c44d7c4f2fb5b56abce497eb5ed9f34d85701de869acedd602619/backoff-2.2.1.tar.gz", hash = "sha256:03f829f5bb1923180821643f8753b0502c3b682293992485b0eef2807afa5cba", size = 17001, upload-time = "2022-10-05T19:19:32.061Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/73/b6e24bd22e6720ca8ee9a85a0c4a2971af8497d8f3193fa05390cbd46e09/backoff-2.2.1-py3-none-any.whl", hash = "sha256:63579f9a0628e06278f7e47b7d7d5b6ce20dc65c5e96a6f3ca99a6adca0396e8", size = 15148, upload-time = "2022-10-05T19:19:30.546Z" },
+]
+
+[[package]]
+name = "beartype"
+version = "0.22.9"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c7/94/1009e248bbfbab11397abca7193bea6626806be9a327d399810d523a07cb/beartype-0.22.9.tar.gz", hash = "sha256:8f82b54aa723a2848a56008d18875f91c1db02c32ef6a62319a002e3e25a975f", size = 1608866, upload-time = "2025-12-13T06:50:30.72Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/71/cc/18245721fa7747065ab478316c7fea7c74777d07f37ae60db2e84f8172e8/beartype-0.22.9-py3-none-any.whl", hash = "sha256:d16c9bbc61ea14637596c5f6fbff2ee99cbe3573e46a716401734ef50c3060c2", size = 1333658, upload-time = "2025-12-13T06:50:28.266Z" },
+]
+
+[[package]]
+name = "beautifulsoup4"
+version = "4.15.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "soupsieve" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/43/65/318323f98dbee45d42dff61d8f047181bc6f2268a9068cfad035a46be5af/beautifulsoup4-4.15.0.tar.gz", hash = "sha256:288e3ca7d54b06f2ac191970bc275c1939cb46d450b255bf6718b04aa37ab4f7", size = 632571, upload-time = "2026-06-07T16:44:20.453Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/c6/92fcd42f1ba33e1184263f25bfabf3d27c383410470f169e4b8163bf9c17/beautifulsoup4-4.15.0-py3-none-any.whl", hash = "sha256:d6f88de62e1d4e38ecb1077eb9724cd0eff29d2a08ca16a401e9b9e93f117cf9", size = 109924, upload-time = "2026-06-07T16:44:21.566Z" },
+]
+
+[[package]]
+name = "binaryornot"
+version = "0.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/86/72/4755b85101f37707c71526a301c1203e413c715a0016ecb592de3d2dcfff/binaryornot-0.6.0.tar.gz", hash = "sha256:cc8d57cfa71d74ff8c28a7726734d53a851d02fad9e3a5581fb807f989f702f0", size = 478718, upload-time = "2026-03-08T16:26:28.804Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cd/0c/31cfaa6b56fe23488ecb993bc9fc526c0d84d89607decdf2a10776426c2e/binaryornot-0.6.0-py3-none-any.whl", hash = "sha256:900adfd5e1b821255ba7e63139b0396b14c88b9286e74e03b6f51e0200331337", size = 14185, upload-time = "2026-03-08T16:26:27.466Z" },
+]
+
+[[package]]
+name = "browser-use"
+version = "0.11.13"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "aiohttp" },
+    { name = "anthropic" },
+    { name = "anyio" },
+    { name = "authlib" },
+    { name = "browser-use-sdk" },
+    { name = "bubus" },
+    { name = "cdp-use" },
+    { name = "click" },
+    { name = "cloudpickle" },
+    { name = "google-api-core" },
+    { name = "google-api-python-client" },
+    { name = "google-auth" },
+    { name = "google-auth-oauthlib" },
+    { name = "google-genai" },
+    { name = "groq" },
+    { name = "httpx" },
+    { name = "inquirerpy" },
+    { name = "markdownify" },
+    { name = "mcp" },
+    { name = "ollama" },
+    { name = "openai" },
+    { name = "pillow" },
+    { name = "portalocker" },
+    { name = "posthog" },
+    { name = "psutil" },
+    { name = "pydantic" },
+    { name = "pyobjc", marker = "platform_system == 'darwin'" },
+    { name = "pyotp" },
+    { name = "pypdf" },
+    { name = "python-docx" },
+    { name = "python-dotenv" },
+    { name = "reportlab" },
+    { name = "requests" },
+    { name = "rich" },
+    { name = "screeninfo", marker = "platform_system != 'darwin'" },
+    { name = "typing-extensions" },
+    { name = "uuid7" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9f/86/40464b112d01dfedf2433570a6537dea1656715bf8631d18a6eaa2dce28b/browser_use-0.11.13.tar.gz", hash = "sha256:c20d029f17c44add2047a72c836cb589b85e90a31a91cf3632a22a2de1928dfe", size = 628359, upload-time = "2026-02-25T05:20:10.662Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c6/ae/011c8a99708c82a2f8b75c5f24fb62541460fcb648050227db67d361bbe4/browser_use-0.11.13-py3-none-any.whl", hash = "sha256:f5232309213715e66e8f2079fb7097ac79a880728735968e4c7d41031ed15e83", size = 745686, upload-time = "2026-02-25T05:20:11.939Z" },
+]
+
+[[package]]
+name = "browser-use-sdk"
+version = "3.8.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "httpx" },
+    { name = "pydantic" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1e/5b/9f52925c3dc1bc651a67031c3d456ce39731fbca870be55b3fedd5555498/browser_use_sdk-3.8.4.tar.gz", hash = "sha256:9dbabc8971e676c8c454b877ba87142a7cebc39c2b4c2888ff16ad3bed1412f6", size = 203882, upload-time = "2026-06-10T11:18:37.308Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0f/3e/67206e2526e73ad4e4064009d6216000fa5e09381681a11104b868592f30/browser_use_sdk-3.8.4-py3-none-any.whl", hash = "sha256:55f1fd41f6753529ace4b583377b5bf12d61bf85f32abf8bd458e8dd331efa83", size = 64702, upload-time = "2026-06-10T11:18:36.201Z" },
+]
+
+[[package]]
+name = "bubus"
+version = "1.5.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "aiofiles" },
+    { name = "anyio" },
+    { name = "portalocker" },
+    { name = "pydantic" },
+    { name = "typing-extensions" },
+    { name = "uuid7" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/2d/85/aa72d1ffced7402fe41805519dab9935e9ce2bce18a10a55f2273ba8ba59/bubus-1.5.6.tar.gz", hash = "sha256:1a5456f0a576e86613a7bd66e819891b677778320b6e291094e339b0d9df2e0d", size = 60186, upload-time = "2025-08-30T18:20:43.032Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f5/54/23aae0681500a459fc4498b60754cb8ead8df964d8166e5915edb7e8136c/bubus-1.5.6-py3-none-any.whl", hash = "sha256:254ae37cd9299941f5e9d6afb11f8e3ce069f83e5b9476f88c6b2e32912f237d", size = 52121, upload-time = "2025-08-30T18:20:42.091Z" },
+]
+
+[[package]]
+name = "cachetools"
+version = "7.1.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f4/8b/0d3945a13955303b81272f759a0331e54c5c793da455e6f5706b89d2639c/cachetools-7.1.4.tar.gz", hash = "sha256:437f55a4e0c1b01a4f3077cc470e6991d47430970e36fbcb77e2be0df4fc1cd6", size = 40085, upload-time = "2026-05-21T22:40:43.376Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8c/7b/1fc1c09cc0756cf25861a3be10565915953876da48bb228fb9a672b20a42/cachetools-7.1.4-py3-none-any.whl", hash = "sha256:323dc4127934744db5b54eb4924482d7edafbf9554e820d1531c2e08c0e4ef54", size = 16761, upload-time = "2026-05-21T22:40:41.845Z" },
+]
+
+[[package]]
+name = "caio"
+version = "0.9.25"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/92/88/b8527e1b00c1811db339a1df8bd1ae49d146fcea9d6a5c40e3a80aaeb38d/caio-0.9.25.tar.gz", hash = "sha256:16498e7f81d1d0f5a4c0ad3f2540e65fe25691376e0a5bd367f558067113ed10", size = 26781, upload-time = "2025-12-26T15:21:36.501Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d3/25/79c98ebe12df31548ba4eaf44db11b7cad6b3e7b4203718335620939083c/caio-0.9.25-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:fb7ff95af4c31ad3f03179149aab61097a71fd85e05f89b4786de0359dffd044", size = 36983, upload-time = "2025-12-26T15:21:36.075Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/2b/21288691f16d479945968a0a4f2856818c1c5be56881d51d4dac9b255d26/caio-0.9.25-cp312-cp312-manylinux2010_x86_64.manylinux2014_x86_64.manylinux_2_12_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:97084e4e30dfa598449d874c4d8e0c8d5ea17d2f752ef5e48e150ff9d240cd64", size = 82012, upload-time = "2025-12-26T15:22:20.983Z" },
+    { url = "https://files.pythonhosted.org/packages/03/c4/8a1b580875303500a9c12b9e0af58cb82e47f5bcf888c2457742a138273c/caio-0.9.25-cp312-cp312-manylinux_2_34_aarch64.whl", hash = "sha256:4fa69eba47e0f041b9d4f336e2ad40740681c43e686b18b191b6c5f4c5544bfb", size = 81502, upload-time = "2026-03-04T22:08:22.381Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/1c/0fe770b8ffc8362c48134d1592d653a81a3d8748d764bec33864db36319d/caio-0.9.25-cp312-cp312-manylinux_2_34_x86_64.whl", hash = "sha256:6bebf6f079f1341d19f7386db9b8b1f07e8cc15ae13bfdaff573371ba0575d69", size = 80200, upload-time = "2026-03-04T22:08:23.382Z" },
+    { url = "https://files.pythonhosted.org/packages/31/57/5e6ff127e6f62c9f15d989560435c642144aa4210882f9494204bc892305/caio-0.9.25-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:d6c2a3411af97762a2b03840c3cec2f7f728921ff8adda53d7ea2315a8563451", size = 36979, upload-time = "2025-12-26T15:21:35.484Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/9f/f21af50e72117eb528c422d4276cbac11fb941b1b812b182e0a9c70d19c5/caio-0.9.25-cp313-cp313-manylinux2010_x86_64.manylinux2014_x86_64.manylinux_2_12_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:0998210a4d5cd5cb565b32ccfe4e53d67303f868a76f212e002a8554692870e6", size = 81900, upload-time = "2025-12-26T15:22:21.919Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/12/c39ae2a4037cb10ad5eb3578eb4d5f8c1a2575c62bba675f3406b7ef0824/caio-0.9.25-cp313-cp313-manylinux_2_34_aarch64.whl", hash = "sha256:1a177d4777141b96f175fe2c37a3d96dec7911ed9ad5f02bac38aaa1c936611f", size = 81523, upload-time = "2026-03-04T22:08:25.187Z" },
+    { url = "https://files.pythonhosted.org/packages/22/59/f8f2e950eb4f1a5a3883e198dca514b9d475415cb6cd7b78b9213a0dd45a/caio-0.9.25-cp313-cp313-manylinux_2_34_x86_64.whl", hash = "sha256:9ed3cfb28c0e99fec5e208c934e5c157d0866aa9c32aa4dc5e9b6034af6286b7", size = 80243, upload-time = "2026-03-04T22:08:26.449Z" },
+    { url = "https://files.pythonhosted.org/packages/69/ca/a08fdc7efdcc24e6a6131a93c85be1f204d41c58f474c42b0670af8c016b/caio-0.9.25-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:fab6078b9348e883c80a5e14b382e6ad6aabbc4429ca034e76e730cf464269db", size = 36978, upload-time = "2025-12-26T15:21:41.055Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/6c/d4d24f65e690213c097174d26eda6831f45f4734d9d036d81790a27e7b78/caio-0.9.25-cp314-cp314-manylinux2010_x86_64.manylinux2014_x86_64.manylinux_2_12_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:44a6b58e52d488c75cfaa5ecaa404b2b41cc965e6c417e03251e868ecd5b6d77", size = 81832, upload-time = "2025-12-26T15:22:22.757Z" },
+    { url = "https://files.pythonhosted.org/packages/87/a4/e534cf7d2d0e8d880e25dd61e8d921ffcfe15bd696734589826f5a2df727/caio-0.9.25-cp314-cp314-manylinux_2_34_aarch64.whl", hash = "sha256:628a630eb7fb22381dd8e3c8ab7f59e854b9c806639811fc3f4310c6bd711d79", size = 81565, upload-time = "2026-03-04T22:08:27.483Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/ed/bf81aeac1d290017e5e5ac3e880fd56ee15e50a6d0353986799d1bc5cfd5/caio-0.9.25-cp314-cp314-manylinux_2_34_x86_64.whl", hash = "sha256:0ba16aa605ccb174665357fc729cf500679c2d94d5f1458a6f0d5ca48f2060a7", size = 80071, upload-time = "2026-03-04T22:08:28.751Z" },
+    { url = "https://files.pythonhosted.org/packages/86/93/1f76c8d1bafe3b0614e06b2195784a3765bbf7b0a067661af9e2dd47fc33/caio-0.9.25-py3-none-any.whl", hash = "sha256:06c0bb02d6b929119b1cfbe1ca403c768b2013a369e2db46bfa2a5761cf82e40", size = 19087, upload-time = "2025-12-26T15:22:00.221Z" },
+]
+
+[[package]]
+name = "cdp-use"
+version = "1.4.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "httpx" },
+    { name = "typing-extensions" },
+    { name = "websockets" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f7/7a/c549417e8c5e4dface6d5d828cd7dc72502dcea33a99f5324abf5a853ce9/cdp_use-1.4.5.tar.gz", hash = "sha256:0da3a32df46336a03ff5a22bc6bc442cd7d2f2d50a118fd4856f29d37f6d26a0", size = 193961, upload-time = "2026-02-22T04:32:50.574Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/56/12/386d8c6bf0448c43674e24d6194c3b57d62e5361e90bca3d58108819ad32/cdp_use-1.4.5-py3-none-any.whl", hash = "sha256:8f8e2435e3a20e4009d2974144192cf3c132f6c2971338e156198814d9b91ecb", size = 350504, upload-time = "2026-02-22T04:32:49.22Z" },
+]
+
+[[package]]
 name = "certifi"
 version = "2026.4.22"
 source = { registry = "https://pypi.org/simple" }
@@ -104,19 +464,6 @@ dependencies = [
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/eb/56/b1ba7935a17738ae8453301356628e8147c79dbb825bcbc73dc7401f9846/cffi-2.0.0.tar.gz", hash = "sha256:44d1b5909021139fe36001ae048dbdde8214afa20200eda0f64c068cac5d5529", size = 523588, upload-time = "2025-09-08T23:24:04.541Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/12/4a/3dfd5f7850cbf0d06dc84ba9aa00db766b52ca38d8b86e3a38314d52498c/cffi-2.0.0-cp311-cp311-macosx_10_13_x86_64.whl", hash = "sha256:b4c854ef3adc177950a8dfc81a86f5115d2abd545751a304c5bcf2c2c7283cfe", size = 184344, upload-time = "2025-09-08T23:22:26.456Z" },
-    { url = "https://files.pythonhosted.org/packages/4f/8b/f0e4c441227ba756aafbe78f117485b25bb26b1c059d01f137fa6d14896b/cffi-2.0.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:2de9a304e27f7596cd03d16f1b7c72219bd944e99cc52b84d0145aefb07cbd3c", size = 180560, upload-time = "2025-09-08T23:22:28.197Z" },
-    { url = "https://files.pythonhosted.org/packages/b1/b7/1200d354378ef52ec227395d95c2576330fd22a869f7a70e88e1447eb234/cffi-2.0.0-cp311-cp311-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:baf5215e0ab74c16e2dd324e8ec067ef59e41125d3eade2b863d294fd5035c92", size = 209613, upload-time = "2025-09-08T23:22:29.475Z" },
-    { url = "https://files.pythonhosted.org/packages/b8/56/6033f5e86e8cc9bb629f0077ba71679508bdf54a9a5e112a3c0b91870332/cffi-2.0.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:730cacb21e1bdff3ce90babf007d0a0917cc3e6492f336c2f0134101e0944f93", size = 216476, upload-time = "2025-09-08T23:22:31.063Z" },
-    { url = "https://files.pythonhosted.org/packages/dc/7f/55fecd70f7ece178db2f26128ec41430d8720f2d12ca97bf8f0a628207d5/cffi-2.0.0-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:6824f87845e3396029f3820c206e459ccc91760e8fa24422f8b0c3d1731cbec5", size = 203374, upload-time = "2025-09-08T23:22:32.507Z" },
-    { url = "https://files.pythonhosted.org/packages/84/ef/a7b77c8bdc0f77adc3b46888f1ad54be8f3b7821697a7b89126e829e676a/cffi-2.0.0-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:9de40a7b0323d889cf8d23d1ef214f565ab154443c42737dfe52ff82cf857664", size = 202597, upload-time = "2025-09-08T23:22:34.132Z" },
-    { url = "https://files.pythonhosted.org/packages/d7/91/500d892b2bf36529a75b77958edfcd5ad8e2ce4064ce2ecfeab2125d72d1/cffi-2.0.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:8941aaadaf67246224cee8c3803777eed332a19d909b47e29c9842ef1e79ac26", size = 215574, upload-time = "2025-09-08T23:22:35.443Z" },
-    { url = "https://files.pythonhosted.org/packages/44/64/58f6255b62b101093d5df22dcb752596066c7e89dd725e0afaed242a61be/cffi-2.0.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:a05d0c237b3349096d3981b727493e22147f934b20f6f125a3eba8f994bec4a9", size = 218971, upload-time = "2025-09-08T23:22:36.805Z" },
-    { url = "https://files.pythonhosted.org/packages/ab/49/fa72cebe2fd8a55fbe14956f9970fe8eb1ac59e5df042f603ef7c8ba0adc/cffi-2.0.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:94698a9c5f91f9d138526b48fe26a199609544591f859c870d477351dc7b2414", size = 211972, upload-time = "2025-09-08T23:22:38.436Z" },
-    { url = "https://files.pythonhosted.org/packages/0b/28/dd0967a76aab36731b6ebfe64dec4e981aff7e0608f60c2d46b46982607d/cffi-2.0.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:5fed36fccc0612a53f1d4d9a816b50a36702c28a2aa880cb8a122b3466638743", size = 217078, upload-time = "2025-09-08T23:22:39.776Z" },
-    { url = "https://files.pythonhosted.org/packages/2b/c0/015b25184413d7ab0a410775fdb4a50fca20f5589b5dab1dbbfa3baad8ce/cffi-2.0.0-cp311-cp311-win32.whl", hash = "sha256:c649e3a33450ec82378822b3dad03cc228b8f5963c0c12fc3b1e0ab940f768a5", size = 172076, upload-time = "2025-09-08T23:22:40.95Z" },
-    { url = "https://files.pythonhosted.org/packages/ae/8f/dc5531155e7070361eb1b7e4c1a9d896d0cb21c49f807a6c03fd63fc877e/cffi-2.0.0-cp311-cp311-win_amd64.whl", hash = "sha256:66f011380d0e49ed280c789fbd08ff0d40968ee7b665575489afa95c98196ab5", size = 182820, upload-time = "2025-09-08T23:22:42.463Z" },
-    { url = "https://files.pythonhosted.org/packages/95/5c/1b493356429f9aecfd56bc171285a4c4ac8697f76e9bbbbb105e537853a1/cffi-2.0.0-cp311-cp311-win_arm64.whl", hash = "sha256:c6638687455baf640e37344fe26d37c404db8b80d037c3d29f58fe8d1c3b194d", size = 177635, upload-time = "2025-09-08T23:22:43.623Z" },
     { url = "https://files.pythonhosted.org/packages/ea/47/4f61023ea636104d4f16ab488e268b93008c3d0bb76893b1b31db1f96802/cffi-2.0.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:6d02d6655b0e54f54c4ef0b94eb6be0607b70853c45ce98bd278dc7de718be5d", size = 185271, upload-time = "2025-09-08T23:22:44.795Z" },
     { url = "https://files.pythonhosted.org/packages/df/a2/781b623f57358e360d62cdd7a8c681f074a71d445418a776eef0aadb4ab4/cffi-2.0.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:8eca2a813c1cb7ad4fb74d368c2ffbbb4789d377ee5bb8df98373c2cc0dee76c", size = 181048, upload-time = "2025-09-08T23:22:45.938Z" },
     { url = "https://files.pythonhosted.org/packages/ff/df/a4f0fbd47331ceeba3d37c2e51e9dfc9722498becbeec2bd8bc856c9538a/cffi-2.0.0-cp312-cp312-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:21d1152871b019407d8ac3985f6775c079416c282e431a4da6afe7aefd2bccbe", size = 212529, upload-time = "2025-09-08T23:22:47.349Z" },
@@ -171,22 +518,6 @@ version = "3.4.7"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/e7/a1/67fe25fac3c7642725500a3f6cfe5821ad557c3abb11c9d20d12c7008d3e/charset_normalizer-3.4.7.tar.gz", hash = "sha256:ae89db9e5f98a11a4bf50407d4363e7b09b31e55bc117b4f7d80aab97ba009e5", size = 144271, upload-time = "2026-04-02T09:28:39.342Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c2/d7/b5b7020a0565c2e9fa8c09f4b5fa6232feb326b8c20081ccded47ea368fd/charset_normalizer-3.4.7-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:7641bb8895e77f921102f72833904dcd9901df5d6d72a2ab8f31d04b7e51e4e7", size = 309705, upload-time = "2026-04-02T09:26:02.191Z" },
-    { url = "https://files.pythonhosted.org/packages/5a/53/58c29116c340e5456724ecd2fff4196d236b98f3da97b404bc5e51ac3493/charset_normalizer-3.4.7-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:202389074300232baeb53ae2569a60901f7efadd4245cf3a3bf0617d60b439d7", size = 206419, upload-time = "2026-04-02T09:26:03.583Z" },
-    { url = "https://files.pythonhosted.org/packages/b2/02/e8146dc6591a37a00e5144c63f29fb7c97a734ea8a111190783c0e60ab63/charset_normalizer-3.4.7-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:30b8d1d8c52a48c2c5690e152c169b673487a2a58de1ec7393196753063fcd5e", size = 227901, upload-time = "2026-04-02T09:26:04.738Z" },
-    { url = "https://files.pythonhosted.org/packages/fb/73/77486c4cd58f1267bf17db420e930c9afa1b3be3fe8c8b8ebbebc9624359/charset_normalizer-3.4.7-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:532bc9bf33a68613fd7d65e4b1c71a6a38d7d42604ecf239c77392e9b4e8998c", size = 222742, upload-time = "2026-04-02T09:26:06.36Z" },
-    { url = "https://files.pythonhosted.org/packages/a1/fa/f74eb381a7d94ded44739e9d94de18dc5edc9c17fb8c11f0a6890696c0a9/charset_normalizer-3.4.7-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2fe249cb4651fd12605b7288b24751d8bfd46d35f12a20b1ba33dea122e690df", size = 214061, upload-time = "2026-04-02T09:26:08.347Z" },
-    { url = "https://files.pythonhosted.org/packages/dc/92/42bd3cefcf7687253fb86694b45f37b733c97f59af3724f356fa92b8c344/charset_normalizer-3.4.7-cp311-cp311-manylinux_2_31_armv7l.whl", hash = "sha256:65bcd23054beab4d166035cabbc868a09c1a49d1efe458fe8e4361215df40265", size = 199239, upload-time = "2026-04-02T09:26:09.823Z" },
-    { url = "https://files.pythonhosted.org/packages/4c/3d/069e7184e2aa3b3cddc700e3dd267413dc259854adc3380421c805c6a17d/charset_normalizer-3.4.7-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:08e721811161356f97b4059a9ba7bafb23ea5ee2255402c42881c214e173c6b4", size = 210173, upload-time = "2026-04-02T09:26:10.953Z" },
-    { url = "https://files.pythonhosted.org/packages/62/51/9d56feb5f2e7074c46f93e0ebdbe61f0848ee246e2f0d89f8e20b89ebb8f/charset_normalizer-3.4.7-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:e060d01aec0a910bdccb8be71faf34e7799ce36950f8294c8bf612cba65a2c9e", size = 209841, upload-time = "2026-04-02T09:26:12.142Z" },
-    { url = "https://files.pythonhosted.org/packages/d2/59/893d8f99cc4c837dda1fe2f1139079703deb9f321aabcb032355de13b6c7/charset_normalizer-3.4.7-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:38c0109396c4cfc574d502df99742a45c72c08eff0a36158b6f04000043dbf38", size = 200304, upload-time = "2026-04-02T09:26:13.711Z" },
-    { url = "https://files.pythonhosted.org/packages/7d/1d/ee6f3be3464247578d1ed5c46de545ccc3d3ff933695395c402c21fa6b77/charset_normalizer-3.4.7-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:1c2a768fdd44ee4a9339a9b0b130049139b8ce3c01d2ce09f67f5a68048d477c", size = 229455, upload-time = "2026-04-02T09:26:14.941Z" },
-    { url = "https://files.pythonhosted.org/packages/54/bb/8fb0a946296ea96a488928bdce8ef99023998c48e4713af533e9bb98ef07/charset_normalizer-3.4.7-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:1a87ca9d5df6fe460483d9a5bbf2b18f620cbed41b432e2bddb686228282d10b", size = 210036, upload-time = "2026-04-02T09:26:16.478Z" },
-    { url = "https://files.pythonhosted.org/packages/9a/bc/015b2387f913749f82afd4fcba07846d05b6d784dd16123cb66860e0237d/charset_normalizer-3.4.7-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:d635aab80466bc95771bb78d5370e74d36d1fe31467b6b29b8b57b2a3cd7d22c", size = 224739, upload-time = "2026-04-02T09:26:17.751Z" },
-    { url = "https://files.pythonhosted.org/packages/17/ab/63133691f56baae417493cba6b7c641571a2130eb7bceba6773367ab9ec5/charset_normalizer-3.4.7-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:ae196f021b5e7c78e918242d217db021ed2a6ace2bc6ae94c0fc596221c7f58d", size = 216277, upload-time = "2026-04-02T09:26:18.981Z" },
-    { url = "https://files.pythonhosted.org/packages/06/6d/3be70e827977f20db77c12a97e6a9f973631a45b8d186c084527e53e77a4/charset_normalizer-3.4.7-cp311-cp311-win32.whl", hash = "sha256:adb2597b428735679446b46c8badf467b4ca5f5056aae4d51a19f9570301b1ad", size = 147819, upload-time = "2026-04-02T09:26:20.295Z" },
-    { url = "https://files.pythonhosted.org/packages/20/d9/5f67790f06b735d7c7637171bbfd89882ad67201891b7275e51116ed8207/charset_normalizer-3.4.7-cp311-cp311-win_amd64.whl", hash = "sha256:8e385e4267ab76874ae30db04c627faaaf0b509e1ccc11a95b3fc3e83f855c00", size = 159281, upload-time = "2026-04-02T09:26:21.74Z" },
-    { url = "https://files.pythonhosted.org/packages/ca/83/6413f36c5a34afead88ce6f66684d943d91f233d76dd083798f9602b75ae/charset_normalizer-3.4.7-cp311-cp311-win_arm64.whl", hash = "sha256:d4a48e5b3c2a489fae013b7589308a40146ee081f6f509e047e0e096084ceca1", size = 147843, upload-time = "2026-04-02T09:26:22.901Z" },
     { url = "https://files.pythonhosted.org/packages/0c/eb/4fc8d0a7110eb5fc9cc161723a34a8a6c200ce3b4fbf681bc86feee22308/charset_normalizer-3.4.7-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:eca9705049ad3c7345d574e3510665cb2cf844c2f2dcfe675332677f081cbd46", size = 311328, upload-time = "2026-04-02T09:26:24.331Z" },
     { url = "https://files.pythonhosted.org/packages/f8/e3/0fadc706008ac9d7b9b5be6dc767c05f9d3e5df51744ce4cc9605de7b9f4/charset_normalizer-3.4.7-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6178f72c5508bfc5fd446a5905e698c6212932f25bcdd4b47a757a50605a90e2", size = 208061, upload-time = "2026-04-02T09:26:25.568Z" },
     { url = "https://files.pythonhosted.org/packages/42/f0/3dd1045c47f4a4604df85ec18ad093912ae1344ac706993aff91d38773a2/charset_normalizer-3.4.7-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:e1421b502d83040e6d7fb2fb18dff63957f720da3d77b2fbd3187ceb63755d7b", size = 229031, upload-time = "2026-04-02T09:26:26.865Z" },
@@ -267,6 +598,15 @@ wheels = [
 ]
 
 [[package]]
+name = "cloudpickle"
+version = "3.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/27/fb/576f067976d320f5f0114a8d9fa1215425441bb35627b1993e5afd8111e5/cloudpickle-3.1.2.tar.gz", hash = "sha256:7fda9eb655c9c230dab534f1983763de5835249750e85fbcef43aaa30a9a2414", size = 22330, upload-time = "2025-11-03T09:25:26.604Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/39/799be3f2f0f38cc727ee3b4f1445fe6d5e4133064ec2e4115069418a5bb6/cloudpickle-3.1.2-py3-none-any.whl", hash = "sha256:9acb47f6afd73f60dc1df93bb801b472f05ff42fa6c84167d25cb206be1fbf4a", size = 22228, upload-time = "2025-11-03T09:25:25.534Z" },
+]
+
+[[package]]
 name = "colorama"
 version = "0.4.6"
 source = { registry = "https://pypi.org/simple" }
@@ -326,12 +666,46 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/1e/75/a2e55f99c16fcac7b5d6c1eb19ad8e00799854d6be5ca845f9259eae1681/cryptography-48.0.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:a5da777e32ffed6f85a7b2b3f7c5cbc88c146bfcd0a1d7baf5fcc6c52ee35dd4", size = 4960575, upload-time = "2026-05-04T22:59:09.851Z" },
     { url = "https://files.pythonhosted.org/packages/b8/23/6e6f32143ab5d8b36ca848a502c4bcd477ae75b9e1677e3530d669062578/cryptography-48.0.0-cp39-abi3-win32.whl", hash = "sha256:77a2ccbbe917f6710e05ba9adaa25fb5075620bf3ea6fb751997875aff4ae4bd", size = 3279117, upload-time = "2026-05-04T22:59:12.019Z" },
     { url = "https://files.pythonhosted.org/packages/9d/9a/0fea98a70cf1749d41d738836f6349d97945f7c89433a259a6c2642eefeb/cryptography-48.0.0-cp39-abi3-win_amd64.whl", hash = "sha256:16cd65b9330583e4619939b3a3843eec1e6e789744bb01e7c7e2e62e33c239c8", size = 3792100, upload-time = "2026-05-04T22:59:14.884Z" },
-    { url = "https://files.pythonhosted.org/packages/be/d2/024b5e06be9d44cb021fb0e1a03d34d63989cf56a0fe62f3dfbab695b9b4/cryptography-48.0.0-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:84cf79f0dc8b36ac5da873481716e87aef31fcfa0444f9e1d8b4b2cece142855", size = 3950391, upload-time = "2026-05-04T22:59:17.415Z" },
-    { url = "https://files.pythonhosted.org/packages/bc/17/3861e17c56fa0fd37491a14a8673fdb77c57fc5693cafe745ea8b06dba75/cryptography-48.0.0-pp311-pypy311_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:fdfef35d751d510fcef5252703621574364fec16418c4a1e5e1055248401054b", size = 4637126, upload-time = "2026-05-04T22:59:20.197Z" },
-    { url = "https://files.pythonhosted.org/packages/f0/0a/7e226dbff530f21480727eb764973a7bff2b912f8e15cd4f129e71b56d1d/cryptography-48.0.0-pp311-pypy311_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:0890f502ddf7d9c6426129c3f49f5c0a39278ed7cd6322c8755ffca6ee675a13", size = 4667270, upload-time = "2026-05-04T22:59:22.647Z" },
-    { url = "https://files.pythonhosted.org/packages/3b/f2/5a72274ca9f1b2a8b44a662ee0bf1b435909deb473d6f97bcd035bcdbc71/cryptography-48.0.0-pp311-pypy311_pp73-manylinux_2_34_aarch64.whl", hash = "sha256:ecde28a596bead48b0cfd2a1b4416c3d43074c2d785e3a398d7ec1fc4d0f7fbb", size = 4636797, upload-time = "2026-05-04T22:59:24.912Z" },
-    { url = "https://files.pythonhosted.org/packages/b4/e1/48cedb2fe63626e91ded1edad159e2a4fb8b6906c4425eb7749673077ce7/cryptography-48.0.0-pp311-pypy311_pp73-manylinux_2_34_x86_64.whl", hash = "sha256:4defde8685ae324a9eb9d818717e93b4638ef67070ac9bc15b8ca85f63048355", size = 4666800, upload-time = "2026-05-04T22:59:27.474Z" },
-    { url = "https://files.pythonhosted.org/packages/a2/ca/7e8365deec19afb2b2c7be7c1c0aa8f99633b54e90c570999acda93260fc/cryptography-48.0.0-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:db63bf618e5dea46c07de12e900fe1cdd2541e6dc9dbae772a70b7d4d4765f6a", size = 3739536, upload-time = "2026-05-04T22:59:29.61Z" },
+]
+
+[[package]]
+name = "cyclopts"
+version = "4.18.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "docstring-parser" },
+    { name = "rich" },
+    { name = "rich-rst" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9a/19/5c438b428b3dca208eb920804dc16aeb3ca1e85d6163d17e8fb0785ead19/cyclopts-4.18.0.tar.gz", hash = "sha256:fb7b730f21932e0784f7e54462df0447aaa1fbf034d65b605bd8a25dce58b188", size = 182821, upload-time = "2026-06-11T19:55:05.326Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5d/9f/b67f14c6b686ca90d317c0358f1a52ae171f43f83c808683fae3ba0b1f90/cyclopts-4.18.0-py3-none-any.whl", hash = "sha256:18ba2912e48e890a97ecc8a05c9beddf30a407b43f4e14cccfd40efddc41f029", size = 221216, upload-time = "2026-06-11T19:55:03.773Z" },
+]
+
+[[package]]
+name = "cython"
+version = "3.2.5"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/3f/3b/ebd94c8b85f8e41b5015a9ed94ee3df866024d480d05cd08b774684fb81d/cython-3.2.5.tar.gz", hash = "sha256:3dd42e4cf36ad15f265bdfec2337cc00c688c8eb6d374ffd13bb19437c27bba1", size = 3286381, upload-time = "2026-05-23T19:34:08.439Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/20/a6/efc97000fdb2f34e2431eb09a6ab4de9fbd3bcdb73a8f9d224afa4a9abd3/cython-3.2.5-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:eb38b89e5a8eb2508a1a0832063826b0703dfb02be84e4aa34b8818ce0ca50fe", size = 2979670, upload-time = "2026-05-23T19:34:41.281Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/30/f648409de61fd74ae63090071061145059664cc9b9ff8578197601a3beb6/cython-3.2.5-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:6e5d7a60835345a8bd29d3aa57070880cc3ce017ea0ade7b9f771ce4bf539b1f", size = 2968935, upload-time = "2026-05-23T19:34:49Z" },
+    { url = "https://files.pythonhosted.org/packages/82/78/668ef887621f68255feddd482dbcdcf5788b6c91227dd35bd17f128f827b/cython-3.2.5-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:a636c8b7824f3cb587eb2fdde59d8f4a14d433565508081cc290198e37567910", size = 2981525, upload-time = "2026-05-23T19:34:58.445Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/de/e3e0cf5704fe569d54b8cd5dc316c9fbf08b1b74728732f86e90168b7a3f/cython-3.2.5-cp39-abi3-macosx_10_9_x86_64.whl", hash = "sha256:224149d18d980e6ea5001b70fc7ce096c1891d59035dfa9cc5ede50f55804913", size = 2879054, upload-time = "2026-05-23T19:35:18.265Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/5c/9cd909e6a8bb178e4e0f9a2a9227c8201a2be38abe45ada4a4c3e9154277/cython-3.2.5-py3-none-any.whl", hash = "sha256:dc1c8cebb7df5bce37f5f8dc1e5bf04313272a5973d50a55c0ec76c83812911b", size = 1257622, upload-time = "2026-05-23T19:34:05.163Z" },
+]
+
+[[package]]
+name = "deprecation"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "packaging" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5a/d3/8ae2869247df154b64c1884d7346d412fed0c49df84db635aab2d1c40e62/deprecation-2.1.0.tar.gz", hash = "sha256:72b3bde64e5d778694b0cf68178aed03d15e15477116add3fb773e581f9518ff", size = 173788, upload-time = "2020-04-20T14:23:38.738Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/02/c3/253a89ee03fc9b9682f1541728eb66db7db22148cd94f89ab22528cd1e1b/deprecation-2.1.0-py2.py3-none-any.whl", hash = "sha256:a10811591210e1fb0e768a8c25517cabeabcba6f0bf96564f8ff45189f90b14a", size = 11178, upload-time = "2020-04-20T14:23:36.581Z" },
 ]
 
 [[package]]
@@ -341,6 +715,67 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/fc/f8/98eea607f65de6527f8a2e8885fc8015d3e6f5775df186e443e0964a11c3/distro-1.9.0.tar.gz", hash = "sha256:2fa77c6fd8940f116ee1d6b94a2f90b13b5ea8d019b98bc8bafdcabcdd9bdbed", size = 60722, upload-time = "2023-12-24T09:54:32.31Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/12/b3/231ffd4ab1fc9d679809f356cebee130ac7daa00d6d6f3206dd4fd137e9e/distro-1.9.0-py3-none-any.whl", hash = "sha256:7bffd925d65168f85027d8da9af6bddab658135b840670a223589bc0c8ef02b2", size = 20277, upload-time = "2023-12-24T09:54:30.421Z" },
+]
+
+[[package]]
+name = "dnspython"
+version = "2.8.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8c/8b/57666417c0f90f08bcafa776861060426765fdb422eb10212086fb811d26/dnspython-2.8.0.tar.gz", hash = "sha256:181d3c6996452cb1189c4046c61599b84a5a86e099562ffde77d26984ff26d0f", size = 368251, upload-time = "2025-09-07T18:58:00.022Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ba/5a/18ad964b0086c6e62e2e7500f7edc89e3faa45033c71c1893d34eed2b2de/dnspython-2.8.0-py3-none-any.whl", hash = "sha256:01d9bbc4a2d76bf0db7c1f729812ded6d912bd318d3b1cf81d30c0f845dbf3af", size = 331094, upload-time = "2025-09-07T18:57:58.071Z" },
+]
+
+[[package]]
+name = "docstring-parser"
+version = "0.18.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e0/4d/f332313098c1de1b2d2ff91cf2674415cc7cddab2ca1b01ae29774bd5fdf/docstring_parser-0.18.0.tar.gz", hash = "sha256:292510982205c12b1248696f44959db3cdd1740237a968ea1e2e7a900eeb2015", size = 29341, upload-time = "2026-04-14T04:09:19.867Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a7/5f/ed01f9a3cdffbd5a008556fc7b2a08ddb1cc6ace7effa7340604b1d16699/docstring_parser-0.18.0-py3-none-any.whl", hash = "sha256:b3fcbed555c47d8479be0796ef7e19c2670d428d72e96da63f3a40122860374b", size = 22484, upload-time = "2026-04-14T04:09:18.638Z" },
+]
+
+[[package]]
+name = "email-validator"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "dnspython" },
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f5/22/900cb125c76b7aaa450ce02fd727f452243f2e91a61af068b40adba60ea9/email_validator-2.3.0.tar.gz", hash = "sha256:9fc05c37f2f6cf439ff414f8fc46d917929974a82244c20eb10231ba60c54426", size = 51238, upload-time = "2025-08-26T13:09:06.831Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/de/15/545e2b6cf2e3be84bc1ed85613edd75b8aea69807a71c26f4ca6a9258e82/email_validator-2.3.0-py3-none-any.whl", hash = "sha256:80f13f623413e6b197ae73bb10bf4eb0908faf509ad8362c5edeb0be7fd450b4", size = 35604, upload-time = "2025-08-26T13:09:05.858Z" },
+]
+
+[[package]]
+name = "exceptiongroup"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8a/0e/97c33bf5009bdbac74fd2beace167cab3f978feb69cc36f1ef79360d6c4e/exceptiongroup-1.3.1-py3-none-any.whl", hash = "sha256:a7a39a3bd276781e98394987d3a5701d0c4edffb633bb7a5144577f82c773598", size = 16740, upload-time = "2025-11-21T23:01:53.443Z" },
+]
+
+[[package]]
+name = "fakeredis"
+version = "2.36.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "redis" },
+    { name = "sortedcontainers" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1f/48/c08ec5c1d0d16e15247787b83d9b2a9cb1f1a27514cd85407956040cc383/fakeredis-2.36.1.tar.gz", hash = "sha256:7240567f4e1c07a2b3d30c0fd88e5e598e948c2e25850a560727de1d1d3dc946", size = 210959, upload-time = "2026-06-07T16:11:50.033Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c7/94/1f993adaa735f2922d991e1e66e64f2de1bf044bee601d03dde5b71513d4/fakeredis-2.36.1-py3-none-any.whl", hash = "sha256:220a77bebb985c59076951336478c4c983be76b5d9f44d3011dd61171d082062", size = 139357, upload-time = "2026-06-07T16:11:48.418Z" },
+]
+
+[package.optional-dependencies]
+lua = [
+    { name = "lupa" },
 ]
 
 [[package]]
@@ -360,12 +795,435 @@ wheels = [
 ]
 
 [[package]]
+name = "fastmcp"
+version = "3.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "fastmcp-slim", extra = ["client", "server"] },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/64/24/519739e98daf92ebc64580e9d3320649bf9a1612c029a913dd88c3474d73/fastmcp-3.4.0.tar.gz", hash = "sha256:29055fb6816f4862c615aabaf0112ae8feb8b469740db13403a0ce5b799ec1dc", size = 28754939, upload-time = "2026-06-03T02:32:40.206Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e9/72/9f9bbfc3a8d26870dbdbbd633cd1c6f42b8d3bec379426c760676d936e86/fastmcp-3.4.0-py3-none-any.whl", hash = "sha256:34523083d6149400a0655a8aa769eb34f85b1ce6dac6d66efb07503ebbe5f44b", size = 8017, upload-time = "2026-06-03T02:32:38.05Z" },
+]
+
+[[package]]
+name = "fastmcp-slim"
+version = "3.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "platformdirs" },
+    { name = "pydantic", extra = ["email"] },
+    { name = "pydantic-settings" },
+    { name = "python-dotenv" },
+    { name = "rich" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e7/b0/4da6078c2d6aa0a38a8b1ae0271e1ed400f9e2cd1b3b46e6453fb1fe2b75/fastmcp_slim-3.4.0.tar.gz", hash = "sha256:faa0ccf16e85ec4b9f79c006fed3546b866d7e6dba3f60cd32cd98e84753a496", size = 575895, upload-time = "2026-06-03T02:32:18.744Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/58/66/cc283d4efd3faf325c26f51cfb43a118270ea732e70dda509f49d80ea625/fastmcp_slim-3.4.0-py3-none-any.whl", hash = "sha256:17cd0a1535972d3748d8c2416f0826dfc86c18df7a6cbc38602373277d44baa6", size = 748849, upload-time = "2026-06-03T02:32:17.435Z" },
+]
+
+[package.optional-dependencies]
+client = [
+    { name = "authlib" },
+    { name = "exceptiongroup" },
+    { name = "httpx" },
+    { name = "mcp" },
+    { name = "opentelemetry-api" },
+    { name = "py-key-value-aio", extra = ["filetree", "keyring", "memory"] },
+]
+server = [
+    { name = "authlib" },
+    { name = "cyclopts" },
+    { name = "exceptiongroup" },
+    { name = "griffelib" },
+    { name = "httpx" },
+    { name = "joserfc" },
+    { name = "jsonref" },
+    { name = "jsonschema-path" },
+    { name = "mcp" },
+    { name = "openapi-pydantic" },
+    { name = "opentelemetry-api" },
+    { name = "packaging" },
+    { name = "py-key-value-aio", extra = ["filetree", "keyring", "memory"] },
+    { name = "pyperclip" },
+    { name = "python-multipart" },
+    { name = "pyyaml" },
+    { name = "uncalled-for" },
+    { name = "uvicorn" },
+    { name = "watchfiles" },
+    { name = "websockets" },
+]
+
+[[package]]
+name = "fastuuid"
+version = "0.14.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/7d/d9daedf0f2ebcacd20d599928f8913e9d2aea1d56d2d355a93bfa2b611d7/fastuuid-0.14.0.tar.gz", hash = "sha256:178947fc2f995b38497a74172adee64fdeb8b7ec18f2a5934d037641ba265d26", size = 18232, upload-time = "2025-10-19T22:19:22.402Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/02/a2/e78fcc5df65467f0d207661b7ef86c5b7ac62eea337c0c0fcedbeee6fb13/fastuuid-0.14.0-cp312-cp312-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:77e94728324b63660ebf8adb27055e92d2e4611645bf12ed9d88d30486471d0a", size = 510164, upload-time = "2025-10-19T22:31:45.635Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/b3/c846f933f22f581f558ee63f81f29fa924acd971ce903dab1a9b6701816e/fastuuid-0.14.0-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:caa1f14d2102cb8d353096bc6ef6c13b2c81f347e6ab9d6fbd48b9dea41c153d", size = 261837, upload-time = "2025-10-19T22:38:38.53Z" },
+    { url = "https://files.pythonhosted.org/packages/54/ea/682551030f8c4fa9a769d9825570ad28c0c71e30cf34020b85c1f7ee7382/fastuuid-0.14.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:d23ef06f9e67163be38cece704170486715b177f6baae338110983f99a72c070", size = 251370, upload-time = "2025-10-19T22:40:26.07Z" },
+    { url = "https://files.pythonhosted.org/packages/14/dd/5927f0a523d8e6a76b70968e6004966ee7df30322f5fc9b6cdfb0276646a/fastuuid-0.14.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0c9ec605ace243b6dbe3bd27ebdd5d33b00d8d1d3f580b39fdd15cd96fd71796", size = 277766, upload-time = "2025-10-19T22:37:23.779Z" },
+    { url = "https://files.pythonhosted.org/packages/16/6e/c0fb547eef61293153348f12e0f75a06abb322664b34a1573a7760501336/fastuuid-0.14.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:808527f2407f58a76c916d6aa15d58692a4a019fdf8d4c32ac7ff303b7d7af09", size = 278105, upload-time = "2025-10-19T22:26:56.821Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/b1/b9c75e03b768f61cf2e84ee193dc18601aeaf89a4684b20f2f0e9f52b62c/fastuuid-0.14.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:2fb3c0d7fef6674bbeacdd6dbd386924a7b60b26de849266d1ff6602937675c8", size = 301564, upload-time = "2025-10-19T22:30:31.604Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/fa/f7395fdac07c7a54f18f801744573707321ca0cee082e638e36452355a9d/fastuuid-0.14.0-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:ab3f5d36e4393e628a4df337c2c039069344db5f4b9d2a3c9cea48284f1dd741", size = 459659, upload-time = "2025-10-19T22:31:32.341Z" },
+    { url = "https://files.pythonhosted.org/packages/66/49/c9fd06a4a0b1f0f048aacb6599e7d96e5d6bc6fa680ed0d46bf111929d1b/fastuuid-0.14.0-cp312-cp312-musllinux_1_1_i686.whl", hash = "sha256:b9a0ca4f03b7e0b01425281ffd44e99d360e15c895f1907ca105854ed85e2057", size = 478430, upload-time = "2025-10-19T22:26:22.962Z" },
+    { url = "https://files.pythonhosted.org/packages/be/9c/909e8c95b494e8e140e8be6165d5fc3f61fdc46198c1554df7b3e1764471/fastuuid-0.14.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:3acdf655684cc09e60fb7e4cf524e8f42ea760031945aa8086c7eae2eeeabeb8", size = 450894, upload-time = "2025-10-19T22:27:01.647Z" },
+    { url = "https://files.pythonhosted.org/packages/90/eb/d29d17521976e673c55ef7f210d4cdd72091a9ec6755d0fd4710d9b3c871/fastuuid-0.14.0-cp312-cp312-win32.whl", hash = "sha256:9579618be6280700ae36ac42c3efd157049fe4dd40ca49b021280481c78c3176", size = 154374, upload-time = "2025-10-19T22:29:19.879Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/fc/f5c799a6ea6d877faec0472d0b27c079b47c86b1cdc577720a5386483b36/fastuuid-0.14.0-cp312-cp312-win_amd64.whl", hash = "sha256:d9e4332dc4ba054434a9594cbfaf7823b57993d7d8e7267831c3e059857cf397", size = 156550, upload-time = "2025-10-19T22:27:49.658Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/83/ae12dd39b9a39b55d7f90abb8971f1a5f3c321fd72d5aa83f90dc67fe9ed/fastuuid-0.14.0-cp313-cp313-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:77a09cb7427e7af74c594e409f7731a0cf887221de2f698e1ca0ebf0f3139021", size = 510720, upload-time = "2025-10-19T22:42:34.633Z" },
+    { url = "https://files.pythonhosted.org/packages/53/b0/a4b03ff5d00f563cc7546b933c28cb3f2a07344b2aec5834e874f7d44143/fastuuid-0.14.0-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:9bd57289daf7b153bfa3e8013446aa144ce5e8c825e9e366d455155ede5ea2dc", size = 262024, upload-time = "2025-10-19T22:30:25.482Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/6d/64aee0a0f6a58eeabadd582e55d0d7d70258ffdd01d093b30c53d668303b/fastuuid-0.14.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:ac60fc860cdf3c3f327374db87ab8e064c86566ca8c49d2e30df15eda1b0c2d5", size = 251679, upload-time = "2025-10-19T22:36:14.096Z" },
+    { url = "https://files.pythonhosted.org/packages/60/f5/a7e9cda8369e4f7919d36552db9b2ae21db7915083bc6336f1b0082c8b2e/fastuuid-0.14.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ab32f74bd56565b186f036e33129da77db8be09178cd2f5206a5d4035fb2a23f", size = 277862, upload-time = "2025-10-19T22:36:23.302Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/d3/8ce11827c783affffd5bd4d6378b28eb6cc6d2ddf41474006b8d62e7448e/fastuuid-0.14.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:33e678459cf4addaedd9936bbb038e35b3f6b2061330fd8f2f6a1d80414c0f87", size = 278278, upload-time = "2025-10-19T22:29:43.809Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/51/680fb6352d0bbade04036da46264a8001f74b7484e2fd1f4da9e3db1c666/fastuuid-0.14.0-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:1e3cc56742f76cd25ecb98e4b82a25f978ccffba02e4bdce8aba857b6d85d87b", size = 301788, upload-time = "2025-10-19T22:36:06.825Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/7c/2014b5785bd8ebdab04ec857635ebd84d5ee4950186a577db9eff0fb8ff6/fastuuid-0.14.0-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:cb9a030f609194b679e1660f7e32733b7a0f332d519c5d5a6a0a580991290022", size = 459819, upload-time = "2025-10-19T22:35:31.623Z" },
+    { url = "https://files.pythonhosted.org/packages/01/d2/524d4ceeba9160e7a9bc2ea3e8f4ccf1ad78f3bde34090ca0c51f09a5e91/fastuuid-0.14.0-cp313-cp313-musllinux_1_1_i686.whl", hash = "sha256:09098762aad4f8da3a888eb9ae01c84430c907a297b97166b8abc07b640f2995", size = 478546, upload-time = "2025-10-19T22:26:03.023Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/17/354d04951ce114bf4afc78e27a18cfbd6ee319ab1829c2d5fb5e94063ac6/fastuuid-0.14.0-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:1383fff584fa249b16329a059c68ad45d030d5a4b70fb7c73a08d98fd53bcdab", size = 450921, upload-time = "2025-10-19T22:31:02.151Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/be/d7be8670151d16d88f15bb121c5b66cdb5ea6a0c2a362d0dcf30276ade53/fastuuid-0.14.0-cp313-cp313-win32.whl", hash = "sha256:a0809f8cc5731c066c909047f9a314d5f536c871a7a22e815cc4967c110ac9ad", size = 154559, upload-time = "2025-10-19T22:36:36.011Z" },
+    { url = "https://files.pythonhosted.org/packages/22/1d/5573ef3624ceb7abf4a46073d3554e37191c868abc3aecd5289a72f9810a/fastuuid-0.14.0-cp313-cp313-win_amd64.whl", hash = "sha256:0df14e92e7ad3276327631c9e7cec09e32572ce82089c55cb1bb8df71cf394ed", size = 156539, upload-time = "2025-10-19T22:33:35.898Z" },
+    { url = "https://files.pythonhosted.org/packages/16/c9/8c7660d1fe3862e3f8acabd9be7fc9ad71eb270f1c65cce9a2b7a31329ab/fastuuid-0.14.0-cp314-cp314-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:b852a870a61cfc26c884af205d502881a2e59cc07076b60ab4a951cc0c94d1ad", size = 510600, upload-time = "2025-10-19T22:43:44.17Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/f4/a989c82f9a90d0ad995aa957b3e572ebef163c5299823b4027986f133dfb/fastuuid-0.14.0-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:c7502d6f54cd08024c3ea9b3514e2d6f190feb2f46e6dbcd3747882264bb5f7b", size = 262069, upload-time = "2025-10-19T22:43:38.38Z" },
+    { url = "https://files.pythonhosted.org/packages/da/6c/a1a24f73574ac995482b1326cf7ab41301af0fabaa3e37eeb6b3df00e6e2/fastuuid-0.14.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:1ca61b592120cf314cfd66e662a5b54a578c5a15b26305e1b8b618a6f22df714", size = 251543, upload-time = "2025-10-19T22:32:22.537Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/20/2a9b59185ba7a6c7b37808431477c2d739fcbdabbf63e00243e37bd6bf49/fastuuid-0.14.0-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:aa75b6657ec129d0abded3bec745e6f7ab642e6dba3a5272a68247e85f5f316f", size = 277798, upload-time = "2025-10-19T22:33:53.821Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/33/4105ca574f6ded0af6a797d39add041bcfb468a1255fbbe82fcb6f592da2/fastuuid-0.14.0-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a8a0dfea3972200f72d4c7df02c8ac70bad1bb4c58d7e0ec1e6f341679073a7f", size = 278283, upload-time = "2025-10-19T22:29:02.812Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/8c/fca59f8e21c4deb013f574eae05723737ddb1d2937ce87cb2a5d20992dc3/fastuuid-0.14.0-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:1bf539a7a95f35b419f9ad105d5a8a35036df35fdafae48fb2fd2e5f318f0d75", size = 301627, upload-time = "2025-10-19T22:35:54.985Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/e2/f78c271b909c034d429218f2798ca4e89eeda7983f4257d7865976ddbb6c/fastuuid-0.14.0-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:9a133bf9cc78fdbd1179cb58a59ad0100aa32d8675508150f3658814aeefeaa4", size = 459778, upload-time = "2025-10-19T22:28:00.999Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/f0/5ff209d865897667a2ff3e7a572267a9ced8f7313919f6d6043aed8b1caa/fastuuid-0.14.0-cp314-cp314-musllinux_1_1_i686.whl", hash = "sha256:f54d5b36c56a2d5e1a31e73b950b28a0d83eb0c37b91d10408875a5a29494bad", size = 478605, upload-time = "2025-10-19T22:36:21.764Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/c8/2ce1c78f983a2c4987ea865d9516dbdfb141a120fd3abb977ae6f02ba7ca/fastuuid-0.14.0-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:ec27778c6ca3393ef662e2762dba8af13f4ec1aaa32d08d77f71f2a70ae9feb8", size = 450837, upload-time = "2025-10-19T22:34:37.178Z" },
+    { url = "https://files.pythonhosted.org/packages/df/60/dad662ec9a33b4a5fe44f60699258da64172c39bd041da2994422cdc40fe/fastuuid-0.14.0-cp314-cp314-win32.whl", hash = "sha256:e23fc6a83f112de4be0cc1990e5b127c27663ae43f866353166f87df58e73d06", size = 154532, upload-time = "2025-10-19T22:35:18.217Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/f6/da4db31001e854025ffd26bc9ba0740a9cbba2c3259695f7c5834908b336/fastuuid-0.14.0-cp314-cp314-win_amd64.whl", hash = "sha256:df61342889d0f5e7a32f7284e55ef95103f2110fee433c2ae7c2c0956d76ac8a", size = 156457, upload-time = "2025-10-19T22:33:44.579Z" },
+]
+
+[[package]]
+name = "filelock"
+version = "3.29.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/91/f5/3557bf28e0f1943e4849154c821533706e6dea010f96fb6aa0b6949037d1/filelock-3.29.3.tar.gz", hash = "sha256:7fc1b3f39cf172fd8203812043c57b8a65aef9969f38b6704f628b881f761a84", size = 61956, upload-time = "2026-06-10T17:37:11.832Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/81/8f/b61d427c4f49a8bdadc93f4e7e74df8a6df6f77ee6e26bf0df53d3925363/filelock-3.29.3-py3-none-any.whl", hash = "sha256:e58333029cc9b925f39aad59b1d8f0a1ad836af4e60d7217f4a4dba87461261d", size = 42324, upload-time = "2026-06-10T17:37:10.37Z" },
+]
+
+[[package]]
+name = "frozenlist"
+version = "1.8.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2d/f5/c831fac6cc817d26fd54c7eaccd04ef7e0288806943f7cc5bbf69f3ac1f0/frozenlist-1.8.0.tar.gz", hash = "sha256:3ede829ed8d842f6cd48fc7081d7a41001a56f1f38603f9d49bf3020d59a31ad", size = 45875, upload-time = "2025-10-06T05:38:17.865Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/69/29/948b9aa87e75820a38650af445d2ef2b6b8a6fab1a23b6bb9e4ef0be2d59/frozenlist-1.8.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:78f7b9e5d6f2fdb88cdde9440dc147259b62b9d3b019924def9f6478be254ac1", size = 87782, upload-time = "2025-10-06T05:36:06.649Z" },
+    { url = "https://files.pythonhosted.org/packages/64/80/4f6e318ee2a7c0750ed724fa33a4bdf1eacdc5a39a7a24e818a773cd91af/frozenlist-1.8.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:229bf37d2e4acdaf808fd3f06e854a4a7a3661e871b10dc1f8f1896a3b05f18b", size = 50594, upload-time = "2025-10-06T05:36:07.69Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/94/5c8a2b50a496b11dd519f4a24cb5496cf125681dd99e94c604ccdea9419a/frozenlist-1.8.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:f833670942247a14eafbb675458b4e61c82e002a148f49e68257b79296e865c4", size = 50448, upload-time = "2025-10-06T05:36:08.78Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/bd/d91c5e39f490a49df14320f4e8c80161cfcce09f1e2cde1edd16a551abb3/frozenlist-1.8.0-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:494a5952b1c597ba44e0e78113a7266e656b9794eec897b19ead706bd7074383", size = 242411, upload-time = "2025-10-06T05:36:09.801Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/83/f61505a05109ef3293dfb1ff594d13d64a2324ac3482be2cedc2be818256/frozenlist-1.8.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:96f423a119f4777a4a056b66ce11527366a8bb92f54e541ade21f2374433f6d4", size = 243014, upload-time = "2025-10-06T05:36:11.394Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/cb/cb6c7b0f7d4023ddda30cf56b8b17494eb3a79e3fda666bf735f63118b35/frozenlist-1.8.0-cp312-cp312-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:3462dd9475af2025c31cc61be6652dfa25cbfb56cbbf52f4ccfe029f38decaf8", size = 234909, upload-time = "2025-10-06T05:36:12.598Z" },
+    { url = "https://files.pythonhosted.org/packages/31/c5/cd7a1f3b8b34af009fb17d4123c5a778b44ae2804e3ad6b86204255f9ec5/frozenlist-1.8.0-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:c4c800524c9cd9bac5166cd6f55285957fcfc907db323e193f2afcd4d9abd69b", size = 250049, upload-time = "2025-10-06T05:36:14.065Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/01/2f95d3b416c584a1e7f0e1d6d31998c4a795f7544069ee2e0962a4b60740/frozenlist-1.8.0-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:d6a5df73acd3399d893dafc71663ad22534b5aa4f94e8a2fabfe856c3c1b6a52", size = 256485, upload-time = "2025-10-06T05:36:15.39Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/03/024bf7720b3abaebcff6d0793d73c154237b85bdf67b7ed55e5e9596dc9a/frozenlist-1.8.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:405e8fe955c2280ce66428b3ca55e12b3c4e9c336fb2103a4937e891c69a4a29", size = 237619, upload-time = "2025-10-06T05:36:16.558Z" },
+    { url = "https://files.pythonhosted.org/packages/69/fa/f8abdfe7d76b731f5d8bd217827cf6764d4f1d9763407e42717b4bed50a0/frozenlist-1.8.0-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:908bd3f6439f2fef9e85031b59fd4f1297af54415fb60e4254a95f75b3cab3f3", size = 250320, upload-time = "2025-10-06T05:36:17.821Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/3c/b051329f718b463b22613e269ad72138cc256c540f78a6de89452803a47d/frozenlist-1.8.0-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:294e487f9ec720bd8ffcebc99d575f7eff3568a08a253d1ee1a0378754b74143", size = 246820, upload-time = "2025-10-06T05:36:19.046Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/ae/58282e8f98e444b3f4dd42448ff36fa38bef29e40d40f330b22e7108f565/frozenlist-1.8.0-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:74c51543498289c0c43656701be6b077f4b265868fa7f8a8859c197006efb608", size = 250518, upload-time = "2025-10-06T05:36:20.763Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/96/007e5944694d66123183845a106547a15944fbbb7154788cbf7272789536/frozenlist-1.8.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:776f352e8329135506a1d6bf16ac3f87bc25b28e765949282dcc627af36123aa", size = 239096, upload-time = "2025-10-06T05:36:22.129Z" },
+    { url = "https://files.pythonhosted.org/packages/66/bb/852b9d6db2fa40be96f29c0d1205c306288f0684df8fd26ca1951d461a56/frozenlist-1.8.0-cp312-cp312-win32.whl", hash = "sha256:433403ae80709741ce34038da08511d4a77062aa924baf411ef73d1146e74faf", size = 39985, upload-time = "2025-10-06T05:36:23.661Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/af/38e51a553dd66eb064cdf193841f16f077585d4d28394c2fa6235cb41765/frozenlist-1.8.0-cp312-cp312-win_amd64.whl", hash = "sha256:34187385b08f866104f0c0617404c8eb08165ab1272e884abc89c112e9c00746", size = 44591, upload-time = "2025-10-06T05:36:24.958Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/06/1dc65480ab147339fecc70797e9c2f69d9cea9cf38934ce08df070fdb9cb/frozenlist-1.8.0-cp312-cp312-win_arm64.whl", hash = "sha256:fe3c58d2f5db5fbd18c2987cba06d51b0529f52bc3a6cdc33d3f4eab725104bd", size = 40102, upload-time = "2025-10-06T05:36:26.333Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/40/0832c31a37d60f60ed79e9dfb5a92e1e2af4f40a16a29abcc7992af9edff/frozenlist-1.8.0-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:8d92f1a84bb12d9e56f818b3a746f3efba93c1b63c8387a73dde655e1e42282a", size = 85717, upload-time = "2025-10-06T05:36:27.341Z" },
+    { url = "https://files.pythonhosted.org/packages/30/ba/b0b3de23f40bc55a7057bd38434e25c34fa48e17f20ee273bbde5e0650f3/frozenlist-1.8.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:96153e77a591c8adc2ee805756c61f59fef4cf4073a9275ee86fe8cba41241f7", size = 49651, upload-time = "2025-10-06T05:36:28.855Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/ab/6e5080ee374f875296c4243c381bbdef97a9ac39c6e3ce1d5f7d42cb78d6/frozenlist-1.8.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:f21f00a91358803399890ab167098c131ec2ddd5f8f5fd5fe9c9f2c6fcd91e40", size = 49417, upload-time = "2025-10-06T05:36:29.877Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/4e/e4691508f9477ce67da2015d8c00acd751e6287739123113a9fca6f1604e/frozenlist-1.8.0-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:fb30f9626572a76dfe4293c7194a09fb1fe93ba94c7d4f720dfae3b646b45027", size = 234391, upload-time = "2025-10-06T05:36:31.301Z" },
+    { url = "https://files.pythonhosted.org/packages/40/76/c202df58e3acdf12969a7895fd6f3bc016c642e6726aa63bd3025e0fc71c/frozenlist-1.8.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:eaa352d7047a31d87dafcacbabe89df0aa506abb5b1b85a2fb91bc3faa02d822", size = 233048, upload-time = "2025-10-06T05:36:32.531Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/c0/8746afb90f17b73ca5979c7a3958116e105ff796e718575175319b5bb4ce/frozenlist-1.8.0-cp313-cp313-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:03ae967b4e297f58f8c774c7eabcce57fe3c2434817d4385c50661845a058121", size = 226549, upload-time = "2025-10-06T05:36:33.706Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/eb/4c7eefc718ff72f9b6c4893291abaae5fbc0c82226a32dcd8ef4f7a5dbef/frozenlist-1.8.0-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:f6292f1de555ffcc675941d65fffffb0a5bcd992905015f85d0592201793e0e5", size = 239833, upload-time = "2025-10-06T05:36:34.947Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/4e/e5c02187cf704224f8b21bee886f3d713ca379535f16893233b9d672ea71/frozenlist-1.8.0-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:29548f9b5b5e3460ce7378144c3010363d8035cea44bc0bf02d57f5a685e084e", size = 245363, upload-time = "2025-10-06T05:36:36.534Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/96/cb85ec608464472e82ad37a17f844889c36100eed57bea094518bf270692/frozenlist-1.8.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:ec3cc8c5d4084591b4237c0a272cc4f50a5b03396a47d9caaf76f5d7b38a4f11", size = 229314, upload-time = "2025-10-06T05:36:38.582Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/6f/4ae69c550e4cee66b57887daeebe006fe985917c01d0fff9caab9883f6d0/frozenlist-1.8.0-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:517279f58009d0b1f2e7c1b130b377a349405da3f7621ed6bfae50b10adf20c1", size = 243365, upload-time = "2025-10-06T05:36:40.152Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/58/afd56de246cf11780a40a2c28dc7cbabbf06337cc8ddb1c780a2d97e88d8/frozenlist-1.8.0-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:db1e72ede2d0d7ccb213f218df6a078a9c09a7de257c2fe8fcef16d5925230b1", size = 237763, upload-time = "2025-10-06T05:36:41.355Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/36/cdfaf6ed42e2644740d4a10452d8e97fa1c062e2a8006e4b09f1b5fd7d63/frozenlist-1.8.0-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:b4dec9482a65c54a5044486847b8a66bf10c9cb4926d42927ec4e8fd5db7fed8", size = 240110, upload-time = "2025-10-06T05:36:42.716Z" },
+    { url = "https://files.pythonhosted.org/packages/03/a8/9ea226fbefad669f11b52e864c55f0bd57d3c8d7eb07e9f2e9a0b39502e1/frozenlist-1.8.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:21900c48ae04d13d416f0e1e0c4d81f7931f73a9dfa0b7a8746fb2fe7dd970ed", size = 233717, upload-time = "2025-10-06T05:36:44.251Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/0b/1b5531611e83ba7d13ccc9988967ea1b51186af64c42b7a7af465dcc9568/frozenlist-1.8.0-cp313-cp313-win32.whl", hash = "sha256:8b7b94a067d1c504ee0b16def57ad5738701e4ba10cec90529f13fa03c833496", size = 39628, upload-time = "2025-10-06T05:36:45.423Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/cf/174c91dbc9cc49bc7b7aab74d8b734e974d1faa8f191c74af9b7e80848e6/frozenlist-1.8.0-cp313-cp313-win_amd64.whl", hash = "sha256:878be833caa6a3821caf85eb39c5ba92d28e85df26d57afb06b35b2efd937231", size = 43882, upload-time = "2025-10-06T05:36:46.796Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/17/502cd212cbfa96eb1388614fe39a3fc9ab87dbbe042b66f97acb57474834/frozenlist-1.8.0-cp313-cp313-win_arm64.whl", hash = "sha256:44389d135b3ff43ba8cc89ff7f51f5a0bb6b63d829c8300f79a2fe4fe61bcc62", size = 39676, upload-time = "2025-10-06T05:36:47.8Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/5c/3bbfaa920dfab09e76946a5d2833a7cbdf7b9b4a91c714666ac4855b88b4/frozenlist-1.8.0-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:e25ac20a2ef37e91c1b39938b591457666a0fa835c7783c3a8f33ea42870db94", size = 89235, upload-time = "2025-10-06T05:36:48.78Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/d6/f03961ef72166cec1687e84e8925838442b615bd0b8854b54923ce5b7b8a/frozenlist-1.8.0-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:07cdca25a91a4386d2e76ad992916a85038a9b97561bf7a3fd12d5d9ce31870c", size = 50742, upload-time = "2025-10-06T05:36:49.837Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/bb/a6d12b7ba4c3337667d0e421f7181c82dda448ce4e7ad7ecd249a16fa806/frozenlist-1.8.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:4e0c11f2cc6717e0a741f84a527c52616140741cd812a50422f83dc31749fb52", size = 51725, upload-time = "2025-10-06T05:36:50.851Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/71/d1fed0ffe2c2ccd70b43714c6cab0f4188f09f8a67a7914a6b46ee30f274/frozenlist-1.8.0-cp313-cp313t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:b3210649ee28062ea6099cfda39e147fa1bc039583c8ee4481cb7811e2448c51", size = 284533, upload-time = "2025-10-06T05:36:51.898Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/1f/fb1685a7b009d89f9bf78a42d94461bc06581f6e718c39344754a5d9bada/frozenlist-1.8.0-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:581ef5194c48035a7de2aefc72ac6539823bb71508189e5de01d60c9dcd5fa65", size = 292506, upload-time = "2025-10-06T05:36:53.101Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/3b/b991fe1612703f7e0d05c0cf734c1b77aaf7c7d321df4572e8d36e7048c8/frozenlist-1.8.0-cp313-cp313t-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:3ef2d026f16a2b1866e1d86fc4e1291e1ed8a387b2c333809419a2f8b3a77b82", size = 274161, upload-time = "2025-10-06T05:36:54.309Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/ec/c5c618767bcdf66e88945ec0157d7f6c4a1322f1473392319b7a2501ded7/frozenlist-1.8.0-cp313-cp313t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:5500ef82073f599ac84d888e3a8c1f77ac831183244bfd7f11eaa0289fb30714", size = 294676, upload-time = "2025-10-06T05:36:55.566Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/ce/3934758637d8f8a88d11f0585d6495ef54b2044ed6ec84492a91fa3b27aa/frozenlist-1.8.0-cp313-cp313t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:50066c3997d0091c411a66e710f4e11752251e6d2d73d70d8d5d4c76442a199d", size = 300638, upload-time = "2025-10-06T05:36:56.758Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/4f/a7e4d0d467298f42de4b41cbc7ddaf19d3cfeabaf9ff97c20c6c7ee409f9/frozenlist-1.8.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:5c1c8e78426e59b3f8005e9b19f6ff46e5845895adbde20ece9218319eca6506", size = 283067, upload-time = "2025-10-06T05:36:57.965Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/48/c7b163063d55a83772b268e6d1affb960771b0e203b632cfe09522d67ea5/frozenlist-1.8.0-cp313-cp313t-musllinux_1_2_armv7l.whl", hash = "sha256:eefdba20de0d938cec6a89bd4d70f346a03108a19b9df4248d3cf0d88f1b0f51", size = 292101, upload-time = "2025-10-06T05:36:59.237Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/d0/2366d3c4ecdc2fd391e0afa6e11500bfba0ea772764d631bbf82f0136c9d/frozenlist-1.8.0-cp313-cp313t-musllinux_1_2_ppc64le.whl", hash = "sha256:cf253e0e1c3ceb4aaff6df637ce033ff6535fb8c70a764a8f46aafd3d6ab798e", size = 289901, upload-time = "2025-10-06T05:37:00.811Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/94/daff920e82c1b70e3618a2ac39fbc01ae3e2ff6124e80739ce5d71c9b920/frozenlist-1.8.0-cp313-cp313t-musllinux_1_2_s390x.whl", hash = "sha256:032efa2674356903cd0261c4317a561a6850f3ac864a63fc1583147fb05a79b0", size = 289395, upload-time = "2025-10-06T05:37:02.115Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/20/bba307ab4235a09fdcd3cc5508dbabd17c4634a1af4b96e0f69bfe551ebd/frozenlist-1.8.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:6da155091429aeba16851ecb10a9104a108bcd32f6c1642867eadaee401c1c41", size = 283659, upload-time = "2025-10-06T05:37:03.711Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/00/04ca1c3a7a124b6de4f8a9a17cc2fcad138b4608e7a3fc5877804b8715d7/frozenlist-1.8.0-cp313-cp313t-win32.whl", hash = "sha256:0f96534f8bfebc1a394209427d0f8a63d343c9779cda6fc25e8e121b5fd8555b", size = 43492, upload-time = "2025-10-06T05:37:04.915Z" },
+    { url = "https://files.pythonhosted.org/packages/59/5e/c69f733a86a94ab10f68e496dc6b7e8bc078ebb415281d5698313e3af3a1/frozenlist-1.8.0-cp313-cp313t-win_amd64.whl", hash = "sha256:5d63a068f978fc69421fb0e6eb91a9603187527c86b7cd3f534a5b77a592b888", size = 48034, upload-time = "2025-10-06T05:37:06.343Z" },
+    { url = "https://files.pythonhosted.org/packages/16/6c/be9d79775d8abe79b05fa6d23da99ad6e7763a1d080fbae7290b286093fd/frozenlist-1.8.0-cp313-cp313t-win_arm64.whl", hash = "sha256:bf0a7e10b077bf5fb9380ad3ae8ce20ef919a6ad93b4552896419ac7e1d8e042", size = 41749, upload-time = "2025-10-06T05:37:07.431Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/c8/85da824b7e7b9b6e7f7705b2ecaf9591ba6f79c1177f324c2735e41d36a2/frozenlist-1.8.0-cp314-cp314-macosx_10_13_universal2.whl", hash = "sha256:cee686f1f4cadeb2136007ddedd0aaf928ab95216e7691c63e50a8ec066336d0", size = 86127, upload-time = "2025-10-06T05:37:08.438Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/e8/a1185e236ec66c20afd72399522f142c3724c785789255202d27ae992818/frozenlist-1.8.0-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:119fb2a1bd47307e899c2fac7f28e85b9a543864df47aa7ec9d3c1b4545f096f", size = 49698, upload-time = "2025-10-06T05:37:09.48Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/93/72b1736d68f03fda5fdf0f2180fb6caaae3894f1b854d006ac61ecc727ee/frozenlist-1.8.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:4970ece02dbc8c3a92fcc5228e36a3e933a01a999f7094ff7c23fbd2beeaa67c", size = 49749, upload-time = "2025-10-06T05:37:10.569Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/b2/fabede9fafd976b991e9f1b9c8c873ed86f202889b864756f240ce6dd855/frozenlist-1.8.0-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:cba69cb73723c3f329622e34bdbf5ce1f80c21c290ff04256cff1cd3c2036ed2", size = 231298, upload-time = "2025-10-06T05:37:11.993Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/3b/d9b1e0b0eed36e70477ffb8360c49c85c8ca8ef9700a4e6711f39a6e8b45/frozenlist-1.8.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:778a11b15673f6f1df23d9586f83c4846c471a8af693a22e066508b77d201ec8", size = 232015, upload-time = "2025-10-06T05:37:13.194Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/94/be719d2766c1138148564a3960fc2c06eb688da592bdc25adcf856101be7/frozenlist-1.8.0-cp314-cp314-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:0325024fe97f94c41c08872db482cf8ac4800d80e79222c6b0b7b162d5b13686", size = 225038, upload-time = "2025-10-06T05:37:14.577Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/09/6712b6c5465f083f52f50cf74167b92d4ea2f50e46a9eea0523d658454ae/frozenlist-1.8.0-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:97260ff46b207a82a7567b581ab4190bd4dfa09f4db8a8b49d1a958f6aa4940e", size = 240130, upload-time = "2025-10-06T05:37:15.781Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/d4/cd065cdcf21550b54f3ce6a22e143ac9e4836ca42a0de1022da8498eac89/frozenlist-1.8.0-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:54b2077180eb7f83dd52c40b2750d0a9f175e06a42e3213ce047219de902717a", size = 242845, upload-time = "2025-10-06T05:37:17.037Z" },
+    { url = "https://files.pythonhosted.org/packages/62/c3/f57a5c8c70cd1ead3d5d5f776f89d33110b1addae0ab010ad774d9a44fb9/frozenlist-1.8.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:2f05983daecab868a31e1da44462873306d3cbfd76d1f0b5b69c473d21dbb128", size = 229131, upload-time = "2025-10-06T05:37:18.221Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/52/232476fe9cb64f0742f3fde2b7d26c1dac18b6d62071c74d4ded55e0ef94/frozenlist-1.8.0-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:33f48f51a446114bc5d251fb2954ab0164d5be02ad3382abcbfe07e2531d650f", size = 240542, upload-time = "2025-10-06T05:37:19.771Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/85/07bf3f5d0fb5414aee5f47d33c6f5c77bfe49aac680bfece33d4fdf6a246/frozenlist-1.8.0-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:154e55ec0655291b5dd1b8731c637ecdb50975a2ae70c606d100750a540082f7", size = 237308, upload-time = "2025-10-06T05:37:20.969Z" },
+    { url = "https://files.pythonhosted.org/packages/11/99/ae3a33d5befd41ac0ca2cc7fd3aa707c9c324de2e89db0e0f45db9a64c26/frozenlist-1.8.0-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:4314debad13beb564b708b4a496020e5306c7333fa9a3ab90374169a20ffab30", size = 238210, upload-time = "2025-10-06T05:37:22.252Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/60/b1d2da22f4970e7a155f0adde9b1435712ece01b3cd45ba63702aea33938/frozenlist-1.8.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:073f8bf8becba60aa931eb3bc420b217bb7d5b8f4750e6f8b3be7f3da85d38b7", size = 231972, upload-time = "2025-10-06T05:37:23.5Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/ab/945b2f32de889993b9c9133216c068b7fcf257d8595a0ac420ac8677cab0/frozenlist-1.8.0-cp314-cp314-win32.whl", hash = "sha256:bac9c42ba2ac65ddc115d930c78d24ab8d4f465fd3fc473cdedfccadb9429806", size = 40536, upload-time = "2025-10-06T05:37:25.581Z" },
+    { url = "https://files.pythonhosted.org/packages/59/ad/9caa9b9c836d9ad6f067157a531ac48b7d36499f5036d4141ce78c230b1b/frozenlist-1.8.0-cp314-cp314-win_amd64.whl", hash = "sha256:3e0761f4d1a44f1d1a47996511752cf3dcec5bbdd9cc2b4fe595caf97754b7a0", size = 44330, upload-time = "2025-10-06T05:37:26.928Z" },
+    { url = "https://files.pythonhosted.org/packages/82/13/e6950121764f2676f43534c555249f57030150260aee9dcf7d64efda11dd/frozenlist-1.8.0-cp314-cp314-win_arm64.whl", hash = "sha256:d1eaff1d00c7751b7c6662e9c5ba6eb2c17a2306ba5e2a37f24ddf3cc953402b", size = 40627, upload-time = "2025-10-06T05:37:28.075Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/c7/43200656ecc4e02d3f8bc248df68256cd9572b3f0017f0a0c4e93440ae23/frozenlist-1.8.0-cp314-cp314t-macosx_10_13_universal2.whl", hash = "sha256:d3bb933317c52d7ea5004a1c442eef86f426886fba134ef8cf4226ea6ee1821d", size = 89238, upload-time = "2025-10-06T05:37:29.373Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/29/55c5f0689b9c0fb765055629f472c0de484dcaf0acee2f7707266ae3583c/frozenlist-1.8.0-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:8009897cdef112072f93a0efdce29cd819e717fd2f649ee3016efd3cd885a7ed", size = 50738, upload-time = "2025-10-06T05:37:30.792Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/7d/b7282a445956506fa11da8c2db7d276adcbf2b17d8bb8407a47685263f90/frozenlist-1.8.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:2c5dcbbc55383e5883246d11fd179782a9d07a986c40f49abe89ddf865913930", size = 51739, upload-time = "2025-10-06T05:37:32.127Z" },
+    { url = "https://files.pythonhosted.org/packages/62/1c/3d8622e60d0b767a5510d1d3cf21065b9db874696a51ea6d7a43180a259c/frozenlist-1.8.0-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:39ecbc32f1390387d2aa4f5a995e465e9e2f79ba3adcac92d68e3e0afae6657c", size = 284186, upload-time = "2025-10-06T05:37:33.21Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/14/aa36d5f85a89679a85a1d44cd7a6657e0b1c75f61e7cad987b203d2daca8/frozenlist-1.8.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:92db2bf818d5cc8d9c1f1fc56b897662e24ea5adb36ad1f1d82875bd64e03c24", size = 292196, upload-time = "2025-10-06T05:37:36.107Z" },
+    { url = "https://files.pythonhosted.org/packages/05/23/6bde59eb55abd407d34f77d39a5126fb7b4f109a3f611d3929f14b700c66/frozenlist-1.8.0-cp314-cp314t-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:2dc43a022e555de94c3b68a4ef0b11c4f747d12c024a520c7101709a2144fb37", size = 273830, upload-time = "2025-10-06T05:37:37.663Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/3f/22cff331bfad7a8afa616289000ba793347fcd7bc275f3b28ecea2a27909/frozenlist-1.8.0-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:cb89a7f2de3602cfed448095bab3f178399646ab7c61454315089787df07733a", size = 294289, upload-time = "2025-10-06T05:37:39.261Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/89/5b057c799de4838b6c69aa82b79705f2027615e01be996d2486a69ca99c4/frozenlist-1.8.0-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:33139dc858c580ea50e7e60a1b0ea003efa1fd42e6ec7fdbad78fff65fad2fd2", size = 300318, upload-time = "2025-10-06T05:37:43.213Z" },
+    { url = "https://files.pythonhosted.org/packages/30/de/2c22ab3eb2a8af6d69dc799e48455813bab3690c760de58e1bf43b36da3e/frozenlist-1.8.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:168c0969a329b416119507ba30b9ea13688fafffac1b7822802537569a1cb0ef", size = 282814, upload-time = "2025-10-06T05:37:45.337Z" },
+    { url = "https://files.pythonhosted.org/packages/59/f7/970141a6a8dbd7f556d94977858cfb36fa9b66e0892c6dd780d2219d8cd8/frozenlist-1.8.0-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:28bd570e8e189d7f7b001966435f9dac6718324b5be2990ac496cf1ea9ddb7fe", size = 291762, upload-time = "2025-10-06T05:37:46.657Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/15/ca1adae83a719f82df9116d66f5bb28bb95557b3951903d39135620ef157/frozenlist-1.8.0-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:b2a095d45c5d46e5e79ba1e5b9cb787f541a8dee0433836cea4b96a2c439dcd8", size = 289470, upload-time = "2025-10-06T05:37:47.946Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/83/dca6dc53bf657d371fbc88ddeb21b79891e747189c5de990b9dfff2ccba1/frozenlist-1.8.0-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:eab8145831a0d56ec9c4139b6c3e594c7a83c2c8be25d5bcf2d86136a532287a", size = 289042, upload-time = "2025-10-06T05:37:49.499Z" },
+    { url = "https://files.pythonhosted.org/packages/96/52/abddd34ca99be142f354398700536c5bd315880ed0a213812bc491cff5e4/frozenlist-1.8.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:974b28cf63cc99dfb2188d8d222bc6843656188164848c4f679e63dae4b0708e", size = 283148, upload-time = "2025-10-06T05:37:50.745Z" },
+    { url = "https://files.pythonhosted.org/packages/af/d3/76bd4ed4317e7119c2b7f57c3f6934aba26d277acc6309f873341640e21f/frozenlist-1.8.0-cp314-cp314t-win32.whl", hash = "sha256:342c97bf697ac5480c0a7ec73cd700ecfa5a8a40ac923bd035484616efecc2df", size = 44676, upload-time = "2025-10-06T05:37:52.222Z" },
+    { url = "https://files.pythonhosted.org/packages/89/76/c615883b7b521ead2944bb3480398cbb07e12b7b4e4d073d3752eb721558/frozenlist-1.8.0-cp314-cp314t-win_amd64.whl", hash = "sha256:06be8f67f39c8b1dc671f5d83aaefd3358ae5cdcf8314552c57e7ed3e6475bdd", size = 49451, upload-time = "2025-10-06T05:37:53.425Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/a3/5982da14e113d07b325230f95060e2169f5311b1017ea8af2a29b374c289/frozenlist-1.8.0-cp314-cp314t-win_arm64.whl", hash = "sha256:102e6314ca4da683dca92e3b1355490fed5f313b768500084fbe6371fddfdb79", size = 42507, upload-time = "2025-10-06T05:37:54.513Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/9a/e35b4a917281c0b8419d4207f4334c8e8c5dbf4f3f5f9ada73958d937dcc/frozenlist-1.8.0-py3-none-any.whl", hash = "sha256:0c18a16eab41e82c295618a77502e17b195883241c563b00f0aa5106fc4eaa0d", size = 13409, upload-time = "2025-10-06T05:38:16.721Z" },
+]
+
+[[package]]
+name = "fsspec"
+version = "2026.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d5/8d/1c51c094345df128ca4a990d633fe1a0ff28726c9e6b3c41ba65087bba1d/fsspec-2026.4.0.tar.gz", hash = "sha256:301d8ac70ae90ef3ad05dcf94d6c3754a097f9b5fe4667d2787aa359ec7df7e4", size = 312760, upload-time = "2026-04-29T20:42:38.635Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d5/0c/043d5e551459da400957a1395e0febbf771446ff34291afcbe3d8be2a279/fsspec-2026.4.0-py3-none-any.whl", hash = "sha256:11ef7bb35dab8a394fde6e608221d5cf3e8499401c249bebaeaad760a1a8dec2", size = 203402, upload-time = "2026-04-29T20:42:36.842Z" },
+]
+
+[[package]]
+name = "func-timeout"
+version = "4.3.5"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b3/0d/bf0567477f7281d9a3926c582bfef21bff7498fc0ffd3e9de21811896a0b/func_timeout-4.3.5.tar.gz", hash = "sha256:74cd3c428ec94f4edfba81f9b2f14904846d5ffccc27c92433b8b5939b5575dd", size = 44264, upload-time = "2019-08-19T21:32:07.43Z" }
+
+[[package]]
+name = "google-api-core"
+version = "2.31.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "google-auth" },
+    { name = "googleapis-common-protos" },
+    { name = "proto-plus" },
+    { name = "protobuf" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c6/22/155cadf1d49272a9cf48f3168c0f3874fa13397297e611a5ea00cd093880/google_api_core-2.31.0.tar.gz", hash = "sha256:2be84ee0f584c48e6bde1b36766e23348b361fb7e55e56135fc76ce1c397f9c2", size = 176492, upload-time = "2026-06-03T14:52:17.257Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/86/40/9bdbb60b03a332bd45acb8703da08bbc27d991d35286b62e42acc86d243a/google_api_core-2.31.0-py3-none-any.whl", hash = "sha256:ef79fb3784c71cbac89cbd03301ba0c8fb8ad2aa95d7f9204dd9628f7adf59ab", size = 173102, upload-time = "2026-06-03T14:51:26.729Z" },
+]
+
+[[package]]
+name = "google-api-python-client"
+version = "2.197.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "google-api-core" },
+    { name = "google-auth" },
+    { name = "google-auth-httplib2" },
+    { name = "httplib2" },
+    { name = "uritemplate" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/22/09/081d66357118bd260f8f182cb1b2dd5bd32ca88e3714d7c93896cab946fc/google_api_python_client-2.197.0.tar.gz", hash = "sha256:32e03977eda4a66eafc6ae58dc9ec46426b6025636d5ef019c5703013eddd4e5", size = 14707398, upload-time = "2026-05-28T20:23:12.498Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/e5/e9cc221fd75230974d4ef45eb72d2261feca3c110d5554215d516bfe6534/google_api_python_client-2.197.0-py3-none-any.whl", hash = "sha256:0f8b89aa75768161dd4f5092d6bcb386c13236b32e0d9a938c02f71342094d14", size = 15287302, upload-time = "2026-05-28T20:23:09.683Z" },
+]
+
+[[package]]
+name = "google-auth"
+version = "2.53.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography" },
+    { name = "pyasn1-modules" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c6/ad/ff781329bbbdc0974a098d996e89c9e1f7024262f9e3eec442fbb9ad1ac6/google_auth-2.53.0.tar.gz", hash = "sha256:e7e6aa16f6bee7b2b264830fd04f08087a1d5a836df516251a5d15327b246c9c", size = 335844, upload-time = "2026-05-15T20:53:07.928Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4a/c9/db44165ba7c581268c6d46017ef63339110378305062830104fc7fa144cb/google_auth-2.53.0-py3-none-any.whl", hash = "sha256:6e7449917c599b35126a99ec268ec6880301f2fea41dce198fe8fd83ff642b68", size = 246071, upload-time = "2026-05-15T20:53:05.609Z" },
+]
+
+[package.optional-dependencies]
+requests = [
+    { name = "requests" },
+]
+
+[[package]]
+name = "google-auth-httplib2"
+version = "0.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "google-auth" },
+    { name = "httplib2" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1c/b3/f192c8bc7e41e0ebdbd95afcae4783417a34b6a6af62d22daf22c3fd38fc/google_auth_httplib2-0.4.0.tar.gz", hash = "sha256:d5b030a204b7a4b4d553ba9ca701b62481ee2b74419325580be70f7d85ffed35", size = 11161, upload-time = "2026-05-07T08:03:46.878Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/97/be/954c35a62b9e31de66b0a43c225c9b6bb9e0f98d6b1dc110a2308e3644f5/google_auth_httplib2-0.4.0-py3-none-any.whl", hash = "sha256:8e55cfafa3358cba85f6cad4a886138e88e158d71e7e5c9ee5936a5c1507fb91", size = 9529, upload-time = "2026-05-07T08:02:12.375Z" },
+]
+
+[[package]]
+name = "google-auth-oauthlib"
+version = "1.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "google-auth" },
+    { name = "requests-oauthlib" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/70/18/90c7fac516e63cf2058166fce0c88c353647c677b51cc036c09c49bb5cbb/google_auth_oauthlib-1.4.0.tar.gz", hash = "sha256:18b5e28880eb8eba9065c436becdc0ee8e4b59117a73a510679c82f70cd363d2", size = 21675, upload-time = "2026-05-07T08:03:47.816Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/37/d3/d7dff0d58a9e9244b48044bfb6a898bfcc8ecc42e0031d1bebc695344725/google_auth_oauthlib-1.4.0-py3-none-any.whl", hash = "sha256:251314f213a9ee46a5ae73988e84fd7cca8bb68e7ecf4bfd45940f9e7f51d070", size = 19261, upload-time = "2026-05-07T08:02:13.798Z" },
+]
+
+[[package]]
+name = "google-genai"
+version = "1.75.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "distro" },
+    { name = "google-auth", extra = ["requests"] },
+    { name = "httpx" },
+    { name = "pydantic" },
+    { name = "requests" },
+    { name = "sniffio" },
+    { name = "tenacity" },
+    { name = "typing-extensions" },
+    { name = "websockets" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9d/59/3ed61240ef20b3ae6ed54e82c6f8b6d1f194947bc6679679dd6cdb037594/google_genai-1.75.0.tar.gz", hash = "sha256:56bac3991b311c93f980c0a2abcd287b672146905df1fbd71c92ed633d5a07cf", size = 539039, upload-time = "2026-05-04T22:48:54.857Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2d/b6/552d40e96da22921eb1fead7c14b00b5b5473a20e45959488660fab35ee2/google_genai-1.75.0-py3-none-any.whl", hash = "sha256:8dc4c096e7d6288c3087f6893f582fe52468932464781edb8193bd92b9fefb2c", size = 793726, upload-time = "2026-05-04T22:48:53.033Z" },
+]
+
+[[package]]
+name = "googleapis-common-protos"
+version = "1.75.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "protobuf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b5/c8/f439cffde755cffa462bfbb156278fa6f9d09119719af9814b858fd4f81f/googleapis_common_protos-1.75.0.tar.gz", hash = "sha256:53a062ff3c32552fbd62c11fe23768b78e4ddf0494d5e5fd97d3f4689c75fbbd", size = 151035, upload-time = "2026-05-07T08:04:49.423Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e7/c8/e2645aa8ed02fd4c7a2f59d68783b65b1f3cbdfe39a6308e156509d1fee8/googleapis_common_protos-1.75.0-py3-none-any.whl", hash = "sha256:961ed60399c457ceb0ee8f285a84c870aabc9c6a832b9d37bb281b5bebde43ed", size = 300631, upload-time = "2026-05-07T08:03:30.345Z" },
+]
+
+[[package]]
+name = "griffelib"
+version = "2.0.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9d/82/74f4a3310cdabfbb10da554c3a672847f1ed33c6f61dd472681ce7f1fe67/griffelib-2.0.2.tar.gz", hash = "sha256:3cf20b3bc470e83763ffbf236e0076b1211bac1bc67de13daf494640f2de707e", size = 166461, upload-time = "2026-03-27T11:34:51.091Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/11/8c/c9138d881c79aa0ea9ed83cbd58d5ca75624378b38cee225dcf5c42cc91f/griffelib-2.0.2-py3-none-any.whl", hash = "sha256:925c857658fb1ba40c0772c37acbc2ab650bd794d9c1b9726922e36ea4117ea1", size = 142357, upload-time = "2026-03-27T11:34:46.275Z" },
+]
+
+[[package]]
+name = "groq"
+version = "1.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "distro" },
+    { name = "httpx" },
+    { name = "pydantic" },
+    { name = "sniffio" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/26/84/d99c4894d32ed52bf2763127804343d9323dce22beb61d42aebc7d9c5f4d/groq-1.4.0.tar.gz", hash = "sha256:09b1ed51408c6969a11ef1a4dfe44d42ec975b5f1510e5de3f3dab56e22dffc6", size = 158123, upload-time = "2026-05-28T03:11:47.5Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3a/5b/28cfd8937be95c0814fd9458710a8a257fb8424a39e291b7bbd494476108/groq-1.4.0-py3-none-any.whl", hash = "sha256:99a3bcd57c71538f69cf11c75cdae91598983d2681b9a14008636a018c4b6d17", size = 143699, upload-time = "2026-05-28T03:11:46.23Z" },
+]
+
+[[package]]
+name = "grpcio"
+version = "1.81.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b0/b5/1ff353970a87eda4c98251e34d2dfd214abd4982dc89119c9252a2a482d2/grpcio-1.81.1.tar.gz", hash = "sha256:6fa10a767143a5e82e8eaab53918af0cd8909a57a27f8cb2288b80a613ac671b", size = 13026582, upload-time = "2026-06-11T12:46:51.673Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/85/07/9a979c81738863a738dc23d65177056e71fbb2db817740ed870b33434e7a/grpcio-1.81.1-cp312-cp312-linux_armv7l.whl", hash = "sha256:8b39472beafc0bdcafc4c8c73ad082ebfdb449d566897a61e7acb4fa88089115", size = 6053264, upload-time = "2026-06-11T12:45:21.017Z" },
+    { url = "https://files.pythonhosted.org/packages/75/95/539706ca0d3bd40dbad583dc56fd883da941f37556b629132da5762781b9/grpcio-1.81.1-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:12b7524c88d4026d3dcb7b0ebe16b6714f3b4af402ddd0f0639ab064a00c87c3", size = 12052560, upload-time = "2026-06-11T12:45:23.652Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/44/f257b7e0bd69c93b06c6cb8ac8d1b901ccb42bedabd83c1a4c77a71f8810/grpcio-1.81.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:1e123f9b37edb8375fd74130d1f69c944bbf0a7b06761ae7211154b8759e94d2", size = 6595983, upload-time = "2026-06-11T12:45:26.963Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/f3/19782aa04c960968bef8c5539329d8e3bbc3364e2e46d19eb5e5cc5e43b7/grpcio-1.81.1-cp312-cp312-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:2c2e2ae6867c2966b8daccc836d54a13218e0007e9a490aeb81dd05be64d22d7", size = 7303455, upload-time = "2026-06-11T12:45:29.707Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/8c/dea020b6d91508cd84463917a63149ec196ee7db505d032ae43fcb3303b9/grpcio-1.81.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:766bc7c9a9c340342f4c864ccbda8e78111e4751f13b895812b9c148fb79e9d0", size = 6809167, upload-time = "2026-06-11T12:45:32.52Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/c7/3030dd940408083bd32cd95d634777a71605ade4887154d93e8a89244946/grpcio-1.81.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:b259a04a737cb3496be0901328eb8b7552ed8df4865d8c8f1cf1bffcfc0776a3", size = 7412536, upload-time = "2026-06-11T12:45:35.403Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/dd/1172a9e42b168edcafefad6115346ef619a3fc02158bb170e66ced24bcdd/grpcio-1.81.1-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:85b10a45b8993d195c4f3ff57025b8d1e11834909ee475c403bfa60cb4caefaf", size = 8408276, upload-time = "2026-06-11T12:45:37.78Z" },
+    { url = "https://files.pythonhosted.org/packages/25/7a/71437c7f3596e5246155c515852795a85a1a8d228190212432b13b97a95d/grpcio-1.81.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:8ea1936c26b99999b27479853039a7f34713f56c49375ad52b38535ec93a796c", size = 7849660, upload-time = "2026-06-11T12:45:40.627Z" },
+    { url = "https://files.pythonhosted.org/packages/65/40/7debc0da45d2efebafb82da75644be347497fe4ee250514b8cd3b86ae8bf/grpcio-1.81.1-cp312-cp312-win32.whl", hash = "sha256:a185a04039df6cae8648bc8ab6d6fde7bf94f7188ecf7828e76ac52eef1e41d6", size = 4185819, upload-time = "2026-06-11T12:45:43.027Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/b9/8fe3ba5ed462067774ebc1f9c7f26aa7ebcc280ddd476be107153de1339e/grpcio-1.81.1-cp312-cp312-win_amd64.whl", hash = "sha256:3ad74f8bb1a18963914c5452d289422830b39459e8776ebbcd207be1fbfb1d94", size = 4930461, upload-time = "2026-06-11T12:45:45.775Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/42/dcc2e4b600538ef18327c0839d56b7d3c3812337c5d710df5877dbb39b1e/grpcio-1.81.1-cp313-cp313-linux_armv7l.whl", hash = "sha256:b10e1ff4756ed27d5a29d7fc79cfce7ef1ff56ad20025b89bac7cf79e09abbbe", size = 6054466, upload-time = "2026-06-11T12:45:48.43Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/4a/a36e03210183a8a7d4c80c3936acee679f4bd77d5861f369db47b2cc5f05/grpcio-1.81.1-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:819edbdcb42ab8598b494bcf0222684bbb7a3c772bd1b1f0be7e029a6063c28e", size = 12048795, upload-time = "2026-06-11T12:45:54.011Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/d5/d68e30b29098f63beab6fe501100fe82674ff142b32c672532da86a99b3a/grpcio-1.81.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:c5bf2dc311127d91230cc79b92188c082634a06cf66c5234db49a43b910183b0", size = 6599094, upload-time = "2026-06-11T12:45:57.799Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/b3/e837954d279754f638a11cca5dcf6b24a005efb398984cefaf7735945a54/grpcio-1.81.1-cp313-cp313-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:e8ca6a1fcdb2943c9cbc1804a1baf3acb6071d72a471591678ded84218006e14", size = 7307182, upload-time = "2026-06-11T12:46:00.568Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/1e/b47957057e729adc6cdf519a47f8be2562b7140e280f1418443eb4022192/grpcio-1.81.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:e64dd101d380a115cc5a0c7856788adb535f1a4e21fc543775602f8be95180ae", size = 6810962, upload-time = "2026-06-11T12:46:03.312Z" },
+    { url = "https://files.pythonhosted.org/packages/40/26/569868e364e05b19ec8f969da53d230bcd89c962cd198f7c29943155c4d3/grpcio-1.81.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:98a07f9bf591e3a8919797bee1c53f026ba4acd587e5a4404c8e57c9ec36b2a5", size = 7415698, upload-time = "2026-06-11T12:46:06.005Z" },
+    { url = "https://files.pythonhosted.org/packages/36/0c/5440a0582cb5653fc42a6e262eeb22700943313f8076f9dc927491b20a59/grpcio-1.81.1-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:c261d74b1a945cf895a9d6eccd1685a8e837531beaab782da4d630a8d12deffb", size = 8407779, upload-time = "2026-06-11T12:46:08.84Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/aa/66fe9f39871d766987d869a03ee0842a026f499c7b1e62decb9e78a8088e/grpcio-1.81.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:58ad1131c300d3c9b933802b3cc4dc69d380822935ba50b28703156ea826fbf7", size = 7844521, upload-time = "2026-06-11T12:46:12.171Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/9e/69bb7194861bcd28fb3193261d4f9c3831b4446993f002cf59068943e7ab/grpcio-1.81.1-cp313-cp313-win32.whl", hash = "sha256:78e29211f26da2fdd0e9c6d2b79f489476140cf7029b6a64808ade7ca4156a42", size = 4182786, upload-time = "2026-06-11T12:46:15.192Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/20/3da8bb0d637feccdc3e1e419bb511ce93651ce7d54164f95de22cc0b8b34/grpcio-1.81.1-cp313-cp313-win_amd64.whl", hash = "sha256:edb59506291b647a30884b1d51a599d605f40b20af4a7dc3d33786a47a31de60", size = 4928648, upload-time = "2026-06-11T12:46:17.823Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/58/19414622b1bf6981bc9c05a365bd548e71876c89000083b3af489251e9c0/grpcio-1.81.1-cp314-cp314-linux_armv7l.whl", hash = "sha256:506f48f2f9c29b143fca3dad7b0d518c188b6c9648c75a2ae6e2d9f2c13a060b", size = 6055336, upload-time = "2026-06-11T12:46:20.557Z" },
+    { url = "https://files.pythonhosted.org/packages/32/f1/2ec88adb92b0eba970dd0e0e7dd086341daa3c75eba4f735f9e44bf684b0/grpcio-1.81.1-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:d865db4a6318e1c1bea83292e0ed231090538fc4ca45425b0f0480eb338bbc6e", size = 12056279, upload-time = "2026-06-11T12:46:24.255Z" },
+    { url = "https://files.pythonhosted.org/packages/41/36/e8c5f8c6ec71de73733695ebc809e98b178b534ec6d8eaa31a7ebab4ad4c/grpcio-1.81.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:e2aa72e3ce1770317ef534f63d397b55e130725f5149bd36077c3b539019db27", size = 6608225, upload-time = "2026-06-11T12:46:27.601Z" },
+    { url = "https://files.pythonhosted.org/packages/30/22/96fc577a845ab093326d9ab1adb874bd4936c8cf98ac8ed2f3db13a0a2fb/grpcio-1.81.1-cp314-cp314-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:0490c30c261eded63f3f354979f9dc4502a9fb944cccb60cd9dc85f5a7349854", size = 7306576, upload-time = "2026-06-11T12:46:30.514Z" },
+    { url = "https://files.pythonhosted.org/packages/76/7b/61dab5d5969f28d97fb1009cead1df0a5cd987d3315e1b37f18a4449f8bc/grpcio-1.81.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:410482da976329fe5f4067270401b12cf2bd552ff8020f054ecfaddb5475f9d6", size = 6812165, upload-time = "2026-06-11T12:46:33.699Z" },
+    { url = "https://files.pythonhosted.org/packages/82/78/6e501929d4f5f96462fd82fd9f0f06e5f9612207582b862868d68757b27d/grpcio-1.81.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:e3657301562ac3cb8018d30d0d3ebfa39932239f7b5703422057ef14b69949f5", size = 7422962, upload-time = "2026-06-11T12:46:36.511Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/7e/f2157589e66daa78ebb3165942d05a08bdea93b9d11c2bc1e172aef89685/grpcio-1.81.1-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:24c8e57504c8f45b237e40b99262d181071e5099a07053695b75d97bb53053a0", size = 8408176, upload-time = "2026-06-11T12:46:39.803Z" },
+    { url = "https://files.pythonhosted.org/packages/da/df/c6717fef716e00d235ffb96123baf6dce76d6004f6233fa767c502861460/grpcio-1.81.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:b427c19380991a4eaab2f6144b64b99b412043314c6bf4ab544f97bb31ee4190", size = 7846681, upload-time = "2026-06-11T12:46:43.013Z" },
+    { url = "https://files.pythonhosted.org/packages/36/84/3502e9f210a6a5c4438c8aca3f88edd2e04f6a27f3d41b26cf0a0024b096/grpcio-1.81.1-cp314-cp314-win32.whl", hash = "sha256:61233fe8951e5c85dff81c2458b6528624760166946b5b47ea150a589168411f", size = 4264615, upload-time = "2026-06-11T12:46:45.741Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/b0/4af731ff7492c68a96e4c71bfd0f4590acde92b31c6fe4894e6465c10ff6/grpcio-1.81.1-cp314-cp314-win_amd64.whl", hash = "sha256:3768a5ff1b2125e6f552e561b6b2dca0e64982d8949689b4df145cf8b98d7821", size = 5070275, upload-time = "2026-06-11T12:46:48.486Z" },
+]
+
+[[package]]
 name = "h11"
 version = "0.16.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
+]
+
+[[package]]
+name = "hf-xet"
+version = "1.5.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4b/2d/57fd21d84d93efb4bd0b962383790e19dd1bc053501b4264c97903b4e83e/hf_xet-1.5.1.tar.gz", hash = "sha256:51ef4500dab3764b41135ee1381a4b62ce56fc54d4c92b719b59e597d6df5bf6", size = 876636, upload-time = "2026-06-08T23:02:53.897Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/64/ee/dd9ba7beae1005e54131b7d45263cc74c8a066d47d354e6d58ae9445a388/hf_xet-1.5.1-cp313-cp313t-macosx_10_12_x86_64.whl", hash = "sha256:dbf48c0d02cf0b2e568944330c60d9120c272dabe013bd892d48e25bc6797577", size = 4069485, upload-time = "2026-06-08T23:02:13.193Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/bc/9cae6cfeb4e03070874e73e5c97c66eb90369d3206b6a2b1ef5f96520888/hf_xet-1.5.1-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:e78e4e5192ad2b674c2e1160b651cb9134db974f8ae1835bdfbfb0166b894a43", size = 3838493, upload-time = "2026-06-08T23:02:15.282Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/b4/d5c01e0eb6d9f2ca2dacd84d0d1b71e6cfbb2ef3208c968528e010e9b3d7/hf_xet-1.5.1-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:6f7a04a8ad962422e225bc49fbbac99dc1806764b1f3e54dbd154bffa7593947", size = 4505658, upload-time = "2026-06-08T23:02:17.196Z" },
+    { url = "https://files.pythonhosted.org/packages/76/c5/29a7598c0c6383c523dc22186d577f4e04267a626cd95ae60f67c00bfe66/hf_xet-1.5.1-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:d48199c2bf4f8df0adc55d31d1368b6ec0e4d4f45bc86b08038089c23db0bed8", size = 4292822, upload-time = "2026-06-08T23:02:18.608Z" },
+    { url = "https://files.pythonhosted.org/packages/04/9a/dceaf6ca69390126b86ea825fb354b93d01163199070b7bd849225de9468/hf_xet-1.5.1-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:97f212a88d14bbf573619a74b7fecb238de77d08fc702e54dec6f78276ca3283", size = 4491255, upload-time = "2026-06-08T23:02:20.124Z" },
+    { url = "https://files.pythonhosted.org/packages/48/a7/e5a7afaacf6c1791fdbeeac42951fb81c3d2bc482992b115dedcc86d963e/hf_xet-1.5.1-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:f61e3665892a6c8c5e765395838b8ddf36185da835253d4bc4509a81e49fb342", size = 4711062, upload-time = "2026-06-08T23:02:21.863Z" },
+    { url = "https://files.pythonhosted.org/packages/53/49/2802f8433c9742ce281bddc1e65c02c32268ca3098d66828b05e12e45ee2/hf_xet-1.5.1-cp313-cp313t-win_amd64.whl", hash = "sha256:f4ad3ebd4c32dd2b27099d69dc7b2df821e30767e46fb6ee6a0713778243b8ff", size = 4017205, upload-time = "2026-06-08T23:02:23.495Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/5a/50c71195b9fb883659f596e7252faf4c18c58e753a9013bdbf9bac5d2250/hf_xet-1.5.1-cp313-cp313t-win_arm64.whl", hash = "sha256:8298485c1e36e7e67cbd01eeb1376619b7af43d4f1ec245caae306f890a8a32d", size = 3845426, upload-time = "2026-06-08T23:02:25.124Z" },
+    { url = "https://files.pythonhosted.org/packages/05/24/5e0c28f80371c17d49fed004597d9d132cb75c1f6f53db2cb95f459d2312/hf_xet-1.5.1-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:3474760d10e3bb6f92ff3f024fcb00c0b3e4001e9b035c7483e49a5dd17aa70f", size = 4069676, upload-time = "2026-06-08T23:02:26.759Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/17/261ba565b6a4d960fb478f61fdf919c0be5824645aaf1c319eca660c1611/hf_xet-1.5.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:6762d89b9e3267dfd502b29b2a327b4525f33b17e7b509a78d94e2151a30ce30", size = 3838509, upload-time = "2026-06-08T23:02:28.573Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/44/7ffdc2e184b0d41fc0f683ba3936ef669ab63cf242cf36ef50e57d683668/hf_xet-1.5.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:bf67e6ed10260cef62e852789dc91ebb03f382d5bdc4b1dbeb64763ea275e7d6", size = 4505881, upload-time = "2026-06-08T23:02:30.257Z" },
+    { url = "https://files.pythonhosted.org/packages/63/b6/788060d5aa4d5e671f1a31bf69624c314eb2d8babab3aa562f9e5d53444e/hf_xet-1.5.1-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:c6b6cd08ca095058780b50b8ce4d6cbf6787bcf27841705d58a9d32246e3e47a", size = 4292995, upload-time = "2026-06-08T23:02:31.993Z" },
+    { url = "https://files.pythonhosted.org/packages/22/93/c5540cbd6b55529b7dc42f6734e88cebee21aefbea34128b66229df56c57/hf_xet-1.5.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e1af0de8ca6f190d4294a28b88023db64a1e2d1d719cab044baf75bec569e7a9", size = 4491570, upload-time = "2026-06-08T23:02:33.86Z" },
+    { url = "https://files.pythonhosted.org/packages/03/f3/9d8ceab30f44f36c1679b1b8683054c71a0dadc787dbf07421891742d3ca/hf_xet-1.5.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:4f561cbbb92f80960772059864b7fb07eae879adde1b2e781ec6f86f6ac26c59", size = 4711565, upload-time = "2026-06-08T23:02:35.454Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/54/27ed9a5e2cc583b4df82f75a03a4df8dbf55f5a9fa1f47f1fadfb20dbeac/hf_xet-1.5.1-cp314-cp314t-win_amd64.whl", hash = "sha256:e7dbb40617410f432182d918e37c12303fe6700fd6aa6c5964e30a535a4461d6", size = 4017343, upload-time = "2026-06-08T23:02:37.14Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/12/ecb2fc8d45e767580e3a37faa97cb895608b614965567efb4f18cff67e27/hf_xet-1.5.1-cp314-cp314t-win_arm64.whl", hash = "sha256:6071d5ccb4d8d2cbd5fea5cc798da4f0ba3f44e25369591c4e89a4987050e61d", size = 3845716, upload-time = "2026-06-08T23:02:39.073Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/d8/5e54cf37434759d1f4f2ba9b66077ff9d4c4e1f37b6bd7975da5c40d94ab/hf_xet-1.5.1-cp37-abi3-macosx_10_12_x86_64.whl", hash = "sha256:6abd35c3221eff63836618ddfb954dcf84798603f71d8e33e3ed7b04acfdbe6e", size = 4077794, upload-time = "2026-06-08T23:02:40.656Z" },
+    { url = "https://files.pythonhosted.org/packages/35/94/4b2ecfbad8f8b04701a23aefb62f540b9137d058b7e1dbef16a32676f0e9/hf_xet-1.5.1-cp37-abi3-macosx_11_0_arm64.whl", hash = "sha256:94e761bbd266bf4c03cee73753916062665ce8365aa40ed321f45afcb934b41e", size = 3845354, upload-time = "2026-06-08T23:02:42.702Z" },
+    { url = "https://files.pythonhosted.org/packages/de/cc/f99f4bc7295023d7bd9ebbfd51f75cc530ca262c1227666268b8208f4b77/hf_xet-1.5.1-cp37-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:892e3a3a3aecc12aded8b93cf4f9cd059282c7de0732f7d55026f3abdf474350", size = 4514864, upload-time = "2026-06-08T23:02:44.497Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/6e/21f7e5a2381278bd3b7b7a5a4d90038518bb6308a0c1daf5d9f8268bb178/hf_xet-1.5.1-cp37-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:a93df2039190502835b1db8cd7e178b0b7b889fe9ab51299d5ced26e0dd879a4", size = 4303784, upload-time = "2026-06-08T23:02:46.203Z" },
+    { url = "https://files.pythonhosted.org/packages/35/0e/f992bb6927ac1cb30ef74e62268f551f338bc32b2191f7c96a44c6f7283e/hf_xet-1.5.1-cp37-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:0c97106032ef70467b4f6bc2d0ccc266d7613ee076afc56516c502f87ce1c4a6", size = 4500703, upload-time = "2026-06-08T23:02:47.628Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/d1/90a498d05447980b977b1669246eeeeae4cfb0ea3e7a286eaba627f91bf9/hf_xet-1.5.1-cp37-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:6208adb15d192b90e4c2ad2a27ed864359b2cb0f2494eb6d7c7f3699ac02e2bf", size = 4719498, upload-time = "2026-06-08T23:02:49.268Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/b6/20f99cfe97cc663a711f7b33cc21d4793e51968e9a26125b4afcd77315ba/hf_xet-1.5.1-cp37-abi3-win_amd64.whl", hash = "sha256:f7b3002f95d1c13e24bcb4537baa8f0eb3838957067c91bb4959bc004a6435f5", size = 4026419, upload-time = "2026-06-08T23:02:50.829Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/fa/77453694888f03e5a8c8852d1514a0894d8e81c622d39edbaf308ea0dcf4/hf_xet-1.5.1-cp37-abi3-win_arm64.whl", hash = "sha256:93d090b57b211133f6c0dab0205ef5cb6d89162979ba75a74845045cc3063b8e", size = 3855178, upload-time = "2026-06-08T23:02:52.452Z" },
 ]
 
 [[package]]
@@ -382,18 +1240,23 @@ wheels = [
 ]
 
 [[package]]
+name = "httplib2"
+version = "0.31.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyparsing" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c1/1f/e86365613582c027dda5ddb64e1010e57a3d53e99ab8a72093fa13d565ec/httplib2-0.31.2.tar.gz", hash = "sha256:385e0869d7397484f4eab426197a4c020b606edd43372492337c0b4010ae5d24", size = 250800, upload-time = "2026-01-23T11:04:44.165Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2f/90/fd509079dfcab01102c0fdd87f3a9506894bc70afcf9e9785ef6b2b3aff6/httplib2-0.31.2-py3-none-any.whl", hash = "sha256:dbf0c2fa3862acf3c55c078ea9c0bc4481d7dc5117cae71be9514912cf9f8349", size = 91099, upload-time = "2026-01-23T11:04:42.78Z" },
+]
+
+[[package]]
 name = "httptools"
 version = "0.7.1"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/b5/46/120a669232c7bdedb9d52d4aeae7e6c7dfe151e99dc70802e2fc7a5e1993/httptools-0.7.1.tar.gz", hash = "sha256:abd72556974f8e7c74a259655924a717a2365b236c882c3f6f8a45fe94703ac9", size = 258961, upload-time = "2025-10-10T03:55:08.559Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9c/08/17e07e8d89ab8f343c134616d72eebfe03798835058e2ab579dcc8353c06/httptools-0.7.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:474d3b7ab469fefcca3697a10d11a32ee2b9573250206ba1e50d5980910da657", size = 206521, upload-time = "2025-10-10T03:54:31.002Z" },
-    { url = "https://files.pythonhosted.org/packages/aa/06/c9c1b41ff52f16aee526fd10fbda99fa4787938aa776858ddc4a1ea825ec/httptools-0.7.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:a3c3b7366bb6c7b96bd72d0dbe7f7d5eead261361f013be5f6d9590465ea1c70", size = 110375, upload-time = "2025-10-10T03:54:31.941Z" },
-    { url = "https://files.pythonhosted.org/packages/cc/cc/10935db22fda0ee34c76f047590ca0a8bd9de531406a3ccb10a90e12ea21/httptools-0.7.1-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:379b479408b8747f47f3b253326183d7c009a3936518cdb70db58cffd369d9df", size = 456621, upload-time = "2025-10-10T03:54:33.176Z" },
-    { url = "https://files.pythonhosted.org/packages/0e/84/875382b10d271b0c11aa5d414b44f92f8dd53e9b658aec338a79164fa548/httptools-0.7.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:cad6b591a682dcc6cf1397c3900527f9affef1e55a06c4547264796bbd17cf5e", size = 454954, upload-time = "2025-10-10T03:54:34.226Z" },
-    { url = "https://files.pythonhosted.org/packages/30/e1/44f89b280f7e46c0b1b2ccee5737d46b3bb13136383958f20b580a821ca0/httptools-0.7.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:eb844698d11433d2139bbeeb56499102143beb582bd6c194e3ba69c22f25c274", size = 440175, upload-time = "2025-10-10T03:54:35.942Z" },
-    { url = "https://files.pythonhosted.org/packages/6f/7e/b9287763159e700e335028bc1824359dc736fa9b829dacedace91a39b37e/httptools-0.7.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:f65744d7a8bdb4bda5e1fa23e4ba16832860606fcc09d674d56e425e991539ec", size = 440310, upload-time = "2025-10-10T03:54:37.1Z" },
-    { url = "https://files.pythonhosted.org/packages/b3/07/5b614f592868e07f5c94b1f301b5e14a21df4e8076215a3bccb830a687d8/httptools-0.7.1-cp311-cp311-win_amd64.whl", hash = "sha256:135fbe974b3718eada677229312e97f3b31f8a9c8ffa3ae6f565bf808d5b6bcb", size = 86875, upload-time = "2025-10-10T03:54:38.421Z" },
     { url = "https://files.pythonhosted.org/packages/53/7f/403e5d787dc4942316e515e949b0c8a013d84078a915910e9f391ba9b3ed/httptools-0.7.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:38e0c83a2ea9746ebbd643bdfb521b9aa4a91703e2cd705c20443405d2fd16a5", size = 206280, upload-time = "2025-10-10T03:54:39.274Z" },
     { url = "https://files.pythonhosted.org/packages/2a/0d/7f3fd28e2ce311ccc998c388dd1c53b18120fda3b70ebb022b135dc9839b/httptools-0.7.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:f25bbaf1235e27704f1a7b86cd3304eabc04f569c828101d94a0e605ef7205a5", size = 110004, upload-time = "2025-10-10T03:54:40.403Z" },
     { url = "https://files.pythonhosted.org/packages/84/a6/b3965e1e146ef5762870bbe76117876ceba51a201e18cc31f5703e454596/httptools-0.7.1-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:2c15f37ef679ab9ecc06bfc4e6e8628c32a8e4b305459de7cf6785acd57e4d03", size = 517655, upload-time = "2025-10-10T03:54:41.347Z" },
@@ -432,6 +1295,11 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
 ]
 
+[package.optional-dependencies]
+socks = [
+    { name = "socksio" },
+]
+
 [[package]]
 name = "httpx-sse"
 version = "0.4.3"
@@ -439,6 +1307,26 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/0f/4c/751061ffa58615a32c31b2d82e8482be8dd4a89154f003147acee90f2be9/httpx_sse-0.4.3.tar.gz", hash = "sha256:9b1ed0127459a66014aec3c56bebd93da3c1bc8bb6618c8082039a44889a755d", size = 15943, upload-time = "2025-10-10T21:48:22.271Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d2/fd/6668e5aec43ab844de6fc74927e155a3b37bf40d7c3790e49fc0406b6578/httpx_sse-0.4.3-py3-none-any.whl", hash = "sha256:0ac1c9fe3c0afad2e0ebb25a934a59f4c7823b60792691f779fad2c5568830fc", size = 8960, upload-time = "2025-10-10T21:48:21.158Z" },
+]
+
+[[package]]
+name = "huggingface-hub"
+version = "1.16.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "filelock" },
+    { name = "fsspec" },
+    { name = "hf-xet", marker = "platform_machine == 'AMD64' or platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'arm64' or platform_machine == 'x86_64'" },
+    { name = "httpx" },
+    { name = "packaging" },
+    { name = "pyyaml" },
+    { name = "tqdm" },
+    { name = "typer" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/48/0f/ed994dbade67a54407c28cab96ef845e0e6d25500be56aca6394f8bfc9dd/huggingface_hub-1.16.1.tar.gz", hash = "sha256:7f1dc4c5ec21aed69be630ad0c3378616be16f3de1a47b141c0e812965d9c832", size = 792534, upload-time = "2026-05-21T18:40:00.908Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/49/79/621a7dbb80c70974f73a597275351ebe03ce5bc65cb5f8f4acb5859252bc/huggingface_hub-1.16.1-py3-none-any.whl", hash = "sha256:64340de934b9ce37857ef85a82de72f5629e8a270f9119eabb12bf495eb53c22", size = 668176, upload-time = "2026-05-21T18:39:58.596Z" },
 ]
 
 [[package]]
@@ -451,6 +1339,18 @@ wheels = [
 ]
 
 [[package]]
+name = "importlib-metadata"
+version = "8.7.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "zipp" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f3/49/3b30cad09e7771a4982d9975a8cbf64f00d4a1ececb53297f1d9a7be1b10/importlib_metadata-8.7.1.tar.gz", hash = "sha256:49fef1ae6440c182052f407c8d34a68f72efc36db9ca90dc0113398f2fdde8bb", size = 57107, upload-time = "2025-12-21T10:00:19.278Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fa/5e/f8e9a1d23b9c20a551a8a02ea3637b4642e22c2626e3a13a9a29cdea99eb/importlib_metadata-8.7.1-py3-none-any.whl", hash = "sha256:5a1f80bf1daa489495071efbb095d75a634cf28a8bc299581244063b53176151", size = 27865, upload-time = "2025-12-21T10:00:18.329Z" },
+]
+
+[[package]]
 name = "iniconfig"
 version = "2.3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -460,25 +1360,78 @@ wheels = [
 ]
 
 [[package]]
+name = "inquirerpy"
+version = "0.3.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pfzy" },
+    { name = "prompt-toolkit" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/64/73/7570847b9da026e07053da3bbe2ac7ea6cde6bb2cbd3c7a5a950fa0ae40b/InquirerPy-0.3.4.tar.gz", hash = "sha256:89d2ada0111f337483cb41ae31073108b2ec1e618a49d7110b0d7ade89fc197e", size = 44431, upload-time = "2022-06-27T23:11:20.598Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ce/ff/3b59672c47c6284e8005b42e84ceba13864aa0f39f067c973d1af02f5d91/InquirerPy-0.3.4-py3-none-any.whl", hash = "sha256:c65fdfbac1fa00e3ee4fb10679f4d3ed7a012abf4833910e63c295827fe2a7d4", size = 67677, upload-time = "2022-06-27T23:11:17.723Z" },
+]
+
+[[package]]
+name = "jaraco-classes"
+version = "3.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "more-itertools" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/c0/ed4a27bc5571b99e3cff68f8a9fa5b56ff7df1c2251cc715a652ddd26402/jaraco.classes-3.4.0.tar.gz", hash = "sha256:47a024b51d0239c0dd8c8540c6c7f484be3b8fcf0b2d85c13825780d3b3f3acd", size = 11780, upload-time = "2024-03-31T07:27:36.643Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7f/66/b15ce62552d84bbfcec9a4873ab79d993a1dd4edb922cbfccae192bd5b5f/jaraco.classes-3.4.0-py3-none-any.whl", hash = "sha256:f662826b6bed8cace05e7ff873ce0f9283b5c924470fe664fff1c2f00f581790", size = 6777, upload-time = "2024-03-31T07:27:34.792Z" },
+]
+
+[[package]]
+name = "jaraco-context"
+version = "6.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/af/50/4763cd07e722bb6285316d390a164bc7e479db9d90daa769f22578f698b4/jaraco_context-6.1.2.tar.gz", hash = "sha256:f1a6c9d391e661cc5b8d39861ff077a7dc24dc23833ccee564b234b81c82dfe3", size = 16801, upload-time = "2026-03-20T22:13:33.922Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f2/58/bc8954bda5fcda97bd7c19be11b85f91973d67a706ed4a3aec33e7de22db/jaraco_context-6.1.2-py3-none-any.whl", hash = "sha256:bf8150b79a2d5d91ae48629d8b427a8f7ba0e1097dd6202a9059f29a36379535", size = 7871, upload-time = "2026-03-20T22:13:32.808Z" },
+]
+
+[[package]]
+name = "jaraco-functools"
+version = "4.5.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "more-itertools" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/36/cf/ea4ef2920830dea3f5ab2ea4da6fb67724e6dca80ee2553788c3607243d0/jaraco_functools-4.5.0.tar.gz", hash = "sha256:3bb5665ea4a020cf78a7040e89154c77edadb3ca74f366479669c5999aa70b03", size = 20272, upload-time = "2026-05-15T21:34:10.025Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/96/9a/982e48afcffcd727a9144506720ffd4224b6b7e355c98641866f38b7c043/jaraco_functools-4.5.0-py3-none-any.whl", hash = "sha256:79ce39246eddbde4b3a03b77ea5f0f7878dc669b166a66cf3fa8e266aa3fa2f4", size = 10594, upload-time = "2026-05-15T21:34:08.595Z" },
+]
+
+[[package]]
+name = "jeepney"
+version = "0.9.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7b/6f/357efd7602486741aa73ffc0617fb310a29b588ed0fd69c2399acbb85b0c/jeepney-0.9.0.tar.gz", hash = "sha256:cf0e9e845622b81e4a28df94c40345400256ec608d0e55bb8a3feaa9163f5732", size = 106758, upload-time = "2025-02-27T18:51:01.684Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b2/a3/e137168c9c44d18eff0376253da9f1e9234d0239e0ee230d2fee6cea8e55/jeepney-0.9.0-py3-none-any.whl", hash = "sha256:97e5714520c16fc0a45695e5365a2e11b81ea79bba796e26f9f1d178cb182683", size = 49010, upload-time = "2025-02-27T18:51:00.104Z" },
+]
+
+[[package]]
+name = "jinja2"
+version = "3.1.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markupsafe" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/df/bf/f7da0350254c0ed7c72f3e33cef02e048281fec7ecec5f032d4aac52226b/jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d", size = 245115, upload-time = "2025-03-05T20:05:02.478Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl", hash = "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67", size = 134899, upload-time = "2025-03-05T20:05:00.369Z" },
+]
+
+[[package]]
 name = "jiter"
 version = "0.14.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/6e/c1/0cddc6eb17d4c53a99840953f95dd3accdc5cfc7a337b0e9b26476276be9/jiter-0.14.0.tar.gz", hash = "sha256:e8a39e66dac7153cf3f964a12aad515afa8d74938ec5cc0018adcdae5367c79e", size = 165725, upload-time = "2026-04-10T14:28:42.01Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/8a/1f/198ae537fccb7080a0ed655eb56abf64a92f79489dfbf79f40fa34225bcd/jiter-0.14.0-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:7e791e247b8044512e070bd1f3633dc08350d32776d2d6e7473309d0edf256a2", size = 316896, upload-time = "2026-04-10T14:26:01.986Z" },
-    { url = "https://files.pythonhosted.org/packages/cf/34/da67cff3fce964a36d03c3e365fb0f8726ade2a6cfd4d3c70107e216ead6/jiter-0.14.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:71527ce13fd5a0c4e40ad37331f8c547177dbb2dd0a93e5278b6a5eecf748804", size = 321085, upload-time = "2026-04-10T14:26:03.364Z" },
-    { url = "https://files.pythonhosted.org/packages/ed/36/4c72e67180d4e71a4f5dcf7886d0840e83c49ab11788172177a77570326e/jiter-0.14.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:02c4a7ab56f746014874f2c525584c0daca1dec37f66fd707ecef3b7e5c2228c", size = 347393, upload-time = "2026-04-10T14:26:05.314Z" },
-    { url = "https://files.pythonhosted.org/packages/bc/db/9b39e09ceafa9878235c0fc29e3e3f9b12a4c6a98ea3085b998cadf3accc/jiter-0.14.0-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:376e9dafff914253bb9d46cdc5f7965607fbe7feb0a491c34e35f92b2770702e", size = 372937, upload-time = "2026-04-10T14:26:06.884Z" },
-    { url = "https://files.pythonhosted.org/packages/b0/96/0dcba1d7a82c1b720774b48ef239376addbaf30df24c34742ac4a57b67b2/jiter-0.14.0-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:23ad2a7a9da1935575c820428dd8d2490ce4d23189691ce33da1fc0a58e14e1c", size = 463646, upload-time = "2026-04-10T14:26:08.345Z" },
-    { url = "https://files.pythonhosted.org/packages/f1/e3/f61b71543e746e6b8b805e7755814fc242715c16f1dba58e1cbccb8032c2/jiter-0.14.0-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:54b3ddf5786bc7732d293bba3411ac637ecfa200a39983166d1df86a59a43c9f", size = 380225, upload-time = "2026-04-10T14:26:10.161Z" },
-    { url = "https://files.pythonhosted.org/packages/ad/5e/0ddeb7096aca099114abe36c4921016e8d251e6f35f5890240b31f1f60ae/jiter-0.14.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5c001d5a646c2a50dc055dd526dad5d5245969e8234d2b1131d0451e81f3a373", size = 358682, upload-time = "2026-04-10T14:26:11.574Z" },
-    { url = "https://files.pythonhosted.org/packages/e9/d1/fe0c46cd7fda9cad8f1ff9ad217dc61f1e4280b21052ec6dfe88c1446ef2/jiter-0.14.0-cp311-cp311-manylinux_2_31_riscv64.whl", hash = "sha256:834bb5bdabca2e91592a03d373838a8d0a1b8bbde7077ae6913fd2fc51812d00", size = 359973, upload-time = "2026-04-10T14:26:13.316Z" },
-    { url = "https://files.pythonhosted.org/packages/ac/21/f5317f91729b501019184771c80d60abd89907009e7bfa6c7e348c5bdd44/jiter-0.14.0-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:4e9178be60e229b1b2b0710f61b9e24d1f4f8556985a83ff4c4f95920eea7314", size = 397568, upload-time = "2026-04-10T14:26:15.212Z" },
-    { url = "https://files.pythonhosted.org/packages/e9/05/79d8f33fb2bf168db0df5c9cd16fe440a8ada57e929d3677b22712c2568f/jiter-0.14.0-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:a7e4ccff04ec03614e62c613e976a3a5860dc9714ce8266f44328bdc8b1cab2c", size = 522535, upload-time = "2026-04-10T14:26:16.956Z" },
-    { url = "https://files.pythonhosted.org/packages/5c/00/d1e3ff3d2a465e67f08507d74bafb2dcd29eba91dc939820e39e8dea38b8/jiter-0.14.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:69539d936fb5d55caf6ecd33e2e884de083ff0ea28579780d56c4403094bb8d9", size = 556709, upload-time = "2026-04-10T14:26:18.5Z" },
-    { url = "https://files.pythonhosted.org/packages/60/5b/bbb2189f62ace8d95e869aa4c84c9946616f301e2d02895a6f20dcc3bba3/jiter-0.14.0-cp311-cp311-win32.whl", hash = "sha256:4927d09b3e572787cc5e0a5318601448e1ab9391bcef95677f5840c2d00eaa6d", size = 208660, upload-time = "2026-04-10T14:26:20.511Z" },
-    { url = "https://files.pythonhosted.org/packages/b8/86/c500b53dcbf08575f5963e536ebd757a1f7c568272ba5d180b212c9a87fb/jiter-0.14.0-cp311-cp311-win_amd64.whl", hash = "sha256:42d6ed359ac49eb922fdd565f209c57340aa06d589c84c8413e42a0f9ae1b842", size = 204659, upload-time = "2026-04-10T14:26:22.152Z" },
-    { url = "https://files.pythonhosted.org/packages/75/4a/a676249049d42cb29bef82233e4fe0524d414cbe3606c7a4b311193c2f77/jiter-0.14.0-cp311-cp311-win_arm64.whl", hash = "sha256:6dd689f5f4a5a33747b28686e051095beb214fe28cfda5e9fe58a295a788f593", size = 194772, upload-time = "2026-04-10T14:26:23.458Z" },
     { url = "https://files.pythonhosted.org/packages/5a/68/7390a418f10897da93b158f2d5a8bd0bcd73a0f9ec3bb36917085bb759ef/jiter-0.14.0-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:2fb2ce3a7bc331256dfb14cefc34832366bb28a9aca81deaf43bbf2a5659e607", size = 316295, upload-time = "2026-04-10T14:26:24.887Z" },
     { url = "https://files.pythonhosted.org/packages/60/a0/5854ac00ff63551c52c6c89534ec6aba4b93474e7924d64e860b1c94165b/jiter-0.14.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:5252a7ca23785cef5d02d4ece6077a1b556a410c591b379f82091c3001e14844", size = 315898, upload-time = "2026-04-10T14:26:26.601Z" },
     { url = "https://files.pythonhosted.org/packages/41/a1/4f44832650a16b18e8391f1bf1d6ca4909bc738351826bcc198bba4357f4/jiter-0.14.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c409578cbd77c338975670ada777add4efd53379667edf0aceea730cabede6fb", size = 343730, upload-time = "2026-04-10T14:26:28.326Z" },
@@ -539,14 +1492,31 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/97/f8/33d78c83bd93ae0c0af05293a6660f88a1977caef39a6d72a84afab94ce0/jiter-0.14.0-cp314-cp314t-win32.whl", hash = "sha256:2f7877ed45118de283786178eceaf877110abacd04fde31efff3940ae9672674", size = 207957, upload-time = "2026-04-10T14:27:59.285Z" },
     { url = "https://files.pythonhosted.org/packages/d6/ac/2b760516c03e2227826d1f7025d89bf6bf6357a28fe75c2a2800873c50bf/jiter-0.14.0-cp314-cp314t-win_amd64.whl", hash = "sha256:14c0cb10337c49f5eafe8e7364daca5e29a020ea03580b8f8e6c597fed4e1588", size = 204690, upload-time = "2026-04-10T14:28:00.962Z" },
     { url = "https://files.pythonhosted.org/packages/dc/2e/a44c20c58aeed0355f2d326969a181696aeb551a25195f47563908a815be/jiter-0.14.0-cp314-cp314t-win_arm64.whl", hash = "sha256:5419d4aa2024961da9fe12a9cfe7484996735dca99e8e090b5c88595ef1951ff", size = 191338, upload-time = "2026-04-10T14:28:02.853Z" },
-    { url = "https://files.pythonhosted.org/packages/32/a1/ef34ca2cab2962598591636a1804b93645821201cc0095d4a93a9a329c9d/jiter-0.14.0-graalpy311-graalpy242_311_native-macosx_10_12_x86_64.whl", hash = "sha256:a25ffa2dbbdf8721855612f6dca15c108224b12d0c4024d0ac3d7902132b4211", size = 311366, upload-time = "2026-04-10T14:28:27.943Z" },
-    { url = "https://files.pythonhosted.org/packages/60/bb/520576a532a6b8a6f42747afed289c8448c879a34d7802fe2c832d4fd38f/jiter-0.14.0-graalpy311-graalpy242_311_native-macosx_11_0_arm64.whl", hash = "sha256:0ac9cbaa86c10996b92bd12c91659b60f939f8e28fcfa6bc11a0e90a774ce95b", size = 309873, upload-time = "2026-04-10T14:28:29.688Z" },
-    { url = "https://files.pythonhosted.org/packages/b2/7c/c16db114ea1f2f532f198aa8dc39585026af45af362c69a0492f31bc4821/jiter-0.14.0-graalpy311-graalpy242_311_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:844e73b6c56b505e9e169234ea3bdea2ea43f769f847f47ac559ba1d2361ebea", size = 344816, upload-time = "2026-04-10T14:28:31.348Z" },
-    { url = "https://files.pythonhosted.org/packages/99/8f/15e7741ff19e9bcd4d753f7ff22f988fd54592f134ca13701c13ea8c20e0/jiter-0.14.0-graalpy311-graalpy242_311_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e52c076f187405fc21523c746c04399c9af8ece566077ed147b2126f2bcba577", size = 351445, upload-time = "2026-04-10T14:28:33.093Z" },
     { url = "https://files.pythonhosted.org/packages/21/42/9042c3f3019de4adcb8c16591c325ec7255beea9fcd33a42a43f3b0b1000/jiter-0.14.0-graalpy312-graalpy250_312_native-macosx_10_12_x86_64.whl", hash = "sha256:fbd9e482663ca9d005d051330e4d2d8150bb208a209409c10f7e7dfdf7c49da9", size = 308810, upload-time = "2026-04-10T14:28:34.673Z" },
     { url = "https://files.pythonhosted.org/packages/60/cf/a7e19b308bd86bb04776803b1f01a5f9a287a4c55205f4708827ee487fbf/jiter-0.14.0-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:33a20d838b91ef376b3a56896d5b04e725c7df5bc4864cc6569cf046a8d73b6d", size = 308443, upload-time = "2026-04-10T14:28:36.658Z" },
     { url = "https://files.pythonhosted.org/packages/ca/44/e26ede3f0caeff93f222559cb0cc4ca68579f07d009d7b6010c5b586f9b1/jiter-0.14.0-graalpy312-graalpy250_312_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:432c4db5255d86a259efde91e55cb4c8d18c0521d844c9e2e7efcce3899fb016", size = 343039, upload-time = "2026-04-10T14:28:38.356Z" },
     { url = "https://files.pythonhosted.org/packages/da/e9/1f9ada30cef7b05e74bb06f52127e7a724976c225f46adb65c37b1dadfb6/jiter-0.14.0-graalpy312-graalpy250_312_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:67f00d94b281174144d6532a04b66a12cb866cbdc47c3af3bfe2973677f9861a", size = 349613, upload-time = "2026-04-10T14:28:40.066Z" },
+]
+
+[[package]]
+name = "joserfc"
+version = "1.7.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/44/90/25cb27518750218e4f850be63d8bbb2343efaad1c01c3571aaa4b3c33bd7/joserfc-1.7.1.tar.gz", hash = "sha256:77d0b76514879c68c6f433bc5b7357a4ab72008ff1e33d8379fd11d72bd8ca81", size = 233181, upload-time = "2026-06-08T07:21:33.412Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/00/fa62404c3e347f946faa13aa21085205f9cc06ad17671e37f81a51662ae8/joserfc-1.7.1-py3-none-any.whl", hash = "sha256:b3e3d655612e2e1ef67b2600f2f420e12e537b020208fab1761fad647319c164", size = 70423, upload-time = "2026-06-08T07:21:32.001Z" },
+]
+
+[[package]]
+name = "json-repair"
+version = "0.60.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5e/a6/d69888cb4ffde30e80db1e6c32caaadd2f984a80067d5ea72c2cb3f61c3f/json_repair-0.60.1.tar.gz", hash = "sha256:841661cdd2df507c9a4e189097f38ca6bc372e06d4b4e36d72e590f68176c290", size = 49451, upload-time = "2026-06-03T17:28:44.451Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/32/1f/2a2b5eea8ef5762a86ad3f8fddddaaba2c0d76dd44e644b9158900868bec/json_repair-0.60.1-py3-none-any.whl", hash = "sha256:ba6ff974f2a8bef2f7768144a7f03f870a816443f03da27a49cdd0ec31a78049", size = 48045, upload-time = "2026-06-03T17:28:43.038Z" },
 ]
 
 [[package]]
@@ -571,6 +1541,15 @@ wheels = [
 ]
 
 [[package]]
+name = "jsonref"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/aa/0d/c1f3277e90ccdb50d33ed5ba1ec5b3f0a242ed8c1b1a85d3afeb68464dca/jsonref-1.1.0.tar.gz", hash = "sha256:32fe8e1d85af0fdefbebce950af85590b22b60f9e95443176adbde4e1ecea552", size = 8814, upload-time = "2023-01-16T16:10:04.455Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/ec/e1db9922bceb168197a558a2b8c03a7963f1afe93517ddd3cf99f202f996/jsonref-1.1.0-py3-none-any.whl", hash = "sha256:590dc7773df6c21cbf948b5dac07a72a251db28b0238ceecce0a2abfa8ec30a9", size = 9425, upload-time = "2023-01-16T16:10:02.255Z" },
+]
+
+[[package]]
 name = "jsonschema"
 version = "4.26.0"
 source = { registry = "https://pypi.org/simple" }
@@ -586,6 +1565,21 @@ wheels = [
 ]
 
 [[package]]
+name = "jsonschema-path"
+version = "0.5.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "pathable" },
+    { name = "pyyaml" },
+    { name = "referencing" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/39/79/cd02a4df6d9270efdc7d3feefe6edd730b0820c39eeaa107a2faee8322d5/jsonschema_path-0.5.0.tar.gz", hash = "sha256:493b156ba895c97602655b620a8456caa2ce08c1aa389f5a7addec065e6e855c", size = 19597, upload-time = "2026-05-19T20:45:00.971Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/2c/9e69d73c4297508be9e3b64a970ea3971b3eb8db64ffc5802d40bd25981f/jsonschema_path-0.5.0-py3-none-any.whl", hash = "sha256:2790a070bc7abb08ea3dbe4d340ece4efadf639223001f020c7503229ba068e2", size = 24077, upload-time = "2026-05-19T20:44:59.225Z" },
+]
+
+[[package]]
 name = "jsonschema-specifications"
 version = "2025.9.1"
 source = { registry = "https://pypi.org/simple" }
@@ -595,6 +1589,23 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/19/74/a633ee74eb36c44aa6d1095e7cc5569bebf04342ee146178e2d36600708b/jsonschema_specifications-2025.9.1.tar.gz", hash = "sha256:b540987f239e745613c7a9176f3edb72b832a4ac465cf02712288397832b5e8d", size = 32855, upload-time = "2025-09-08T01:34:59.186Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/41/45/1a4ed80516f02155c51f51e8cedb3c1902296743db0bbc66608a0db2814f/jsonschema_specifications-2025.9.1-py3-none-any.whl", hash = "sha256:98802fee3a11ee76ecaca44429fda8a41bff98b00a0f2838151b113f210cc6fe", size = 18437, upload-time = "2025-09-08T01:34:57.871Z" },
+]
+
+[[package]]
+name = "keyring"
+version = "25.7.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jaraco-classes" },
+    { name = "jaraco-context" },
+    { name = "jaraco-functools" },
+    { name = "jeepney", marker = "sys_platform == 'linux'" },
+    { name = "pywin32-ctypes", marker = "sys_platform == 'win32'" },
+    { name = "secretstorage", marker = "sys_platform == 'linux'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/43/4b/674af6ef2f97d56f0ab5153bf0bfa28ccb6c3ed4d1babf4305449668807b/keyring-25.7.0.tar.gz", hash = "sha256:fe01bd85eb3f8fb3dd0405defdeac9a5b4f6f0439edbb3149577f244a2e8245b", size = 63516, upload-time = "2025-11-16T16:26:09.482Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/81/db/e655086b7f3a705df045bf0933bdd9c2f79bb3c97bfef1384598bb79a217/keyring-25.7.0-py3-none-any.whl", hash = "sha256:be4a0b195f149690c166e850609a477c532ddbfbaed96a404d4e43f8d5e2689f", size = 39160, upload-time = "2025-11-16T16:26:08.402Z" },
 ]
 
 [[package]]
@@ -706,6 +1717,284 @@ wheels = [
 ]
 
 [[package]]
+name = "libtmux"
+version = "0.58.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/65/4e/daccd4fd72ad3f17b8fb97f69403774d6c510b5d513521b454fdaedb0561/libtmux-0.58.0.tar.gz", hash = "sha256:abbe330bec2c45687a4bf417ee436373b37046afe123ba547495ee0448e1145a", size = 522080, upload-time = "2026-05-23T16:03:38.566Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/49/d5/1cee7c13865d0d55ddb54709aaf85e0dc645e2998ce85ffce2c36d3bf08d/libtmux-0.58.0-py3-none-any.whl", hash = "sha256:1aec9875983a8eb121a8de7be7dffa6b97d9754c013ce960944d058764e47ec3", size = 113680, upload-time = "2026-05-23T16:03:37.049Z" },
+]
+
+[[package]]
+name = "litellm"
+version = "1.88.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "aiohttp" },
+    { name = "click" },
+    { name = "fastuuid" },
+    { name = "httpx" },
+    { name = "importlib-metadata" },
+    { name = "jinja2" },
+    { name = "jsonschema" },
+    { name = "openai" },
+    { name = "pydantic" },
+    { name = "python-dotenv" },
+    { name = "tiktoken" },
+    { name = "tokenizers" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/16/ea/f99ececb7f22703fe120f1d8be9ffb749ec9453fbbbbbebc0d6a6b4d7864/litellm-1.88.1.tar.gz", hash = "sha256:89c6b74cc7912d6365793006ff951c0450fe847625008dfe49de8a7dc4529aa5", size = 13885969, upload-time = "2026-06-09T01:06:25.192Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/42/9a/8f8909201b4bebaf96498c09226f6baa8540086a4c4188ad57d7dfbd97c1/litellm-1.88.1-py3-none-any.whl", hash = "sha256:369b84e57d9426582ddc35e731956ddb6618cda97cc44e4e4d2dfa75982a6e3a", size = 15276206, upload-time = "2026-06-09T01:06:16.72Z" },
+]
+
+[[package]]
+name = "lmnr"
+version = "0.7.52"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "grpcio" },
+    { name = "httpx" },
+    { name = "lmnr-claude-code-proxy" },
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-exporter-otlp-proto-grpc" },
+    { name = "opentelemetry-exporter-otlp-proto-http" },
+    { name = "opentelemetry-instrumentation" },
+    { name = "opentelemetry-instrumentation-threading" },
+    { name = "opentelemetry-sdk" },
+    { name = "opentelemetry-semantic-conventions" },
+    { name = "opentelemetry-semantic-conventions-ai" },
+    { name = "orjson" },
+    { name = "packaging" },
+    { name = "pydantic" },
+    { name = "python-dotenv" },
+    { name = "tenacity" },
+    { name = "tqdm" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d0/f3/c5145aa358b813fab44fe46ffe9b8a3f0e843d7b8bf80beefb6e4150b105/lmnr-0.7.52.tar.gz", hash = "sha256:f6377186fea076082769bfb39e809291c22a435b9b7e469b32ca85738997b853", size = 263689, upload-time = "2026-05-27T21:13:35.383Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/00/5f/7d51eafb3bfeec96592d314bdcb0f9a757d20496c857b5e9617da6d3e69e/lmnr-0.7.52-py3-none-any.whl", hash = "sha256:97eb6481b93b07e6f76f3b94e8ac6c38dd073a668642341817da737320e98661", size = 346456, upload-time = "2026-05-27T21:13:33.788Z" },
+]
+
+[[package]]
+name = "lmnr-claude-code-proxy"
+version = "0.1.22"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "httpx" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/42/6b/1914d8c5c1c57ab64896a33f7eb442d9998df81e8c6464892df2d516d5cd/lmnr_claude_code_proxy-0.1.22.tar.gz", hash = "sha256:c5b76df948f750045f37fd5cb62dc563397c1f262d3a4e85d00386588a8de035", size = 61533, upload-time = "2026-06-10T20:35:24.477Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/83/2c/30b2bc1f3b650a5d9dcb9f9431faf82768745208b2fc7ba0acf10b64dfa6/lmnr_claude_code_proxy-0.1.22-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:ec269db7dd77c8548945201aa7ac4bc1a2c81423f3837bef0b8ee1c097cb2e5c", size = 1367650, upload-time = "2026-06-10T20:33:41.944Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/31/490946379080b647b76eb35be2e6d343ef49885a79316efa364c077ea2a5/lmnr_claude_code_proxy-0.1.22-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:2b866497e05bae270a7e7ec9b985b54d0e7c950cc3b24c564dba08a2e6ba36f4", size = 1314913, upload-time = "2026-06-10T20:34:04.983Z" },
+    { url = "https://files.pythonhosted.org/packages/43/0e/b121145f5f868d6c2f503813280d70e3dad1de42a823e15d73b913a3ce9f/lmnr_claude_code_proxy-0.1.22-cp312-cp312-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:e8784edafc906aeeaa47e966b4b06b4cfe1f67b9257bf86e5fd0af7a8145d175", size = 1354214, upload-time = "2026-06-10T20:35:56.001Z" },
+    { url = "https://files.pythonhosted.org/packages/09/15/824bcfd08d0ea5c9db5645b390644c6e9def14ff0f103977f92242498b9a/lmnr_claude_code_proxy-0.1.22-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:fe96853d0af0afbc18efcf4caa02dd1f7753639a3d102bebef6785ffb54b92c8", size = 1189749, upload-time = "2026-06-10T20:33:25.054Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/a7/3ad03e0a32761229923b275a2af9167a0aa58d44e609ce5ad8c4e7c215f7/lmnr_claude_code_proxy-0.1.22-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:ee6ea4f602eec35567d50c7bb1d71b5dd5a2ebeec9ceb501351949bcd5944308", size = 1358422, upload-time = "2026-06-10T20:34:19.422Z" },
+    { url = "https://files.pythonhosted.org/packages/14/45/7657648c529f9a14e1246d5030cea58662cc7b20c9788e528372829a7760/lmnr_claude_code_proxy-0.1.22-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:bd1a96d6696501b7162cf785590db62d1ceedf1fa1dab5a29f97e1378be07aa9", size = 1275780, upload-time = "2026-06-10T20:34:56.7Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/3e/e474569c6bbd7f108ddf4ce450dce1a7d5148a6b60551e855b2e7f56cbb4/lmnr_claude_code_proxy-0.1.22-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e6fc1ebd8831d13658f1e3bd4a9fbcfc02433348eebe53bf432dd2f6d8c9df99", size = 1501031, upload-time = "2026-06-10T20:35:37.17Z" },
+    { url = "https://files.pythonhosted.org/packages/79/e2/087e05fa4f959b53aafa825bdbaeceae6931febd2e4c7ef4d6aad6a4e49a/lmnr_claude_code_proxy-0.1.22-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:cfca1b2ad9557e19d14ac605af6d2929809445a165f84484acd43d92385feeec", size = 1467503, upload-time = "2026-06-10T20:33:05.484Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/57/d2c0413e2b5dc4cbfc22a75d1059cea9de0bf55abd640814fa58a35900ef/lmnr_claude_code_proxy-0.1.22-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:0d3f9bfa866701100425ab6a69a18be6b97be2df9d246a1f16e8af74c33b1943", size = 1647289, upload-time = "2026-06-10T20:35:54.335Z" },
+    { url = "https://files.pythonhosted.org/packages/03/c9/04a8a40c0f230aad46d501c6b8420a0d3dc088d4f9866a95a90a38e33fef/lmnr_claude_code_proxy-0.1.22-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:5069e87de2415119764b261fae77d856223ccd255db07954c01f0581365e3656", size = 1462627, upload-time = "2026-06-10T20:35:10.724Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/1f/2cc00f700a4a382c72f764b4d1abee6e703072f8003d103481269ee41c03/lmnr_claude_code_proxy-0.1.22-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:8bedb4925134d4d2ca46ef7f0f087fa0928ee33e772d984309f5baa98585458b", size = 1525246, upload-time = "2026-06-10T20:35:59.32Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/cd/9710193de33949b3b058da0ef6258f87dbd187d8100800d1e36a907c1c7b/lmnr_claude_code_proxy-0.1.22-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:5ea9c6c06f02dac55cd30c682ec03cf4942ce65d38f8dbe7635ca49d7f50686d", size = 1719096, upload-time = "2026-06-10T20:35:12.375Z" },
+    { url = "https://files.pythonhosted.org/packages/68/77/f94c2aa5da7cf586f5ab20af1ce39e084d3e375b5cf0165f1b6662a36dda/lmnr_claude_code_proxy-0.1.22-cp312-cp312-win32.whl", hash = "sha256:2e2734ff15269b21cf717f0f458d890d58d8ece01e026c117245d8b4a81f7dfb", size = 1077061, upload-time = "2026-06-10T20:34:30.502Z" },
+    { url = "https://files.pythonhosted.org/packages/53/53/1cfdcc407b897c02ec9edc448853269f30fa174e8ded7f3eefb0730786a4/lmnr_claude_code_proxy-0.1.22-cp312-cp312-win_amd64.whl", hash = "sha256:baca93346ce704452ac4dcaaeb28a27e8f3f95b0683fde6fb0169544696005af", size = 1314136, upload-time = "2026-06-10T20:34:31.924Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/30/2f5e4460f51bfa5b05e1459c02253aae17e66890d3e0291ed6ca97fa66a0/lmnr_claude_code_proxy-0.1.22-cp312-cp312-win_arm64.whl", hash = "sha256:e6f4078c4d5c4a940eb0f102b04f2c849931b656aed89858469307f8da327cbb", size = 1237749, upload-time = "2026-06-10T20:33:37.727Z" },
+    { url = "https://files.pythonhosted.org/packages/71/23/64b7df94c3c2f3132a34b9c7f4b9aadd2742e680124282acfd22621db834/lmnr_claude_code_proxy-0.1.22-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:79e7b101ff55a4c831a0c7def58cc701e091eea1213794ab0abffb13b40ce925", size = 1367831, upload-time = "2026-06-10T20:33:34.969Z" },
+    { url = "https://files.pythonhosted.org/packages/38/4b/128596ce770a83fd6fbde0c9717d19cb5249bacf1f47e74ae62fe4942eb7/lmnr_claude_code_proxy-0.1.22-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:b045141b413d0a4c9104f82f0d7ac570f24aaebeab69972a0085dd7edc0fb1f2", size = 1314988, upload-time = "2026-06-10T20:33:29.218Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/d7/a1af210ef21a7d2112e69fb796e7f7111636c64bfdd4c202710074256f54/lmnr_claude_code_proxy-0.1.22-cp313-cp313-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:6a3961ea0656fe3314be0b8de762bde1a0ccaac5624c5864fd0de94661442195", size = 1354358, upload-time = "2026-06-10T20:34:58.159Z" },
+    { url = "https://files.pythonhosted.org/packages/81/8c/5e73e1c02a172f8c1cea94f4c9392056ff60e7f8a1033058e989a04629ec/lmnr_claude_code_proxy-0.1.22-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:dd75856094e408652ae05a07e28ce32a1289c158ae6d5d265f4baf7e124f9b58", size = 1189818, upload-time = "2026-06-10T20:34:22.235Z" },
+    { url = "https://files.pythonhosted.org/packages/75/dc/b37b1d6d91dad79954bcad28e276678e094aad9d20e53e58d397a1a4a8ea/lmnr_claude_code_proxy-0.1.22-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:77f0852ea0091acaeb3e72bd11ce6b193a9f9d241a91aaf104205bf8e2f9b757", size = 1358465, upload-time = "2026-06-10T20:33:08.618Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/ee/3deac6babb7a96d81170d136320ec7440ac0e6ed4841dcea4405744b3cf2/lmnr_claude_code_proxy-0.1.22-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:28185fb6dd80ccb74dffb816f2813e9fdf34d226a9f3a85dae31e7122e323b5a", size = 1275988, upload-time = "2026-06-10T20:34:54.316Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/cc/39088748a1c64e6d0c476fe85ccb66ebd5a40632fbb0ddcfa9286e8e1584/lmnr_claude_code_proxy-0.1.22-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bf214aefb5447d269385e4873e7e81f3a4ca5df859ff94bf59b1c75b4fd1f2ff", size = 1501140, upload-time = "2026-06-10T20:34:11.384Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/0f/7dc52da9345d0f4e971fb68efca2ca546d83ac401f56b0e4782c8fe62794/lmnr_claude_code_proxy-0.1.22-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:484350257c2d1a300f3bc5fea54f91ad4218dc71de84d8ece30fbabdecf4bf19", size = 1467505, upload-time = "2026-06-10T20:33:53.39Z" },
+    { url = "https://files.pythonhosted.org/packages/09/48/d734a37b2a6e14845f35d2f1a0a59353cfb161b0effe49f13c7797707db9/lmnr_claude_code_proxy-0.1.22-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:f10a6b05002d1b3f246e1fa02bbac115b50452cd2bea58b1fd6204d0a7290683", size = 1647390, upload-time = "2026-06-10T20:35:44.181Z" },
+    { url = "https://files.pythonhosted.org/packages/65/55/5f35b5a4a090cc682e8c17eea9df4d34dea7c3194c69d5c00f0f692018c8/lmnr_claude_code_proxy-0.1.22-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:b02cfa276d7107b0598ba34e38332bac33e2b2d85ffb39cc2546b121135b11f5", size = 1462928, upload-time = "2026-06-10T20:34:35.09Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/31/8a898e7a67dfaaef44496de61a10036ed90445eeda7b941f66a8339cc013/lmnr_claude_code_proxy-0.1.22-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:f51e6f8dd7df6b51e073845324c6b877c5e8beac96334dba28904ef684f05ddf", size = 1525217, upload-time = "2026-06-10T20:35:09.216Z" },
+    { url = "https://files.pythonhosted.org/packages/14/b4/07c9112b87c416ff0086a03fbce62daefad9cd3af966b21e37fe15bd2de1/lmnr_claude_code_proxy-0.1.22-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:27d116ed79f9b07e508f1efb5eeb7039e59290be5f2443484e5b04d68a6cb91f", size = 1719359, upload-time = "2026-06-10T20:35:15.457Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/c6/54cd8db3620c778e77dcf2d683f773640214f8b9d81ab31abfd1a0b40b29/lmnr_claude_code_proxy-0.1.22-cp313-cp313-win32.whl", hash = "sha256:b95ac10df2316723396d24ccb2fc8ca4b50a7f6ce05f9eb488d90d73ab8fd3fc", size = 1080231, upload-time = "2026-06-10T20:34:07.764Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/e9/4beafd83e8616eb4022c060e3f5b12b12cf67304d534f76a79da3f6bc084/lmnr_claude_code_proxy-0.1.22-cp313-cp313-win_amd64.whl", hash = "sha256:dccf79e0893c9460f9b636dfef036dee46aaccc8a516fcb499c64e04f38db4b6", size = 1314260, upload-time = "2026-06-10T20:33:32.177Z" },
+    { url = "https://files.pythonhosted.org/packages/37/c5/48cf88f2e3995356adce82016db8361ced0213cf9f2b860e268e28e76325/lmnr_claude_code_proxy-0.1.22-cp313-cp313-win_arm64.whl", hash = "sha256:f6bfa56426065a22dc96ccba2f30118de0b27f73eef5d612298ff9142be3ee3f", size = 1237873, upload-time = "2026-06-10T20:35:01.315Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/41/9dd342821c9914817b380d8c33cb9f52990aafd45de0457ed9723db1e87e/lmnr_claude_code_proxy-0.1.22-cp313-cp313t-macosx_10_12_x86_64.whl", hash = "sha256:18106e307aa6d635d2db174be37b1306ace8ebeb9f694425688785f7c690d00c", size = 1375946, upload-time = "2026-06-10T20:34:00.818Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/89/9c4e5a937aab1dc1a558ca4a6df6433e778708085c88c558f522213a4c34/lmnr_claude_code_proxy-0.1.22-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:8a126fef572f53371962c2188ca2b2039dc87b5ac8d015962ccc7b1d2dc7228c", size = 1315049, upload-time = "2026-06-10T20:35:49.712Z" },
+    { url = "https://files.pythonhosted.org/packages/94/84/953e768b8e574285f8629a0b6e3623d8452898b8e284fc3f2db9593b3384/lmnr_claude_code_proxy-0.1.22-cp313-cp313t-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:1cd134910c6c1355d7fd06fefbbbc1314e3204e2b8b97d031926cebfdf98e035", size = 1354465, upload-time = "2026-06-10T20:34:16.598Z" },
+    { url = "https://files.pythonhosted.org/packages/de/e0/c5bef28a74bd3054578a19b35b1be9773bca98b368db24509ea7909cc033/lmnr_claude_code_proxy-0.1.22-cp313-cp313t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:3649bd397dee162e7786a266b760fef268d93ba121c986d085bdd046cfe13709", size = 1189642, upload-time = "2026-06-10T20:33:18.923Z" },
+    { url = "https://files.pythonhosted.org/packages/87/21/3796c0519e04cad3d3ad808f64ea2b1d4755127caf3e86009ba78ba58c7f/lmnr_claude_code_proxy-0.1.22-cp313-cp313t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9f7f081ab498430e82cc51dacb299bb25b3ff485e822692973a4f0fd35833b67", size = 1358579, upload-time = "2026-06-10T20:33:40.54Z" },
+    { url = "https://files.pythonhosted.org/packages/de/2c/1b476434724c1500f2c22dc7606393b13e94195eed7b408aa7da41287d44/lmnr_claude_code_proxy-0.1.22-cp313-cp313t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e6e9de9e9da66fc4678829240955f402a3ce7615aa2319e866227481a7d6d803", size = 1275833, upload-time = "2026-06-10T20:35:52.815Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/15/f2aa6c7de2216e81ea2ee0201dce3af235c9f68aa7232f78d9d848556382/lmnr_claude_code_proxy-0.1.22-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9a2216f8212cf4210ce1a77ffc5b0e34998e0cd1e903985faedacc01929958b7", size = 1501076, upload-time = "2026-06-10T20:33:11.954Z" },
+    { url = "https://files.pythonhosted.org/packages/37/79/db08d066b90caf4271d15b7929935ba1b8784ab134ff4cfa2474a103590e/lmnr_claude_code_proxy-0.1.22-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:63a5f785d66b4c4e031a875c3941b242678cad1c4c6681974481fea283138cdc", size = 1467596, upload-time = "2026-06-10T20:34:27.515Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/5d/4b115bb71474073bc7890f68617cef30d8f3a471e75d40a8efac24a5c676/lmnr_claude_code_proxy-0.1.22-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:7eec5af81510989cac12fdacee473e2b386461fdd6703d15e6650f0cc1f371b2", size = 1647407, upload-time = "2026-06-10T20:34:24.058Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/1b/fd1552549c14b96b9087a5827867b2f4f586de274987beb8d89cdb3e10ad/lmnr_claude_code_proxy-0.1.22-cp313-cp313t-musllinux_1_2_armv7l.whl", hash = "sha256:b1f57e78042da04983d9a69218aa919a24389abe94094c25741f71d8dc7110ca", size = 1462736, upload-time = "2026-06-10T20:35:34.014Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/11/c144c75b69c60d3c4ac1964658abd081470adf402ac46211bd52be614f00/lmnr_claude_code_proxy-0.1.22-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:f921edc3f34cdf84547f4139c78afd559f5380daa95353bdc175b1cda65c66c1", size = 1525418, upload-time = "2026-06-10T20:33:45.295Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/24/2919addfda2109aeceeeade57168ec999739ca1d7b442d2bdaec7e3d02d1/lmnr_claude_code_proxy-0.1.22-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:8dc14fb21fea85688ba562de58aeba7fcb227ad3c1d1e3084979b66c8f1ee857", size = 1719358, upload-time = "2026-06-10T20:34:49.687Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/0a/616f52a44718c0a6ab848bd7fa3a8bd46a6274491776c640d67f5208cbdd/lmnr_claude_code_proxy-0.1.22-cp313-cp313t-win32.whl", hash = "sha256:ad1ea3809fe336986688e0d18404c2b86bf0553c2e5f9230c230e381617bb5ed", size = 1077253, upload-time = "2026-06-10T20:33:39.005Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/9f/0e735e1d945300498a1e2c0212926ffb694e41a33dccdd1e5c3e5fdf804c/lmnr_claude_code_proxy-0.1.22-cp313-cp313t-win_amd64.whl", hash = "sha256:feec9b9bc0af06daf3bfb3aeb4ed1ccd8a51530f6e5923efd24b673d163e0327", size = 1314164, upload-time = "2026-06-10T20:34:02.067Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/d1/7c92b65cf519eac72683521f8750b4cba4d3a325537f1a71fea9648fb595/lmnr_claude_code_proxy-0.1.22-cp313-cp313t-win_arm64.whl", hash = "sha256:e2128108dcdb7faa1904f6d2720b2406ea05fa22d9d6c525e9b052497ceeb9e3", size = 1237834, upload-time = "2026-06-10T20:33:13.409Z" },
+    { url = "https://files.pythonhosted.org/packages/78/3e/1c29b4953ca20c029d9485650cacdb4de49861bd4feabb801ec14e0cc60e/lmnr_claude_code_proxy-0.1.22-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:f185a3161d86ed477ec4e5259b9d9edd7e6b253d42333de226fb72d3c1f407bb", size = 1367943, upload-time = "2026-06-10T20:34:39.778Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/dd/b55dd1b9f50566c0a37e6a1f1d47d1fbfcbaeca860cfe46ea609ebf2cea3/lmnr_claude_code_proxy-0.1.22-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c0f9b09cb656c431d069325bf3e4cbd6f22a5b43c051807ae38ab665a0ec6682", size = 1315307, upload-time = "2026-06-10T20:34:44.593Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/cf/e873d03287f64b6c45f618949d220d1414ce5b454240b7fb807bd7214bf0/lmnr_claude_code_proxy-0.1.22-cp314-cp314-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:24174a9d5295c445a2b69fb898206cc37e0b655d3588c7df2b00132277394436", size = 1354445, upload-time = "2026-06-10T20:33:47.529Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/8a/d2190140bc8ff5d14f505e7c0761c0c84d94aab4cc30c81690a83cc73f5f/lmnr_claude_code_proxy-0.1.22-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:a9949a3cae44a4d151e1cde30d792cbb4dd39dc1e7d856fcc74793d4d1eb02c1", size = 1189843, upload-time = "2026-06-10T20:34:43.133Z" },
+    { url = "https://files.pythonhosted.org/packages/02/26/ebac19fe81f5899d663d473a88249939dff79c618f435ad486dc31648498/lmnr_claude_code_proxy-0.1.22-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:7b3af3edee00b9357cac5679006287e3073827c9b676f6645a283a92127469e0", size = 1358524, upload-time = "2026-06-10T20:33:59.413Z" },
+    { url = "https://files.pythonhosted.org/packages/80/f9/b2afbd0ad185b084799a43ddbc7037610aecd63f5b4513db209b2c5cb884/lmnr_claude_code_proxy-0.1.22-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:7ec208605733094a618432537922661ce4950f70b8b91ffa469eb1ba2c8a75a1", size = 1276030, upload-time = "2026-06-10T20:35:07.48Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/92/77d078eec9a0459ee0965fb27177e20556eda3e8334e30245cab2073b317/lmnr_claude_code_proxy-0.1.22-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:85ac62e724ecaa8b36a127d0e205016c7ec4a25c2bfb570fa3b1e279ba740ffc", size = 1501206, upload-time = "2026-06-10T20:34:29.063Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/ee/26687dcb148ebfbd72c9f3ea530dab52032aa14e742f0b66a4a97079777c/lmnr_claude_code_proxy-0.1.22-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:c8831e629bf9b447cf71bf9400cfad77dbdb028201a9a450335a7b917cee29dc", size = 1467483, upload-time = "2026-06-10T20:34:03.591Z" },
+    { url = "https://files.pythonhosted.org/packages/96/07/b51114aab07f5dd2cb695525051e007896bc5f72ca433b8be8587b6c072f/lmnr_claude_code_proxy-0.1.22-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:3b1d51ae3bacde24816a7dc2f1ede3dc74818fabf7ab099b5e07d0cf8c93ec81", size = 1647524, upload-time = "2026-06-10T20:34:41.496Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/47/89ad78f9f6da5933d90690345541cdccb8534654c8c54b92b4a43a138b58/lmnr_claude_code_proxy-0.1.22-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:1e377b89f6e86fbade22992a5a2917d8d639a80a7887eb3cb3c56d82e5992a28", size = 1463139, upload-time = "2026-06-10T20:35:18.663Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/86/4a885d6f495f0720effce961bf0e0c368cda5236976504d275f1d767e4ed/lmnr_claude_code_proxy-0.1.22-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:674f30e18023f8afe980e1f8ed71c74fbb77c0c1f462999d622cb3ebd13f9640", size = 1525416, upload-time = "2026-06-10T20:33:26.54Z" },
+    { url = "https://files.pythonhosted.org/packages/34/62/165fc8e7a05c945bad66d8c70bdd8f8eb591c3f6c6027fe436b95da80a24/lmnr_claude_code_proxy-0.1.22-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:e32266d07cd1fef0c260bf6f4ffc00a6708dfac1d0a07d11a84dbe4b87bd04e5", size = 1719607, upload-time = "2026-06-10T20:35:30.745Z" },
+    { url = "https://files.pythonhosted.org/packages/36/a8/0d36722152d1083311f9592d403770d79394621d27f4ca13df860843af3d/lmnr_claude_code_proxy-0.1.22-cp314-cp314-win32.whl", hash = "sha256:7753ba753271ba13500a5e2c7c82cdce3d6bb4e1cc53c4ee940464885a183957", size = 1077224, upload-time = "2026-06-10T20:35:20.111Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/5c/21394314cb22d3173cd86e6211760d36633ee1480d2b1324d26d1b1a8421/lmnr_claude_code_proxy-0.1.22-cp314-cp314-win_amd64.whl", hash = "sha256:ebec522829effb4722594ea99eacf640e97b47f6fd8bd8218291275387a2468b", size = 1320952, upload-time = "2026-06-10T20:35:35.482Z" },
+    { url = "https://files.pythonhosted.org/packages/92/ae/e0eb7f33d2ade93e4103475b30655c4c95f6606b24a91c67bf3db9c2aea2/lmnr_claude_code_proxy-0.1.22-cp314-cp314-win_arm64.whl", hash = "sha256:d02e548c983e33fa6da5234388f9bf18e4e71ffd37fd5723af199945a25eb4dd", size = 1242227, upload-time = "2026-06-10T20:33:22.362Z" },
+    { url = "https://files.pythonhosted.org/packages/be/ae/a0ff53d8d1a2289233114646b807fd943c64f6fbd91d675c917a873529e6/lmnr_claude_code_proxy-0.1.22-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:0b944cbc3faf8bb21329d650ed85910c69de323939c7139e99e305b7e953bbc1", size = 1367933, upload-time = "2026-06-10T20:33:06.935Z" },
+    { url = "https://files.pythonhosted.org/packages/67/03/1ba4fe072ddf75fbeb0a54469737bbd2074f4f96225666849fd8c2cee255/lmnr_claude_code_proxy-0.1.22-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:ca6b63240136e3524f860346aac2ebfd1e2e7da7e24773c35d4807e982a0195d", size = 1315156, upload-time = "2026-06-10T20:33:01.178Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/ad/253c6a5847e41ddd9f30d9d90650d3cae41f3ac3fd06b96fb016730ffa36/lmnr_claude_code_proxy-0.1.22-cp314-cp314t-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:f6183bacbcf602ae659754c01873043ea53c7ae89b3db85272d2b199b9fd04a9", size = 1354636, upload-time = "2026-06-10T20:35:21.628Z" },
+    { url = "https://files.pythonhosted.org/packages/08/92/6f8e5065fc7361d9223a3c3c7fcdb14e0300248667228d7af025e4a577d3/lmnr_claude_code_proxy-0.1.22-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:a8744a467460af74c87c4ce8856359279a985336ec2b6415d171b0e734791308", size = 1189759, upload-time = "2026-06-10T20:35:40.734Z" },
+    { url = "https://files.pythonhosted.org/packages/40/31/119501cb252340a813964e29383ed488276469124aa24fef7b53bb1ea7bf/lmnr_claude_code_proxy-0.1.22-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:ab8c36619084df3b51af13b30344a86cd08f21231e501cc29ec6199df427d7b0", size = 1358520, upload-time = "2026-06-10T20:34:38.15Z" },
+    { url = "https://files.pythonhosted.org/packages/86/07/ed27730f402ac25a78d2b2c829b2170b8b5968f0b3c154d119fa0c46d1d9/lmnr_claude_code_proxy-0.1.22-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:7ea802d19d688d51b101c4ae2d9df1ff4f4039c82a9a0960e13d91197869b1d0", size = 1275928, upload-time = "2026-06-10T20:34:36.684Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/86/6aee67731afc0a2caac86ae7262c385bf54cb6e1d592ece8339d091e8536/lmnr_claude_code_proxy-0.1.22-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b02ea2c9440569da5fe78aa94eb7fa2bf0c449f54d274dd86266325c9f9bfe6b", size = 1501190, upload-time = "2026-06-10T20:34:06.456Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/1a/7e8a0a527c6a70b9a3dfe691703dbaf18965101d8ed9cf8e5757f1808486/lmnr_claude_code_proxy-0.1.22-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:5ed9b3ecaeeb8594bc87c728f24dc783c3cf3335556ac7733c57c6358b534661", size = 1467410, upload-time = "2026-06-10T20:33:04.022Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/7d/d3c953ca4168010e7f96d99a20da3b30438c232c7f14876d4bf656aa0e39/lmnr_claude_code_proxy-0.1.22-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:6864c7fee5c1bef199c56e28759d190e4ff257dc7d4f0ee42972f4531ea73192", size = 1647287, upload-time = "2026-06-10T20:33:16.094Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/c5/e74a9a878892fe8236a1785ad27f4aafd1e3dd9eb93111c8924a880d4e8b/lmnr_claude_code_proxy-0.1.22-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:7f7390c7b012dc64c4d79c618c383117bcb318821eb86744b834c2efb62fb124", size = 1462639, upload-time = "2026-06-10T20:34:59.61Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/1b/763e01706ac56076ca725eb27852e3ee292bf79a1682da6f9f91c0516ce6/lmnr_claude_code_proxy-0.1.22-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:dd0834671a9636fdafc3e7d1d0c2d2c727e179dbf24857293f1e93d13dbfa917", size = 1525474, upload-time = "2026-06-10T20:33:56.438Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/65/6dbd59d099da5af6175ea23339749334feaf81f8e006ec6b714972023626/lmnr_claude_code_proxy-0.1.22-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:72018793c7694cfd5943cce67c7c8c3c4a4cba1f3136b63aef80c09fe9988db7", size = 1719286, upload-time = "2026-06-10T20:35:25.866Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/cf/5065e00d3da93d1148b26f56e35c67f2a4ffe0dc316cdc67808a69f44a2f/lmnr_claude_code_proxy-0.1.22-cp314-cp314t-win32.whl", hash = "sha256:8ea85c016fe1d0cc9f84d29469f1c2bed449d87dbeecd32e5fed0ab16f345bce", size = 1080427, upload-time = "2026-06-10T20:35:46.295Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/c7/f9be0e51e48ec4257118b50f1d99dfd15aba5ea6fcd7b29e9286c6205f3f/lmnr_claude_code_proxy-0.1.22-cp314-cp314t-win_amd64.whl", hash = "sha256:e6a97c7e21097e41de7e3dae17efbecc962136e64978399f707fc69680c27b6f", size = 1320847, upload-time = "2026-06-10T20:35:48.05Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/1a/cd95eba9bde002f1966407b177e6adb1f84661f8d0c2c50663a7e2823ee5/lmnr_claude_code_proxy-0.1.22-cp314-cp314t-win_arm64.whl", hash = "sha256:3dc25f440a4efd840b8136de90600ef3b11dbf97df2dd78f46d0c0890b91f70c", size = 1242210, upload-time = "2026-06-10T20:33:36.426Z" },
+]
+
+[[package]]
+name = "lupa"
+version = "2.8"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/a6/0f869fbb07c393f15473b1eefefb7b5bec162fb7481803d040ed4dc46002/lupa-2.8.tar.gz", hash = "sha256:d8022641b9ec8ecf2c5ecbe9f47e5a70e0b87c4b5ae921b92cb02a638e0acd08", size = 6156370, upload-time = "2026-04-15T20:08:30.534Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/09/21/9be4516ddd22f8eadba336d9ba065d17d79108465ae1b7f71424ab99b9d0/lupa-2.8-cp310-abi3-win32.whl", hash = "sha256:c2a5fd15dc62374e1661a55f01744c9ec1c56f291ba4a0749d3af2174556e78f", size = 1594887, upload-time = "2026-04-15T20:05:23.377Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/99/1557c9685d7034d9ce8dd2b54c40a26d6deb7c67c1fdb5c801abd1a02c3f/lupa-2.8-cp310-abi3-win_arm64.whl", hash = "sha256:9e304fb1c50cf23fd8882afbe1aa87525ef8a72667bcab3b37b2bbb2bc542269", size = 1371742, upload-time = "2026-04-15T20:05:27.417Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/0b/368f2f0bc750b25c69d4563e44f677925ab5dd3d2887f9b0c15465d21a2a/lupa-2.8-cp312-abi3-macosx_10_13_x86_64.whl", hash = "sha256:f4342f4de76ae7ce2ab0672d36003bdb7e1a33252f293b569298ddd792e70e33", size = 1194056, upload-time = "2026-04-15T20:05:55.794Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/0f/c89eb8dd36fdea4e50ae3f7f5275bea3b0cc5d4057b8ee7b3bbc78010422/lupa-2.8-cp312-abi3-manylinux2010_i686.manylinux_2_12_i686.manylinux_2_28_i686.whl", hash = "sha256:4203fa1659315e939a5304e75001b8cc14234fb3cbb3ed86c049b0cc5d90fcee", size = 1434278, upload-time = "2026-04-15T20:05:57.94Z" },
+    { url = "https://files.pythonhosted.org/packages/47/30/c3b4d2cd8733621b404b8a4214e5f852955c4ba632546dc84123bea9ee89/lupa-2.8-cp312-abi3-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:81f2d843ce668b653146c007467570210ae44be51dac6926666c51d49536f307", size = 1150068, upload-time = "2026-04-15T20:06:01.04Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/d2/bac12c398519efafc6af84be1974edd0d7a4895fb4735b5c8d615d298595/lupa-2.8-cp312-abi3-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:d3d0cde2c77588d1c60875a4f34f059513476c6e1775351897195b51e0f3df08", size = 1409532, upload-time = "2026-04-15T20:06:03.592Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/6a/18b52e11962014026e07813530b0b108ee8bc0a2a13ef0eaea5d41dce023/lupa-2.8-cp312-abi3-manylinux_2_34_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:9e0d11b8f3a8dac6413f704fef7161d048bb10c58bdac6cbffa5e60efa56e9a3", size = 1242687, upload-time = "2026-04-15T20:06:06.863Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/8e/7fd4eb049875f61429b96780d2eae4700f0e78fe0a52db8edb231b1cd09f/lupa-2.8-cp312-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:54cff414f21f8cd8c6be4aae52541f3b9cd39602b59e3a3db9b5c9f9f674ff18", size = 1856038, upload-time = "2026-04-15T20:06:09.358Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/f9/37ad9d2773d30f2931890d310a4bdce28d45484206e6f48bc18b0325eabd/lupa-2.8-cp312-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:24b4d8af5558e549b70daf1547f5c1c1d664ecea9fc790f83efe5d75e9a93797", size = 1128982, upload-time = "2026-04-15T20:06:12.312Z" },
+    { url = "https://files.pythonhosted.org/packages/57/31/c0fd7984c24844ea79caa45c0235f61a06b38fd69a839f6c62770f8d684a/lupa-2.8-cp312-abi3-musllinux_1_2_i686.whl", hash = "sha256:ce86dff1ee7f7cf45f5622065ae991949dd7bb1703581cbc58a630137bb7ccf9", size = 1457594, upload-time = "2026-04-15T20:06:15.881Z" },
+    { url = "https://files.pythonhosted.org/packages/11/f5/a28e411be30ec1bf0db1eb0c087eebc73be9e7a1adcfe6ac209861ccc446/lupa-2.8-cp312-abi3-musllinux_1_2_ppc64le.whl", hash = "sha256:f4d01b2a08c70bbb883a9e082b6b36b89121ed5910b710f1ba11c73295ff4fba", size = 1425721, upload-time = "2026-04-15T20:06:18.009Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/c1/359f767c4ae024be30d909fe8a9f0e9af266bad47ce2bd2ed248fb986fcf/lupa-2.8-cp312-abi3-musllinux_1_2_riscv64.whl", hash = "sha256:7f210d5a8353e510ea1199c42cf3cbdd630553bf2bc8fb4c00fea06fdec7c798", size = 1253258, upload-time = "2026-04-15T20:06:21.17Z" },
+    { url = "https://files.pythonhosted.org/packages/17/52/473f11790c261fd02bbf318a546fe040e9ec9f677181272fa78d3b4112a4/lupa-2.8-cp312-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:4f81a02806e7c7ad26d8c6fa222c8bef1b0c1b124347c879be880b41339d41e4", size = 2395272, upload-time = "2026-04-15T20:06:24.137Z" },
+    { url = "https://files.pythonhosted.org/packages/94/bf/75c8795655a8836eab6a11a630352c4b7c5dc5c54d075077bc9bffdeee45/lupa-2.8-cp312-abi3-win32.whl", hash = "sha256:360056453a7a4eaa4ac5a204c31a5a014b1eb2ee5490603234d2ba831684f1f2", size = 1606136, upload-time = "2026-04-15T20:06:27.815Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/29/11a2cdd612b6f55e506292dfb6ba343216e80a693e7fe3f876ef204ce9c6/lupa-2.8-cp312-abi3-win_arm64.whl", hash = "sha256:1628371c6592a6d5650497a9e31fb2bb3a7e9883c1f301d1111265e484045af9", size = 1364495, upload-time = "2026-04-15T20:06:30.254Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/17/fa834b6b09ad17e7df5d0f7715d64877a125a3776ada689751a1f9dc2959/lupa-2.8-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:450650f91c48c2415b0d59ab3abfcfda3b6efb5b858205f4d4bda8ad141fa529", size = 1190111, upload-time = "2026-04-15T20:06:32.84Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/43/45589901b7d1a0e3a9d91d19a311fb6a56924e8571536c3f2212160fd953/lupa-2.8-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:27044f3363047f946b3d3aab9157cbd172b3538ada9ec1baef43432bf7d03a78", size = 1812999, upload-time = "2026-04-15T20:06:35.664Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/ac/4ade7d15ff5c61758d7943ac6f0a496bf1cc65b6c09f842b52a0702e664c/lupa-2.8-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8cf4f064a0e5531afce2d7d750120c10c10f9529139af6ca6150d13151034398", size = 2368731, upload-time = "2026-04-15T20:06:37.959Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/27/05f950d15b8ab120b39c43588b438ff3ace70c1b1b0225a960393a497483/lupa-2.8-cp312-cp312-win_amd64.whl", hash = "sha256:281bedc5deb92d31e649a3552edd662449365a635904fa4d5cb4509c7245e34e", size = 1941809, upload-time = "2026-04-15T20:06:40.302Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/3f/19f83c3a0c84dc8bea8a58e7416dca6a3ede662c33c8d1ec758e5afc754a/lupa-2.8-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:45fc9da0145ecb0083ef5ff9975116cc784bd0258bdc2bd131ba15483ce18398", size = 1201203, upload-time = "2026-04-15T20:06:42.169Z" },
+    { url = "https://files.pythonhosted.org/packages/89/0f/a14f0073f09610158038582e230618a48c14da6bd88185289461aa4cb854/lupa-2.8-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:58e18afed57955b41130e269c78f53d4123ab86e236b53816f4cbffa25cb5d30", size = 1806210, upload-time = "2026-04-15T20:06:45.486Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/14/48fff156c63a136001a7620878af7d31aa07e66b495ed621e3eddd73c294/lupa-2.8-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:fc47f536ac13a79cef47d29a2b205576a22841f042a2bcec1676b95806e7706a", size = 2359005, upload-time = "2026-04-15T20:06:47.819Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/18/3ac638ec90edf178242b8a2b2f00f8adae694248c03a26341ef941bb746e/lupa-2.8-cp313-cp313-win_amd64.whl", hash = "sha256:ce9404c661dbac65cc9bed351ad45e797af93d30d70be309a3fa8209ac86d93b", size = 1936754, upload-time = "2026-04-15T20:06:50.448Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/ef/5ee5fed6ea7459a671196359ce04bfeeaf26be1dac8ff24bf28e5c7a6e81/lupa-2.8-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:348c3f8ecabb6324dcbc05c2740d762ef8fcec7b06c79e45262ab97a217684e3", size = 1209388, upload-time = "2026-04-15T20:06:53.022Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/b1/67a940d5542cb0384b443fe951b5a83ea9340d1333a733a258fdd1c619ba/lupa-2.8-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:951496471056061598a7d1729a6cdf48d662fec777a9f2d8aa5a1e62fd30e5a5", size = 1826821, upload-time = "2026-04-15T20:06:55.699Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/a2/b354e5ba3b911ec50686003dc8897e892b9e8c5c036b33219b03d54c4daf/lupa-2.8-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a591b9947ca347b41a63370e121d6e2b1458fe6dde9ae065029ec10a37f25ff4", size = 2366893, upload-time = "2026-04-15T20:06:58.9Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/52/d76066401f29539df5352f70ecded66576f32933b6045cd0bfc56cb770b9/lupa-2.8-cp314-cp314-win_amd64.whl", hash = "sha256:3903c9cf628dae2f56405503247b77a61a3a61bd2dda470e336950c74776d55d", size = 1994716, upload-time = "2026-04-15T20:07:19.194Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/bd/3efc437a4361c16d25e66478c50357c9a8e8ecfb718fe749eb9ca3176ef6/lupa-2.8-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:f711a8ab0486b9ac6fdda94a22ddcfbc9f0d4a27e3a8cf1bf79c6e48b33017c1", size = 1251217, upload-time = "2026-04-15T20:07:01.64Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/f4/2e9f8ecbaca854bfdf14af8a9b505ec0cbc640377b3b218921594b7563cd/lupa-2.8-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:dc51250e76367a3e27fcd01dc769b9bfcbbc34f48df48dde53d6af6e75b7eaa5", size = 1814701, upload-time = "2026-04-15T20:07:04.149Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/53/4000b1acaa8b1f3827fcff0cfcdff44d3befddda42cab7e685a49689b5a1/lupa-2.8-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f8a22088a552828958603323f0a5c4b3e11e03b75d0bf4c965ef879de9b60a8d", size = 2348414, upload-time = "2026-04-15T20:07:07.285Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/78/26ee48d3890cddf03cefb65f433e3492759c0b3c0582180755bddbaab7bd/lupa-2.8-cp314-cp314t-win32.whl", hash = "sha256:4f7c553c1d8cfffbe85d81daef730d12cae4b6002d457542914da0ac8a1145b3", size = 1831611, upload-time = "2026-04-15T20:07:09.752Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/d1/4a5cc64a3cad22821ae4c3f7a90456a08ca19457d8354f4abf46ad03c7e8/lupa-2.8-cp314-cp314t-win_amd64.whl", hash = "sha256:d8766aff03a78c80ad2d188a8bdb216de5ec838359cd87e05bbdfa56394a6105", size = 2209250, upload-time = "2026-04-15T20:07:11.906Z" },
+    { url = "https://files.pythonhosted.org/packages/37/7c/cdcb654daf668192aaf36b0aeb94f2281dad092aaa5003688691131736ea/lupa-2.8-cp314-cp314t-win_arm64.whl", hash = "sha256:91d622777febda3ab1bed1d45295f2f32a4680c7b3d7caf8c669998ed5c44118", size = 1126735, upload-time = "2026-04-15T20:07:15.434Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/44/de1961ad38e17cd326a53c246c7e3b91178ed578f4cf22ffcd5e7e11b041/lupa-2.8-cp39-abi3-macosx_10_9_x86_64.whl", hash = "sha256:b036738282a5acd2e71fdddb317c9df8b87c1673aa57f403d05fcc2be8abc4ba", size = 1186020, upload-time = "2026-04-15T20:07:35.017Z" },
+    { url = "https://files.pythonhosted.org/packages/13/c2/276f0b9dc8bcc5a8a58af5316dfa0e6f56be3613dd6dbcc8d3d2cb6559ba/lupa-2.8-cp39-abi3-manylinux2010_i686.manylinux_2_12_i686.manylinux_2_28_i686.whl", hash = "sha256:ac6b6e8d0e617e26a98cbb44880bcd75de5d32b3ad7b3b3793583909292b47ed", size = 1468944, upload-time = "2026-04-15T20:07:37.782Z" },
+    { url = "https://files.pythonhosted.org/packages/63/38/52934e52a5180dc6425d20284d004fe4b27a4f9171a82dc99fb67af250bf/lupa-2.8-cp39-abi3-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:ba3a7dd839f90c3d2e53bebe3c192b1f3f9fd720a6781256405123211fd0dce6", size = 1172998, upload-time = "2026-04-15T20:07:40.812Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/82/76b3809bd0839d9b3b4ec58d06591e08f17337b6d9576877cb9d48b34e94/lupa-2.8-cp39-abi3-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:d7edb13a7a5250b5c6c22d1495d9e842b5c9fc5081c8fe6b5efe2112fe3e41f9", size = 1449975, upload-time = "2026-04-15T20:07:44.262Z" },
+    { url = "https://files.pythonhosted.org/packages/16/07/2f89d54f747c67c23b4b9ae4aa8c8dd06bb409155dedcf406157f2736b66/lupa-2.8-cp39-abi3-manylinux_2_34_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:891f72e0bffbed1e4175f975aeb2a083956586a100066525e1be485f617f7b25", size = 1281944, upload-time = "2026-04-15T20:07:46.458Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/bd/7375d2b0fcae79d806baf52a76f26c96964593f58e1372d13ae5ac09c676/lupa-2.8-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:a295f87b5b7ebbfd5191932e8cb0e51df3c7769101ac6b6c7d7c9fb27bfd1307", size = 1910455, upload-time = "2026-04-15T20:07:49.75Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/0c/8abb3bc0e08b311fc01db05b6e9f9ff31a8f65e4fc3f0aeb05cfef75c8ac/lupa-2.8-cp39-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:4fe5d7a810b64ea8511eb885fc8cdde042ee5ff7b7d08ae78f32449756acb177", size = 1155548, upload-time = "2026-04-15T20:07:52.657Z" },
+    { url = "https://files.pythonhosted.org/packages/80/2e/9eeecd3f493099721c1d3f31beeca23a4237db1a54223684df4dc96aa1bd/lupa-2.8-cp39-abi3-musllinux_1_2_i686.whl", hash = "sha256:bfc470012ef66ad064c7bd77416af03a3452ef630b04b9012595ea13f2e54518", size = 1489232, upload-time = "2026-04-15T20:07:54.92Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/13/731c99dc2e7652ae818a6de45bdf0142049f7cb566049061c898355f1891/lupa-2.8-cp39-abi3-musllinux_1_2_ppc64le.whl", hash = "sha256:250e035fdaffe8c87093e3ebc206ac29a26131b1568ea711d780c26001ce96e7", size = 1466321, upload-time = "2026-04-15T20:07:57.627Z" },
+    { url = "https://files.pythonhosted.org/packages/de/71/3ad8cc4fc05a77dc0d3f7079348bd1cad4675a0d14c24f8e6a3ce5f008f7/lupa-2.8-cp39-abi3-musllinux_1_2_riscv64.whl", hash = "sha256:b9bddb09acfffb4f828f790f444b11dc0cca591afea1a244d9329eea2d20c003", size = 1288577, upload-time = "2026-04-15T20:07:59.913Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/b2/1175f6d0aa7b68627fbe2f58bd1e8bea36a89d10dfd67671d2b024c96162/lupa-2.8-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:2e64acbbd47e9b82a64405a39e0d2b36a5a7dad8ab41c0f3437f572f7d282ba3", size = 2444866, upload-time = "2026-04-15T20:08:02.753Z" },
+]
+
+[[package]]
+name = "lxml"
+version = "6.1.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/05/3b/aab6728cae887456f409b4d75e8a01856e4f04bd510de38052a47768b680/lxml-6.1.1.tar.gz", hash = "sha256:ba96ae44888e0185281e937633a743ea90d5a196c6000f82565ebb0580012d40", size = 4197430, upload-time = "2026-05-18T19:19:06.424Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6a/6e/c4add832b6fc1e887125b96f880d7b9b70aae5248718e046b1704bcac4b9/lxml-6.1.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:104c09bda8d2a562824c0e319d0768ce26a779b7601e0931d33b09b53c392ef7", size = 8570821, upload-time = "2026-05-18T19:17:42.068Z" },
+    { url = "https://files.pythonhosted.org/packages/22/00/ff3009c88e65de8011630acf8ab5a09cb2becd2aaf47fba2f3449f6224e9/lxml-6.1.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:25c6997a9a534e016695a0ba06b2f07945de682731ff01065b6d5a4474179da1", size = 4624252, upload-time = "2026-05-18T19:17:47.897Z" },
+    { url = "https://files.pythonhosted.org/packages/42/95/bb63f0fd62e554fe078e1fb3c8fe9083c14ddc7ad7fa178d10e57e071ac7/lxml-6.1.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:c921ba5c51e4e9f63b8b00267d06566e1f63407408a0496da2d1d0bfc819c7fc", size = 4930746, upload-time = "2026-05-18T19:18:29.637Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/99/0013e8d9b5960f4f041cf0b73e2f80c23eb5205b1f7bfb20203243651359/lxml-6.1.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:54a7f95e4de5fb94e2f9f4b9055c6ba33bf3d628fd77a1d647c5923caa2cdcdc", size = 5093723, upload-time = "2026-05-18T19:18:34.168Z" },
+    { url = "https://files.pythonhosted.org/packages/29/91/317b332636bfc7bddcff828d41b3307f50043f4b237e40849c333d80fa1a/lxml-6.1.1-cp312-cp312-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:96f2ec43df44b1f76249ee0a615334f9b5b060e1c8bd90e706dad2d14d02f383", size = 5005557, upload-time = "2026-05-18T19:18:39.798Z" },
+    { url = "https://files.pythonhosted.org/packages/42/2f/cc9bf06afe70f9c9093ae60855d9759da9db601ec4080f7473319666ffd7/lxml-6.1.1-cp312-cp312-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:70ef8a7e102a1508f8121aae5b0867abd663f72c14f0a9c937e6554cb4587b7b", size = 5631036, upload-time = "2026-05-18T19:18:44.858Z" },
+    { url = "https://files.pythonhosted.org/packages/08/f6/af32e23e563971ffb0fb86be52bc5be5c2c118858ffc119bf6a9039b173d/lxml-6.1.1-cp312-cp312-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ebe6af670449830d6d9b752c256a983291c766a1365ba5d5460048f9e33a7818", size = 5240367, upload-time = "2026-05-18T19:18:49.217Z" },
+    { url = "https://files.pythonhosted.org/packages/78/83/8555d40948b09ce86f1bd0c68a7ac31d07b1929f92cc1b074006c97ef2d2/lxml-6.1.1-cp312-cp312-manylinux_2_28_i686.whl", hash = "sha256:27acc820660aaffa4f7c087f29120e12980f7779d56d8492d263170111284740", size = 5350171, upload-time = "2026-05-18T19:18:52.779Z" },
+    { url = "https://files.pythonhosted.org/packages/63/75/5d92da93729b7bad783689e6496049fa40927b45bec7bf183c981de3ca70/lxml-6.1.1-cp312-cp312-manylinux_2_31_armv7l.whl", hash = "sha256:1db753c9115ec7100d073b744d17e25e88a8f90f5c39b2f5dd878149af59671f", size = 4694874, upload-time = "2026-05-18T19:18:55.139Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/b5/3aad415a9a25b822e783f15deeb4dffccf5113030f1afa2222dd929313d9/lxml-6.1.1-cp312-cp312-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:c4f469aebd783bb741c2ecb2a681008fd26bfe5c16a9a72ed5467f834e810df2", size = 5244492, upload-time = "2026-05-18T19:19:01.28Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/a1/5fcf7eb9904b80086aa47dcf0027de07b1bb990afad2e6823144c368ae04/lxml-6.1.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:766b010012d59470072c1816b5b6c69f1d243e5db36ea5968e94accf430a4635", size = 5048232, upload-time = "2026-05-18T19:18:12.67Z" },
+    { url = "https://files.pythonhosted.org/packages/77/74/1f601b63c7a69fcdf10fa9b148c81da8442204194f6c55509cc485c786b9/lxml-6.1.1-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:b8d812c6011c08b8111a15e54dd990b8923692d80adf35488bee34026c35accf", size = 4777023, upload-time = "2026-05-18T19:18:15.928Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/b9/7a78f51aec95b1bf780d78e12705a9f6533284f8693dc5c0e6724fa53d3f/lxml-6.1.1-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:fe0306bd29505a9177aac19f1877174b0e7422c222a59f70b2cd41633448c3dc", size = 5645773, upload-time = "2026-05-18T19:18:23.223Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/6e/98a7b7ad54e4e74fa1f20fff776913980619d0ebe5558232d7da6580bdd8/lxml-6.1.1-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:5ba186ad207446c65d3bb3d3e0412b032b1d9f595e59861e2354798c5703d955", size = 5233088, upload-time = "2026-05-18T19:18:31.433Z" },
+    { url = "https://files.pythonhosted.org/packages/65/d1/bc0ed2427bf609f2ee10da303a6a226f9c8bce94f945dc29a32ce55de6e4/lxml-6.1.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:aa366a1e55b8ebfe8ca8ddc3cfe75c8ebade181aeb0f661d0cb05986b647f72a", size = 5260995, upload-time = "2026-05-18T19:18:37.091Z" },
+    { url = "https://files.pythonhosted.org/packages/69/8b/6772e1a4b513fc50a8d931f19edde0e13ae6918510a1e13ff67864f3e5ed/lxml-6.1.1-cp312-cp312-win32.whl", hash = "sha256:126c93f7f56f0eda92f6d8c619edc463a4f23d9252f1c9d0405a76f25fa9f11a", size = 3596382, upload-time = "2026-05-18T19:17:18.37Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/89/45198e9624762af2dfd2cb8782598477ceb29f6e59caab560388ae1f4ec1/lxml-6.1.1-cp312-cp312-win_amd64.whl", hash = "sha256:26e6eda8d38c1fcab1090dd196ee87cbd13788e531937610e2589085de074e77", size = 3997255, upload-time = "2026-05-18T19:17:56.781Z" },
+    { url = "https://files.pythonhosted.org/packages/90/a9/7a54b6834088d9ae528a7b780584ba6a39a9457b0ac330479f20ffbc9449/lxml-6.1.1-cp312-cp312-win_arm64.whl", hash = "sha256:6540377fbd53fe1b629172288c464fb18db11ce1fa7dc15891da10aa9dcc3e7f", size = 3659610, upload-time = "2026-05-19T19:22:50.843Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/eb/7e6f37c5584ccbb2ff267f56fd0339016938c1c8684cfefab9b33ffc2f36/lxml-6.1.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:68a9198d0fc122d14bb76837de9aa80cf84caed990b5b237f532ed87d3706736", size = 8559780, upload-time = "2026-05-18T19:17:57.661Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/36/587c2521cf23a2cd6c9c22108aa7528f683a1f195ed7ccd23a4b1786ad36/lxml-6.1.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:7d47866cb32fb503450b6edc9df355d10dc49836af2e89901bd6ac6b0896d9d9", size = 4618006, upload-time = "2026-05-18T19:18:04.452Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/ca/ab7bfe2bf4c972af5e7878262845ead3a24a929a9b04bc11c7c1ece6c82a/lxml-6.1.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:eb7c9811bfaa8b1ed5ed319f5d370dfbcaa59d52ea64be2a5a85e18195930354", size = 4924139, upload-time = "2026-05-18T19:19:04.873Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/55/a0c72851dfee5ecc689f949723a73dea457758912542cb955b108eaf0d8f/lxml-6.1.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:762ff394d5bd56da0cf034a23dcce4e13923f15321a2adfa2ac00201dc6d3fca", size = 5082329, upload-time = "2026-05-18T19:19:09.728Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/b6/0608f7d61a3b96cc67e5648a3d906e31a5082093e10e7be65b3886289938/lxml-6.1.1-cp313-cp313-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a088f287f7d8275a33c07f2cac6c50b9319309a0200a39e7e75d80c707723099", size = 4993564, upload-time = "2026-05-18T19:19:13.608Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/66/ae227524b066d29d55bf0b453d93d2d793c40218657d643dcbbca13b8faf/lxml-6.1.1-cp313-cp313-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:e902da4b04e6b52e5893900d4b8ab46068f75f3561f01bf1080957f9fd932ed6", size = 5613467, upload-time = "2026-05-18T19:19:16.228Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/76/dbe4a00b50385e40194231dcfe5a12c059de7cf90e89c83407d2b085b719/lxml-6.1.1-cp313-cp313-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1d4962d4c66bf830a7e59ed6cfc17d148149898a3aefa8ec6e59763e6e3ed085", size = 5228304, upload-time = "2026-05-18T19:19:19.354Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/01/00b1b8442ed2041793336868ba0b9ea4b13d7da7c085c6404c207a63bf79/lxml-6.1.1-cp313-cp313-manylinux_2_28_i686.whl", hash = "sha256:581d4c8ae690a6609e64862dd6b7c2489635c2d13907fc2b20f2bc200ff1d21e", size = 5341607, upload-time = "2026-05-18T19:19:22.297Z" },
+    { url = "https://files.pythonhosted.org/packages/63/36/1ad29931e9a4638bb707869f01d423a6c815f82152138d1a40dfcfde2b95/lxml-6.1.1-cp313-cp313-manylinux_2_31_armv7l.whl", hash = "sha256:876e1ff5930ed8bf295ec5ef9a8155e9b6b1876bbf1deed8b3a8069311875a8f", size = 4700168, upload-time = "2026-05-18T19:19:25.133Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/d1/a9536cecf9be18a0dc72d32bead283a2332d1ffebd2dd3ac70ce444686e5/lxml-6.1.1-cp313-cp313-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:9eb9b5a968f6e0f6d640092a567e14529ff8cea2e29d00da6f78a79fa49f013c", size = 5232487, upload-time = "2026-05-18T19:19:28.603Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/77/b4fb1e03bf5d130e879214d3100092e386418807fb74dd0adc4b0a48f351/lxml-6.1.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:aa49e06d94aba782c6a02eecb7e507969e7e7a41b267f1b359bb35585f295d5b", size = 5044231, upload-time = "2026-05-18T19:18:42.246Z" },
+    { url = "https://files.pythonhosted.org/packages/26/4c/d00daeeb0a5530c4028a9232aa1b93db3ef4ed2158c116ea73c79a9765b3/lxml-6.1.1-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:70cdfd80589d59e43e18005dd7244e8895e93db8ab6a620b7e23df5445a4e3d2", size = 4769450, upload-time = "2026-05-18T19:18:48.013Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/6a/715a3a8d156ce42f29cf014706f5410c2ff3b02267774110fc23266409fe/lxml-6.1.1-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:aad9aa39483ed8ec44d6d2e59e5b98a0d80676ef0d92f44bfc374836111f62f5", size = 5635874, upload-time = "2026-05-18T19:18:51.914Z" },
+    { url = "https://files.pythonhosted.org/packages/45/37/0544bc21dde2a88f3a17b504e6fc79c0e01d25a33c2f6079724e9e72b9c7/lxml-6.1.1-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:d49514be2f28d895c38cf9d2b72d7b9a07d00314519f456c0b50b53cfcf4c785", size = 5223987, upload-time = "2026-05-18T19:18:59.715Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/f8/f6a5e8185bcb28c2befae3d31f8e3df3b811cb0f47746517a81279fcafe1/lxml-6.1.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:47402e62c52ff5988c1e8c6c63177f5708bccf48e366dea4e3dcf1e645e04947", size = 5250276, upload-time = "2026-05-18T19:19:03.834Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/f2/1a2b9f1b7a49d45495369be7ef9ad05b262930f2eab3e3145706fca8083f/lxml-6.1.1-cp313-cp313-win32.whl", hash = "sha256:3483644525531e1d5762b0c44a8e18b6efba321b6dcf8a8952de10b037618bca", size = 3596903, upload-time = "2026-05-18T19:17:29.863Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/99/f4ffb024f238eec2131aaa09f3278fb6129cf892741bf68e1fc1afb8c100/lxml-6.1.1-cp313-cp313-win_amd64.whl", hash = "sha256:a10bd2fd62e8ce916ececb342f348f190724a098c1faa056fdfb2a22ad5e8660", size = 3995869, upload-time = "2026-05-18T19:18:02.596Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/53/70eb8c5c6037f27448f1e3c54ebede9545a801ae63f0a7254afca4fe8e45/lxml-6.1.1-cp313-cp313-win_arm64.whl", hash = "sha256:424aa57aca0897eb922aef34395bd1289b3b6f04e6bae20ea123c0c7e333cffc", size = 3658490, upload-time = "2026-05-19T19:22:53.846Z" },
+    { url = "https://files.pythonhosted.org/packages/13/e2/2e325795566de01d0d7c3bb57d3c370616b2d07b01214e84eec5d3b10963/lxml-6.1.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:19b7ab10b210b0b3ad7985d9ac4eb66ab09a90b20fe6e2f7ba55d01a234345d0", size = 8577146, upload-time = "2026-05-18T19:18:17.765Z" },
+    { url = "https://files.pythonhosted.org/packages/93/cf/5630b5e4be7d2e6bee8efe83865c925221103cf0221303b104ce134b01e2/lxml-6.1.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:c08e5c694306507275f2290073350c4f32e383db15213b2c69e7ff39c1193840", size = 4623866, upload-time = "2026-05-18T19:18:30.669Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/51/3904907c063451cf8d4a5c9fe0cad95fa1f4ec57f4e3884fa0731bd7a305/lxml-6.1.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:74a9717fd0d82effef5c2854f0d917231d5324b5a3eb7275c43ac9fa32f97a14", size = 4950022, upload-time = "2026-05-18T19:19:31.958Z" },
+    { url = "https://files.pythonhosted.org/packages/94/cd/9c7611a51c37a2830928405817cc5d56a97f64fab83cc3f628748b135749/lxml-6.1.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:efe0374196335f93b53269acd811b944f2e6bdc88e8894f214bd636455484909", size = 5086695, upload-time = "2026-05-18T19:19:34.764Z" },
+    { url = "https://files.pythonhosted.org/packages/da/d6/24e3b5906abb0b674ff2ae195bc3ce59708df2bcd17cf17703b2d7dd643a/lxml-6.1.1-cp314-cp314-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ac931cdc9442c1763b8a8f6cd62c0c938737eafc5be75eff88df55fc73bc0d00", size = 5031642, upload-time = "2026-05-18T19:19:37.771Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/db/6ec54f99019838bff54785c51da07f189eb4676861c5f2730962b0d8d665/lxml-6.1.1-cp314-cp314-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:aee395f5d0927f947758b4ec119fd5fc8ec71f07a1c5c52077b30b04c0fa6955", size = 5647338, upload-time = "2026-05-18T19:19:40.553Z" },
+    { url = "https://files.pythonhosted.org/packages/42/3d/ef4dcfffd22d27a61805d8ed9f7fb888495bc6aa88648fa07c1eaa5586b6/lxml-6.1.1-cp314-cp314-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9395002973c827b3ed67db77e6ec09f092919a587022174554096a269378fb13", size = 5239528, upload-time = "2026-05-18T19:19:43.657Z" },
+    { url = "https://files.pythonhosted.org/packages/62/bb/37fb3f0dff146bdcfa78eec47879273820b2a0bf350ec236ce14bd0b1c26/lxml-6.1.1-cp314-cp314-manylinux_2_28_i686.whl", hash = "sha256:73bc2086f141224ebddb7fc5c6a36ca58b31b94b561e1dfe8e073e3270fad1e7", size = 5350730, upload-time = "2026-05-18T19:19:46.307Z" },
+    { url = "https://files.pythonhosted.org/packages/90/42/43253f168388df4fae1f38c01df36ddb9bee39e2048167b54cdcbae85ea3/lxml-6.1.1-cp314-cp314-manylinux_2_31_armv7l.whl", hash = "sha256:3779def59032b81e44a5f70096ef6bf2082f8d901937dca354474ba09782e245", size = 4697530, upload-time = "2026-05-18T19:19:49.889Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/a8/c5a8504f81bbdfc8e7094c2c850cdb4ed6777fc4d5ddd9e5ab819f3b0d54/lxml-6.1.1-cp314-cp314-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:86c89b9d55ebf820ad7c90bc533410f0d098054f293351f10603c0c46ff598f5", size = 5250670, upload-time = "2026-05-18T19:19:53.199Z" },
+    { url = "https://files.pythonhosted.org/packages/77/b7/c7e76ab18744d75e21f320ebf9ff9d1ceae2b54dd431ea5a64caf26c9672/lxml-6.1.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:19607c6bbff2a44cf3fe8250abccd20942d3462473e0a721d01d379ed017e462", size = 5084485, upload-time = "2026-05-18T19:19:08.422Z" },
+    { url = "https://files.pythonhosted.org/packages/31/31/b35c53f8ef7b7c31cacd23d3638652fff7bcd1deb6eedb709ab43b685908/lxml-6.1.1-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:c6ed5141a5c7507cf3ee76bd363b0d6f801e3321adc35b5d825a23115faa5465", size = 4737635, upload-time = "2026-05-18T19:19:12.321Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/06/31f23c813a7fe8e0cb1b175e915b08c9bf4e86d225b210feadbdbe519667/lxml-6.1.1-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:62aeb7e85b5d60320b9d77eef2e773994e2c0ce10121b277e0a19804e1654a5a", size = 5670681, upload-time = "2026-05-18T19:19:15.001Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/bc/ce619bccc89b1fd9ad8a8e1330ee3f3beff9f2ff95b712d7bbcdd6e22fc3/lxml-6.1.1-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:b1b963fd8f5caa68e99dfae060d54de1fe9cba899b8718b44a00cdca53c3e590", size = 5238229, upload-time = "2026-05-18T19:19:18.131Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/5d/b329acbbedc0b619ebc2be6cf7ee9ed07e80892c88d4dfd612c33805789a/lxml-6.1.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:63876be28efefa04a1df615b46770e82042cce445cfdce55160522f57b231ccb", size = 5264191, upload-time = "2026-05-18T19:19:21.118Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/85/be36fb1425b30db3c3f9df75fe86343ebffb79e6320bd7f588e25bfeac39/lxml-6.1.1-cp314-cp314-win32.whl", hash = "sha256:7f7a92e8583f06b1fd49d01158143b8461cfcd135dcb10ec807270a3051bd603", size = 3657202, upload-time = "2026-05-18T19:17:39.509Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/ce/3cf9a827342269f54d405a6202397de63f07c69cbd6ce7d183a3f0cba1e9/lxml-6.1.1-cp314-cp314-win_amd64.whl", hash = "sha256:b2d444f2e66624d68e9c6b211e28a76e22fff5fcabcfff4deac18b529b7d4137", size = 4064497, upload-time = "2026-05-18T19:18:14.662Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/3e/1a957bde8f0760039e627f94699f82caa782c9d838d86c3d28245ee67212/lxml-6.1.1-cp314-cp314-win_arm64.whl", hash = "sha256:3fd9728a2735fda14f4e8235830c86b539e9661e849665bf926d3f867943b4bf", size = 3741991, upload-time = "2026-05-19T19:22:59.111Z" },
+    { url = "https://files.pythonhosted.org/packages/78/b2/00ed55b3a2efa4658fb795c38d1090ec9b3e8a6c3683d4441fa517f09c3b/lxml-6.1.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:787b2496d0dbe8cd180984e8d29e3a6f76e7ea34db781cb3bd55e4ba1ef8b4ee", size = 8827545, upload-time = "2026-05-18T19:18:41.193Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/73/74573db19baa618d5f266f2407898b087ff6927115b00b71e5fc1b700847/lxml-6.1.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:2c8daa471358dc2d6fcf02165e80ec68f77871a286df95bc5cc3816153b0fd2c", size = 4735736, upload-time = "2026-05-18T19:18:46.761Z" },
+    { url = "https://files.pythonhosted.org/packages/16/02/6f7061f4f95f51e545d48e87647c54791d204a4e881be4156e7a26ba5338/lxml-6.1.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:acd7d70b64c0aae0c7922cca83d288a16f5f6da523637697872253415269baef", size = 4970291, upload-time = "2026-05-18T19:19:56.215Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/02/55fc057d8283427dea7d6edb102e7a840239c77a64a983d92f62a304c0e9/lxml-6.1.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:4f0dd2f01f9f8a89f565d000e03abcf0a13d692a346c8d22f628d49af098777a", size = 5102822, upload-time = "2026-05-18T19:19:59.223Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/48/8e1cf78d89d66850121d9255a2a24414c98f775da93b90cf976956c24b14/lxml-6.1.1-cp314-cp314t-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0b7e8a14c8634bf6f7a568634cb395305a6d964aeb5b7ee32248094bed3a7e2c", size = 5027923, upload-time = "2026-05-18T19:20:01.549Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/00/0632a0647612c8af24d26997b3b961397daa9d5b2581444805933629a4cb/lxml-6.1.1-cp314-cp314t-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:86281fbdd6a8162756f8d603f37e3435bfa38043adb79c6dc6a2dfee065e7525", size = 5595843, upload-time = "2026-05-18T19:20:03.93Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/86/ab008a7dc360711b66858d61c80a5979a70a09f2aa2b05d9698df80b803d/lxml-6.1.1-cp314-cp314t-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c5d7152ec39ca7c402d8fb9bad86140a15b9503bd0c54484e3f1bbe3dd37ceca", size = 5224515, upload-time = "2026-05-18T19:20:06.381Z" },
+    { url = "https://files.pythonhosted.org/packages/75/c6/2702ff375e728e34f56d9a45339a9cf7e4427e917f542225242d63a05afa/lxml-6.1.1-cp314-cp314t-manylinux_2_28_i686.whl", hash = "sha256:88d8cb75b9d82858497a5393e3c63cfbf03035225e4b35a49ed7ccb151e4dc0e", size = 5312511, upload-time = "2026-05-18T19:20:09.308Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/57/a5807c98f87a86f10ef9ffab35516df7c0f0c4b6d5d33e9f608ab9c04a31/lxml-6.1.1-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:f64ec5397ea6a41fc1b4af0380d79b44a755b5531dcaccd9940fb260dca93038", size = 4639206, upload-time = "2026-05-18T19:20:11.704Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/e1/8a0a2c35734812395f4da4eaf33748a7e5705bfb2a58b128da764339d5ec/lxml-6.1.1-cp314-cp314t-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:d34bbf07dbc7ca5970671b1512e928991fb5e9d95365636c9b2d8b4f53af405e", size = 5232404, upload-time = "2026-05-18T19:20:14.064Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/e2/0e6a4dd5ad84d01d99aa7bae7cfefd4a760a0e0f8176818241de17d9b6c0/lxml-6.1.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:17e0e18d4ad8adbd0399291bc44845b69d9dd68439a3cdebdf35ff902ec05072", size = 5083769, upload-time = "2026-05-18T19:19:23.758Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/7e/161f33d463f6ffc1c7679104b65086dea120080d49dde4d238f015aaee2f/lxml-6.1.1-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:3ab541146f1f6968c462d6c2ac495148e8cdba2f8347700b2141b6ec5a75bf52", size = 4758936, upload-time = "2026-05-18T19:19:27.256Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/fb/2369825e3f6ca99305bf9f7b7085fda91c8b0922a89e54d900974aa3ef85/lxml-6.1.1-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:2a0217714657e023ef4293500f65aa20fce6164c8fd6b08fa5bd4a859fb14b9b", size = 5620296, upload-time = "2026-05-18T19:19:29.993Z" },
+    { url = "https://files.pythonhosted.org/packages/30/90/d61e383146f74c5ab683947ea14dc7b82778838ab9b95ea73a23b60d0191/lxml-6.1.1-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:05a82eb6e1530a64f26225b55cbd178113bd0b5af1c2b625f25e5296742c26d2", size = 5228598, upload-time = "2026-05-18T19:19:33.523Z" },
+    { url = "https://files.pythonhosted.org/packages/76/2d/2dafd8149e94b05bb070690efd5bb2680720681e03ff03fc57d2b70a1105/lxml-6.1.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:9e36f163528fc50cbef305f02a5fd66d404edf7049cdaff211dbc2cba5a7013e", size = 5247845, upload-time = "2026-05-18T19:19:36.649Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/68/b30e913340c380ddac9580c6e6230991fc37240ec4f64704833e4f3e2769/lxml-6.1.1-cp314-cp314t-win32.whl", hash = "sha256:649dda677cf3bd6ac9ae14007ba0c824ded8ce5808b53fc7431d9140399118c1", size = 3897345, upload-time = "2026-05-18T19:17:33.562Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/4e/9eb2af5335545f9fbcd7af57bcf87c6025d31eaa31b14ec184a6c8675328/lxml-6.1.1-cp314-cp314t-win_amd64.whl", hash = "sha256:793033d6c5cdf33a573f910d9bea14ef8f5771820411d118da8e1182edb53d5e", size = 4393350, upload-time = "2026-05-18T19:18:10.076Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/2c/0f1e93c636720e8a3eb59af2bfda99d98b55891e1c53bc30c2e0e865f01b/lxml-6.1.1-cp314-cp314t-win_arm64.whl", hash = "sha256:58bb955caba94e467d2a96da17660d2d704e0675894cba21ab8a775b8621fd1c", size = 3817223, upload-time = "2026-05-19T19:22:56.823Z" },
+]
+
+[[package]]
 name = "markdown-it-py"
 version = "4.2.0"
 source = { registry = "https://pypi.org/simple" }
@@ -715,6 +2004,82 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/06/ff/7841249c247aa650a76b9ee4bbaeae59370dc8bfd2f6c01f3630c35eb134/markdown_it_py-4.2.0.tar.gz", hash = "sha256:04a21681d6fbb623de53f6f364d352309d4094dd4194040a10fd51833e418d49", size = 82454, upload-time = "2026-05-07T12:08:28.36Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b3/81/4da04ced5a082363ecfa159c010d200ecbd959ae410c10c0264a38cac0f5/markdown_it_py-4.2.0-py3-none-any.whl", hash = "sha256:9f7ebbcd14fe59494226453aed97c1070d83f8d24b6fc3a3bcf9a38092641c4a", size = 91687, upload-time = "2026-05-07T12:08:27.182Z" },
+]
+
+[[package]]
+name = "markdownify"
+version = "1.2.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "beautifulsoup4" },
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3f/bc/c8c8eea5335341306b0fa7e1cb33c5e1c8d24ef70ddd684da65f41c49c92/markdownify-1.2.2.tar.gz", hash = "sha256:b274f1b5943180b031b699b199cbaeb1e2ac938b75851849a31fd0c3d6603d09", size = 18816, upload-time = "2025-11-16T19:21:18.565Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/43/ce/f1e3e9d959db134cedf06825fae8d5b294bd368aacdd0831a3975b7c4d55/markdownify-1.2.2-py3-none-any.whl", hash = "sha256:3f02d3cc52714084d6e589f70397b6fc9f2f3a8531481bf35e8cc39f975e186a", size = 15724, upload-time = "2025-11-16T19:21:17.622Z" },
+]
+
+[[package]]
+name = "markupsafe"
+version = "3.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7e/99/7690b6d4034fffd95959cbe0c02de8deb3098cc577c67bb6a24fe5d7caa7/markupsafe-3.0.3.tar.gz", hash = "sha256:722695808f4b6457b320fdc131280796bdceb04ab50fe1795cd540799ebe1698", size = 80313, upload-time = "2025-09-27T18:37:40.426Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5a/72/147da192e38635ada20e0a2e1a51cf8823d2119ce8883f7053879c2199b5/markupsafe-3.0.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:d53197da72cc091b024dd97249dfc7794d6a56530370992a5e1a08983ad9230e", size = 11615, upload-time = "2025-09-27T18:36:30.854Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/81/7e4e08678a1f98521201c3079f77db69fb552acd56067661f8c2f534a718/markupsafe-3.0.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:1872df69a4de6aead3491198eaf13810b565bdbeec3ae2dc8780f14458ec73ce", size = 12020, upload-time = "2025-09-27T18:36:31.971Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/2c/799f4742efc39633a1b54a92eec4082e4f815314869865d876824c257c1e/markupsafe-3.0.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3a7e8ae81ae39e62a41ec302f972ba6ae23a5c5396c8e60113e9066ef893da0d", size = 24332, upload-time = "2025-09-27T18:36:32.813Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/2e/8d0c2ab90a8c1d9a24f0399058ab8519a3279d1bd4289511d74e909f060e/markupsafe-3.0.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d6dd0be5b5b189d31db7cda48b91d7e0a9795f31430b7f271219ab30f1d3ac9d", size = 22947, upload-time = "2025-09-27T18:36:33.86Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/54/887f3092a85238093a0b2154bd629c89444f395618842e8b0c41783898ea/markupsafe-3.0.3-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:94c6f0bb423f739146aec64595853541634bde58b2135f27f61c1ffd1cd4d16a", size = 21962, upload-time = "2025-09-27T18:36:35.099Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/2f/336b8c7b6f4a4d95e91119dc8521402461b74a485558d8f238a68312f11c/markupsafe-3.0.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:be8813b57049a7dc738189df53d69395eba14fb99345e0a5994914a3864c8a4b", size = 23760, upload-time = "2025-09-27T18:36:36.001Z" },
+    { url = "https://files.pythonhosted.org/packages/32/43/67935f2b7e4982ffb50a4d169b724d74b62a3964bc1a9a527f5ac4f1ee2b/markupsafe-3.0.3-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:83891d0e9fb81a825d9a6d61e3f07550ca70a076484292a70fde82c4b807286f", size = 21529, upload-time = "2025-09-27T18:36:36.906Z" },
+    { url = "https://files.pythonhosted.org/packages/89/e0/4486f11e51bbba8b0c041098859e869e304d1c261e59244baa3d295d47b7/markupsafe-3.0.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:77f0643abe7495da77fb436f50f8dab76dbc6e5fd25d39589a0f1fe6548bfa2b", size = 23015, upload-time = "2025-09-27T18:36:37.868Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/e1/78ee7a023dac597a5825441ebd17170785a9dab23de95d2c7508ade94e0e/markupsafe-3.0.3-cp312-cp312-win32.whl", hash = "sha256:d88b440e37a16e651bda4c7c2b930eb586fd15ca7406cb39e211fcff3bf3017d", size = 14540, upload-time = "2025-09-27T18:36:38.761Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/5b/bec5aa9bbbb2c946ca2733ef9c4ca91c91b6a24580193e891b5f7dbe8e1e/markupsafe-3.0.3-cp312-cp312-win_amd64.whl", hash = "sha256:26a5784ded40c9e318cfc2bdb30fe164bdb8665ded9cd64d500a34fb42067b1c", size = 15105, upload-time = "2025-09-27T18:36:39.701Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/f1/216fc1bbfd74011693a4fd837e7026152e89c4bcf3e77b6692fba9923123/markupsafe-3.0.3-cp312-cp312-win_arm64.whl", hash = "sha256:35add3b638a5d900e807944a078b51922212fb3dedb01633a8defc4b01a3c85f", size = 13906, upload-time = "2025-09-27T18:36:40.689Z" },
+    { url = "https://files.pythonhosted.org/packages/38/2f/907b9c7bbba283e68f20259574b13d005c121a0fa4c175f9bed27c4597ff/markupsafe-3.0.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:e1cf1972137e83c5d4c136c43ced9ac51d0e124706ee1c8aa8532c1287fa8795", size = 11622, upload-time = "2025-09-27T18:36:41.777Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/d9/5f7756922cdd676869eca1c4e3c0cd0df60ed30199ffd775e319089cb3ed/markupsafe-3.0.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:116bb52f642a37c115f517494ea5feb03889e04df47eeff5b130b1808ce7c219", size = 12029, upload-time = "2025-09-27T18:36:43.257Z" },
+    { url = "https://files.pythonhosted.org/packages/00/07/575a68c754943058c78f30db02ee03a64b3c638586fba6a6dd56830b30a3/markupsafe-3.0.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:133a43e73a802c5562be9bbcd03d090aa5a1fe899db609c29e8c8d815c5f6de6", size = 24374, upload-time = "2025-09-27T18:36:44.508Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/21/9b05698b46f218fc0e118e1f8168395c65c8a2c750ae2bab54fc4bd4e0e8/markupsafe-3.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ccfcd093f13f0f0b7fdd0f198b90053bf7b2f02a3927a30e63f3ccc9df56b676", size = 22980, upload-time = "2025-09-27T18:36:45.385Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/71/544260864f893f18b6827315b988c146b559391e6e7e8f7252839b1b846a/markupsafe-3.0.3-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:509fa21c6deb7a7a273d629cf5ec029bc209d1a51178615ddf718f5918992ab9", size = 21990, upload-time = "2025-09-27T18:36:46.916Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/28/b50fc2f74d1ad761af2f5dcce7492648b983d00a65b8c0e0cb457c82ebbe/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:a4afe79fb3de0b7097d81da19090f4df4f8d3a2b3adaa8764138aac2e44f3af1", size = 23784, upload-time = "2025-09-27T18:36:47.884Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/76/104b2aa106a208da8b17a2fb72e033a5a9d7073c68f7e508b94916ed47a9/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:795e7751525cae078558e679d646ae45574b47ed6e7771863fcc079a6171a0fc", size = 21588, upload-time = "2025-09-27T18:36:48.82Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/99/16a5eb2d140087ebd97180d95249b00a03aa87e29cc224056274f2e45fd6/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:8485f406a96febb5140bfeca44a73e3ce5116b2501ac54fe953e488fb1d03b12", size = 23041, upload-time = "2025-09-27T18:36:49.797Z" },
+    { url = "https://files.pythonhosted.org/packages/19/bc/e7140ed90c5d61d77cea142eed9f9c303f4c4806f60a1044c13e3f1471d0/markupsafe-3.0.3-cp313-cp313-win32.whl", hash = "sha256:bdd37121970bfd8be76c5fb069c7751683bdf373db1ed6c010162b2a130248ed", size = 14543, upload-time = "2025-09-27T18:36:51.584Z" },
+    { url = "https://files.pythonhosted.org/packages/05/73/c4abe620b841b6b791f2edc248f556900667a5a1cf023a6646967ae98335/markupsafe-3.0.3-cp313-cp313-win_amd64.whl", hash = "sha256:9a1abfdc021a164803f4d485104931fb8f8c1efd55bc6b748d2f5774e78b62c5", size = 15113, upload-time = "2025-09-27T18:36:52.537Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/3a/fa34a0f7cfef23cf9500d68cb7c32dd64ffd58a12b09225fb03dd37d5b80/markupsafe-3.0.3-cp313-cp313-win_arm64.whl", hash = "sha256:7e68f88e5b8799aa49c85cd116c932a1ac15caaa3f5db09087854d218359e485", size = 13911, upload-time = "2025-09-27T18:36:53.513Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/d7/e05cd7efe43a88a17a37b3ae96e79a19e846f3f456fe79c57ca61356ef01/markupsafe-3.0.3-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:218551f6df4868a8d527e3062d0fb968682fe92054e89978594c28e642c43a73", size = 11658, upload-time = "2025-09-27T18:36:54.819Z" },
+    { url = "https://files.pythonhosted.org/packages/99/9e/e412117548182ce2148bdeacdda3bb494260c0b0184360fe0d56389b523b/markupsafe-3.0.3-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:3524b778fe5cfb3452a09d31e7b5adefeea8c5be1d43c4f810ba09f2ceb29d37", size = 12066, upload-time = "2025-09-27T18:36:55.714Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/e6/fa0ffcda717ef64a5108eaa7b4f5ed28d56122c9a6d70ab8b72f9f715c80/markupsafe-3.0.3-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4e885a3d1efa2eadc93c894a21770e4bc67899e3543680313b09f139e149ab19", size = 25639, upload-time = "2025-09-27T18:36:56.908Z" },
+    { url = "https://files.pythonhosted.org/packages/96/ec/2102e881fe9d25fc16cb4b25d5f5cde50970967ffa5dddafdb771237062d/markupsafe-3.0.3-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8709b08f4a89aa7586de0aadc8da56180242ee0ada3999749b183aa23df95025", size = 23569, upload-time = "2025-09-27T18:36:57.913Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/30/6f2fce1f1f205fc9323255b216ca8a235b15860c34b6798f810f05828e32/markupsafe-3.0.3-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:b8512a91625c9b3da6f127803b166b629725e68af71f8184ae7e7d54686a56d6", size = 23284, upload-time = "2025-09-27T18:36:58.833Z" },
+    { url = "https://files.pythonhosted.org/packages/58/47/4a0ccea4ab9f5dcb6f79c0236d954acb382202721e704223a8aafa38b5c8/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:9b79b7a16f7fedff2495d684f2b59b0457c3b493778c9eed31111be64d58279f", size = 24801, upload-time = "2025-09-27T18:36:59.739Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/70/3780e9b72180b6fecb83a4814d84c3bf4b4ae4bf0b19c27196104149734c/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:12c63dfb4a98206f045aa9563db46507995f7ef6d83b2f68eda65c307c6829eb", size = 22769, upload-time = "2025-09-27T18:37:00.719Z" },
+    { url = "https://files.pythonhosted.org/packages/98/c5/c03c7f4125180fc215220c035beac6b9cb684bc7a067c84fc69414d315f5/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:8f71bc33915be5186016f675cd83a1e08523649b0e33efdb898db577ef5bb009", size = 23642, upload-time = "2025-09-27T18:37:01.673Z" },
+    { url = "https://files.pythonhosted.org/packages/80/d6/2d1b89f6ca4bff1036499b1e29a1d02d282259f3681540e16563f27ebc23/markupsafe-3.0.3-cp313-cp313t-win32.whl", hash = "sha256:69c0b73548bc525c8cb9a251cddf1931d1db4d2258e9599c28c07ef3580ef354", size = 14612, upload-time = "2025-09-27T18:37:02.639Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/98/e48a4bfba0a0ffcf9925fe2d69240bfaa19c6f7507b8cd09c70684a53c1e/markupsafe-3.0.3-cp313-cp313t-win_amd64.whl", hash = "sha256:1b4b79e8ebf6b55351f0d91fe80f893b4743f104bff22e90697db1590e47a218", size = 15200, upload-time = "2025-09-27T18:37:03.582Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/72/e3cc540f351f316e9ed0f092757459afbc595824ca724cbc5a5d4263713f/markupsafe-3.0.3-cp313-cp313t-win_arm64.whl", hash = "sha256:ad2cf8aa28b8c020ab2fc8287b0f823d0a7d8630784c31e9ee5edea20f406287", size = 13973, upload-time = "2025-09-27T18:37:04.929Z" },
+    { url = "https://files.pythonhosted.org/packages/33/8a/8e42d4838cd89b7dde187011e97fe6c3af66d8c044997d2183fbd6d31352/markupsafe-3.0.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:eaa9599de571d72e2daf60164784109f19978b327a3910d3e9de8c97b5b70cfe", size = 11619, upload-time = "2025-09-27T18:37:06.342Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/64/7660f8a4a8e53c924d0fa05dc3a55c9cee10bbd82b11c5afb27d44b096ce/markupsafe-3.0.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c47a551199eb8eb2121d4f0f15ae0f923d31350ab9280078d1e5f12b249e0026", size = 12029, upload-time = "2025-09-27T18:37:07.213Z" },
+    { url = "https://files.pythonhosted.org/packages/da/ef/e648bfd021127bef5fa12e1720ffed0c6cbb8310c8d9bea7266337ff06de/markupsafe-3.0.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f34c41761022dd093b4b6896d4810782ffbabe30f2d443ff5f083e0cbbb8c737", size = 24408, upload-time = "2025-09-27T18:37:09.572Z" },
+    { url = "https://files.pythonhosted.org/packages/41/3c/a36c2450754618e62008bf7435ccb0f88053e07592e6028a34776213d877/markupsafe-3.0.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:457a69a9577064c05a97c41f4e65148652db078a3a509039e64d3467b9e7ef97", size = 23005, upload-time = "2025-09-27T18:37:10.58Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/20/b7fdf89a8456b099837cd1dc21974632a02a999ec9bf7ca3e490aacd98e7/markupsafe-3.0.3-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e8afc3f2ccfa24215f8cb28dcf43f0113ac3c37c2f0f0806d8c70e4228c5cf4d", size = 22048, upload-time = "2025-09-27T18:37:11.547Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/a7/591f592afdc734f47db08a75793a55d7fbcc6902a723ae4cfbab61010cc5/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:ec15a59cf5af7be74194f7ab02d0f59a62bdcf1a537677ce67a2537c9b87fcda", size = 23821, upload-time = "2025-09-27T18:37:12.48Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/33/45b24e4f44195b26521bc6f1a82197118f74df348556594bd2262bda1038/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:0eb9ff8191e8498cca014656ae6b8d61f39da5f95b488805da4bb029cccbfbaf", size = 21606, upload-time = "2025-09-27T18:37:13.485Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/0e/53dfaca23a69fbfbbf17a4b64072090e70717344c52eaaaa9c5ddff1e5f0/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:2713baf880df847f2bece4230d4d094280f4e67b1e813eec43b4c0e144a34ffe", size = 23043, upload-time = "2025-09-27T18:37:14.408Z" },
+    { url = "https://files.pythonhosted.org/packages/46/11/f333a06fc16236d5238bfe74daccbca41459dcd8d1fa952e8fbd5dccfb70/markupsafe-3.0.3-cp314-cp314-win32.whl", hash = "sha256:729586769a26dbceff69f7a7dbbf59ab6572b99d94576a5592625d5b411576b9", size = 14747, upload-time = "2025-09-27T18:37:15.36Z" },
+    { url = "https://files.pythonhosted.org/packages/28/52/182836104b33b444e400b14f797212f720cbc9ed6ba34c800639d154e821/markupsafe-3.0.3-cp314-cp314-win_amd64.whl", hash = "sha256:bdc919ead48f234740ad807933cdf545180bfbe9342c2bb451556db2ed958581", size = 15341, upload-time = "2025-09-27T18:37:16.496Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/18/acf23e91bd94fd7b3031558b1f013adfa21a8e407a3fdb32745538730382/markupsafe-3.0.3-cp314-cp314-win_arm64.whl", hash = "sha256:5a7d5dc5140555cf21a6fefbdbf8723f06fcd2f63ef108f2854de715e4422cb4", size = 14073, upload-time = "2025-09-27T18:37:17.476Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/f0/57689aa4076e1b43b15fdfa646b04653969d50cf30c32a102762be2485da/markupsafe-3.0.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:1353ef0c1b138e1907ae78e2f6c63ff67501122006b0f9abad68fda5f4ffc6ab", size = 11661, upload-time = "2025-09-27T18:37:18.453Z" },
+    { url = "https://files.pythonhosted.org/packages/89/c3/2e67a7ca217c6912985ec766c6393b636fb0c2344443ff9d91404dc4c79f/markupsafe-3.0.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:1085e7fbddd3be5f89cc898938f42c0b3c711fdcb37d75221de2666af647c175", size = 12069, upload-time = "2025-09-27T18:37:19.332Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/00/be561dce4e6ca66b15276e184ce4b8aec61fe83662cce2f7d72bd3249d28/markupsafe-3.0.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1b52b4fb9df4eb9ae465f8d0c228a00624de2334f216f178a995ccdcf82c4634", size = 25670, upload-time = "2025-09-27T18:37:20.245Z" },
+    { url = "https://files.pythonhosted.org/packages/50/09/c419f6f5a92e5fadde27efd190eca90f05e1261b10dbd8cbcb39cd8ea1dc/markupsafe-3.0.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:fed51ac40f757d41b7c48425901843666a6677e3e8eb0abcff09e4ba6e664f50", size = 23598, upload-time = "2025-09-27T18:37:21.177Z" },
+    { url = "https://files.pythonhosted.org/packages/22/44/a0681611106e0b2921b3033fc19bc53323e0b50bc70cffdd19f7d679bb66/markupsafe-3.0.3-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:f190daf01f13c72eac4efd5c430a8de82489d9cff23c364c3ea822545032993e", size = 23261, upload-time = "2025-09-27T18:37:22.167Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/57/1b0b3f100259dc9fffe780cfb60d4be71375510e435efec3d116b6436d43/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e56b7d45a839a697b5eb268c82a71bd8c7f6c94d6fd50c3d577fa39a9f1409f5", size = 24835, upload-time = "2025-09-27T18:37:23.296Z" },
+    { url = "https://files.pythonhosted.org/packages/26/6a/4bf6d0c97c4920f1597cc14dd720705eca0bf7c787aebc6bb4d1bead5388/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:f3e98bb3798ead92273dc0e5fd0f31ade220f59a266ffd8a4f6065e0a3ce0523", size = 22733, upload-time = "2025-09-27T18:37:24.237Z" },
+    { url = "https://files.pythonhosted.org/packages/14/c7/ca723101509b518797fedc2fdf79ba57f886b4aca8a7d31857ba3ee8281f/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:5678211cb9333a6468fb8d8be0305520aa073f50d17f089b5b4b477ea6e67fdc", size = 23672, upload-time = "2025-09-27T18:37:25.271Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/df/5bd7a48c256faecd1d36edc13133e51397e41b73bb77e1a69deab746ebac/markupsafe-3.0.3-cp314-cp314t-win32.whl", hash = "sha256:915c04ba3851909ce68ccc2b8e2cd691618c4dc4c4232fb7982bca3f41fd8c3d", size = 14819, upload-time = "2025-09-27T18:37:26.285Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/8a/0402ba61a2f16038b48b39bccca271134be00c5c9f0f623208399333c448/markupsafe-3.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4faffd047e07c38848ce017e8725090413cd80cbc23d86e55c587bf979e579c9", size = 15426, upload-time = "2025-09-27T18:37:27.316Z" },
+    { url = "https://files.pythonhosted.org/packages/70/bc/6f1c2f612465f5fa89b95bead1f44dcb607670fd42891d8fdcd5d039f4f4/markupsafe-3.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:32001d6a8fc98c8cb5c947787c5d08b0a50663d139f1305bac5885d98d9b40fa", size = 14146, upload-time = "2025-09-27T18:37:28.327Z" },
 ]
 
 [[package]]
@@ -752,6 +2117,136 @@ wheels = [
 ]
 
 [[package]]
+name = "more-itertools"
+version = "11.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/de/1d/f4da6f02cdffe04d6362210b807146a26044c88d839208aec273bb0d9184/more_itertools-11.1.0.tar.gz", hash = "sha256:48e8f4d9e7e5878571ecf6f2b4e57634f93cd474cc8cfbd2376f2d11b396e30d", size = 145772, upload-time = "2026-05-22T14:14:29.909Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e8/3d/1087453384dbde46a8c7f9356eead2c58be8a7bf156bca40243377c85715/more_itertools-11.1.0-py3-none-any.whl", hash = "sha256:4b65538ae22f6fed0ce4874efd317463a7489796a0939fa66824dd542125a192", size = 72226, upload-time = "2026-05-22T14:14:28.824Z" },
+]
+
+[[package]]
+name = "multidict"
+version = "6.7.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1a/c2/c2d94cbe6ac1753f3fc980da97b3d930efe1da3af3c9f5125354436c073d/multidict-6.7.1.tar.gz", hash = "sha256:ec6652a1bee61c53a3e5776b6049172c53b6aaba34f18c9ad04f82712bac623d", size = 102010, upload-time = "2026-01-26T02:46:45.979Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8d/9c/f20e0e2cf80e4b2e4b1c365bf5fe104ee633c751a724246262db8f1a0b13/multidict-6.7.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:a90f75c956e32891a4eda3639ce6dd86e87105271f43d43442a3aedf3cddf172", size = 76893, upload-time = "2026-01-26T02:43:52.754Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/cf/18ef143a81610136d3da8193da9d80bfe1cb548a1e2d1c775f26b23d024a/multidict-6.7.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:3fccb473e87eaa1382689053e4a4618e7ba7b9b9b8d6adf2027ee474597128cd", size = 45456, upload-time = "2026-01-26T02:43:53.893Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/65/1caac9d4cd32e8433908683446eebc953e82d22b03d10d41a5f0fefe991b/multidict-6.7.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:b0fa96985700739c4c7853a43c0b3e169360d6855780021bfc6d0f1ce7c123e7", size = 43872, upload-time = "2026-01-26T02:43:55.041Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/3b/d6bd75dc4f3ff7c73766e04e705b00ed6dbbaccf670d9e05a12b006f5a21/multidict-6.7.1-cp312-cp312-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:cb2a55f408c3043e42b40cc8eecd575afa27b7e0b956dfb190de0f8499a57a53", size = 251018, upload-time = "2026-01-26T02:43:56.198Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/80/c959c5933adedb9ac15152e4067c702a808ea183a8b64cf8f31af8ad3155/multidict-6.7.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:eb0ce7b2a32d09892b3dd6cc44877a0d02a33241fafca5f25c8b6b62374f8b75", size = 258883, upload-time = "2026-01-26T02:43:57.499Z" },
+    { url = "https://files.pythonhosted.org/packages/86/85/7ed40adafea3d4f1c8b916e3b5cc3a8e07dfcdcb9cd72800f4ed3ca1b387/multidict-6.7.1-cp312-cp312-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:c3a32d23520ee37bf327d1e1a656fec76a2edd5c038bf43eddfa0572ec49c60b", size = 242413, upload-time = "2026-01-26T02:43:58.755Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/57/b8565ff533e48595503c785f8361ff9a4fde4d67de25c207cd0ba3befd03/multidict-6.7.1-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:9c90fed18bffc0189ba814749fdcc102b536e83a9f738a9003e569acd540a733", size = 268404, upload-time = "2026-01-26T02:44:00.216Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/50/9810c5c29350f7258180dfdcb2e52783a0632862eb334c4896ac717cebcb/multidict-6.7.1-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:da62917e6076f512daccfbbde27f46fed1c98fee202f0559adec8ee0de67f71a", size = 269456, upload-time = "2026-01-26T02:44:02.202Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/8d/5e5be3ced1d12966fefb5c4ea3b2a5b480afcea36406559442c6e31d4a48/multidict-6.7.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bfde23ef6ed9db7eaee6c37dcec08524cb43903c60b285b172b6c094711b3961", size = 256322, upload-time = "2026-01-26T02:44:03.56Z" },
+    { url = "https://files.pythonhosted.org/packages/31/6e/d8a26d81ac166a5592782d208dd90dfdc0a7a218adaa52b45a672b46c122/multidict-6.7.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:3758692429e4e32f1ba0df23219cd0b4fc0a52f476726fff9337d1a57676a582", size = 253955, upload-time = "2026-01-26T02:44:04.845Z" },
+    { url = "https://files.pythonhosted.org/packages/59/4c/7c672c8aad41534ba619bcd4ade7a0dc87ed6b8b5c06149b85d3dd03f0cd/multidict-6.7.1-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:398c1478926eca669f2fd6a5856b6de9c0acf23a2cb59a14c0ba5844fa38077e", size = 251254, upload-time = "2026-01-26T02:44:06.133Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/bd/84c24de512cbafbdbc39439f74e967f19570ce7924e3007174a29c348916/multidict-6.7.1-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:c102791b1c4f3ab36ce4101154549105a53dc828f016356b3e3bcae2e3a039d3", size = 252059, upload-time = "2026-01-26T02:44:07.518Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/ba/f5449385510825b73d01c2d4087bf6d2fccc20a2d42ac34df93191d3dd03/multidict-6.7.1-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:a088b62bd733e2ad12c50dad01b7d0166c30287c166e137433d3b410add807a6", size = 263588, upload-time = "2026-01-26T02:44:09.382Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/11/afc7c677f68f75c84a69fe37184f0f82fce13ce4b92f49f3db280b7e92b3/multidict-6.7.1-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:3d51ff4785d58d3f6c91bdbffcb5e1f7ddfda557727043aa20d20ec4f65e324a", size = 259642, upload-time = "2026-01-26T02:44:10.73Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/17/ebb9644da78c4ab36403739e0e6e0e30ebb135b9caf3440825001a0bddcb/multidict-6.7.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:fc5907494fccf3e7d3f94f95c91d6336b092b5fc83811720fae5e2765890dfba", size = 251377, upload-time = "2026-01-26T02:44:12.042Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/a4/840f5b97339e27846c46307f2530a2805d9d537d8b8bd416af031cad7fa0/multidict-6.7.1-cp312-cp312-win32.whl", hash = "sha256:28ca5ce2fd9716631133d0e9a9b9a745ad7f60bac2bccafb56aa380fc0b6c511", size = 41887, upload-time = "2026-01-26T02:44:14.245Z" },
+    { url = "https://files.pythonhosted.org/packages/80/31/0b2517913687895f5904325c2069d6a3b78f66cc641a86a2baf75a05dcbb/multidict-6.7.1-cp312-cp312-win_amd64.whl", hash = "sha256:fcee94dfbd638784645b066074b338bc9cc155d4b4bffa4adce1615c5a426c19", size = 46053, upload-time = "2026-01-26T02:44:15.371Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/5b/aba28e4ee4006ae4c7df8d327d31025d760ffa992ea23812a601d226e682/multidict-6.7.1-cp312-cp312-win_arm64.whl", hash = "sha256:ba0a9fb644d0c1a2194cf7ffb043bd852cea63a57f66fbd33959f7dae18517bf", size = 43307, upload-time = "2026-01-26T02:44:16.852Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/22/929c141d6c0dba87d3e1d38fbdf1ba8baba86b7776469f2bc2d3227a1e67/multidict-6.7.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:2b41f5fed0ed563624f1c17630cb9941cf2309d4df00e494b551b5f3e3d67a23", size = 76174, upload-time = "2026-01-26T02:44:18.509Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/75/bc704ae15fee974f8fccd871305e254754167dce5f9e42d88a2def741a1d/multidict-6.7.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:84e61e3af5463c19b67ced91f6c634effb89ef8bfc5ca0267f954451ed4bb6a2", size = 45116, upload-time = "2026-01-26T02:44:19.745Z" },
+    { url = "https://files.pythonhosted.org/packages/79/76/55cd7186f498ed080a18440c9013011eb548f77ae1b297206d030eb1180a/multidict-6.7.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:935434b9853c7c112eee7ac891bc4cb86455aa631269ae35442cb316790c1445", size = 43524, upload-time = "2026-01-26T02:44:21.571Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/3c/414842ef8d5a1628d68edee29ba0e5bcf235dbfb3ccd3ea303a7fe8c72ff/multidict-6.7.1-cp313-cp313-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:432feb25a1cb67fe82a9680b4d65fb542e4635cb3166cd9c01560651ad60f177", size = 249368, upload-time = "2026-01-26T02:44:22.803Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/32/befed7f74c458b4a525e60519fe8d87eef72bb1e99924fa2b0f9d97a221e/multidict-6.7.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e82d14e3c948952a1a85503817e038cba5905a3352de76b9a465075d072fba23", size = 256952, upload-time = "2026-01-26T02:44:24.306Z" },
+    { url = "https://files.pythonhosted.org/packages/03/d6/c878a44ba877f366630c860fdf74bfb203c33778f12b6ac274936853c451/multidict-6.7.1-cp313-cp313-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:4cfb48c6ea66c83bcaaf7e4dfa7ec1b6bbcf751b7db85a328902796dfde4c060", size = 240317, upload-time = "2026-01-26T02:44:25.772Z" },
+    { url = "https://files.pythonhosted.org/packages/68/49/57421b4d7ad2e9e60e25922b08ceb37e077b90444bde6ead629095327a6f/multidict-6.7.1-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:1d540e51b7e8e170174555edecddbd5538105443754539193e3e1061864d444d", size = 267132, upload-time = "2026-01-26T02:44:27.648Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/fe/ec0edd52ddbcea2a2e89e174f0206444a61440b40f39704e64dc807a70bd/multidict-6.7.1-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:273d23f4b40f3dce4d6c8a821c741a86dec62cded82e1175ba3d99be128147ed", size = 268140, upload-time = "2026-01-26T02:44:29.588Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/73/6e1b01cbeb458807aa0831742232dbdd1fa92bfa33f52a3f176b4ff3dc11/multidict-6.7.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9d624335fd4fa1c08a53f8b4be7676ebde19cd092b3895c421045ca87895b429", size = 254277, upload-time = "2026-01-26T02:44:30.902Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/b2/5fb8c124d7561a4974c342bc8c778b471ebbeb3cc17df696f034a7e9afe7/multidict-6.7.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:12fad252f8b267cc75b66e8fc51b3079604e8d43a75428ffe193cd9e2195dfd6", size = 252291, upload-time = "2026-01-26T02:44:32.31Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/96/51d4e4e06bcce92577fcd488e22600bd38e4fd59c20cb49434d054903bd2/multidict-6.7.1-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:03ede2a6ffbe8ef936b92cb4529f27f42be7f56afcdab5ab739cd5f27fb1cbf9", size = 250156, upload-time = "2026-01-26T02:44:33.734Z" },
+    { url = "https://files.pythonhosted.org/packages/db/6b/420e173eec5fba721a50e2a9f89eda89d9c98fded1124f8d5c675f7a0c0f/multidict-6.7.1-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:90efbcf47dbe33dcf643a1e400d67d59abeac5db07dc3f27d6bdeae497a2198c", size = 249742, upload-time = "2026-01-26T02:44:35.222Z" },
+    { url = "https://files.pythonhosted.org/packages/44/a3/ec5b5bd98f306bc2aa297b8c6f11a46714a56b1e6ef5ebda50a4f5d7c5fb/multidict-6.7.1-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:5c4b9bfc148f5a91be9244d6264c53035c8a0dcd2f51f1c3c6e30e30ebaa1c84", size = 262221, upload-time = "2026-01-26T02:44:36.604Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/f7/e8c0d0da0cd1e28d10e624604e1a36bcc3353aaebdfdc3a43c72bc683a12/multidict-6.7.1-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:401c5a650f3add2472d1d288c26deebc540f99e2fb83e9525007a74cd2116f1d", size = 258664, upload-time = "2026-01-26T02:44:38.008Z" },
+    { url = "https://files.pythonhosted.org/packages/52/da/151a44e8016dd33feed44f730bd856a66257c1ee7aed4f44b649fb7edeb3/multidict-6.7.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:97891f3b1b3ffbded884e2916cacf3c6fc87b66bb0dde46f7357404750559f33", size = 249490, upload-time = "2026-01-26T02:44:39.386Z" },
+    { url = "https://files.pythonhosted.org/packages/87/af/a3b86bf9630b732897f6fc3f4c4714b90aa4361983ccbdcd6c0339b21b0c/multidict-6.7.1-cp313-cp313-win32.whl", hash = "sha256:e1c5988359516095535c4301af38d8a8838534158f649c05dd1050222321bcb3", size = 41695, upload-time = "2026-01-26T02:44:41.318Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/35/e994121b0e90e46134673422dd564623f93304614f5d11886b1b3e06f503/multidict-6.7.1-cp313-cp313-win_amd64.whl", hash = "sha256:960c83bf01a95b12b08fd54324a4eb1d5b52c88932b5cba5d6e712bb3ed12eb5", size = 45884, upload-time = "2026-01-26T02:44:42.488Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/61/42d3e5dbf661242a69c97ea363f2d7b46c567da8eadef8890022be6e2ab0/multidict-6.7.1-cp313-cp313-win_arm64.whl", hash = "sha256:563fe25c678aaba333d5399408f5ec3c383ca5b663e7f774dd179a520b8144df", size = 43122, upload-time = "2026-01-26T02:44:43.664Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/b3/e6b21c6c4f314bb956016b0b3ef2162590a529b84cb831c257519e7fde44/multidict-6.7.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:c76c4bec1538375dad9d452d246ca5368ad6e1c9039dadcf007ae59c70619ea1", size = 83175, upload-time = "2026-01-26T02:44:44.894Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/76/23ecd2abfe0957b234f6c960f4ade497f55f2c16aeb684d4ecdbf1c95791/multidict-6.7.1-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:57b46b24b5d5ebcc978da4ec23a819a9402b4228b8a90d9c656422b4bdd8a963", size = 48460, upload-time = "2026-01-26T02:44:46.106Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/57/a0ed92b23f3a042c36bc4227b72b97eca803f5f1801c1ab77c8a212d455e/multidict-6.7.1-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:e954b24433c768ce78ab7929e84ccf3422e46deb45a4dc9f93438f8217fa2d34", size = 46930, upload-time = "2026-01-26T02:44:47.278Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/66/02ec7ace29162e447f6382c495dc95826bf931d3818799bbef11e8f7df1a/multidict-6.7.1-cp313-cp313t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:3bd231490fa7217cc832528e1cd8752a96f0125ddd2b5749390f7c3ec8721b65", size = 242582, upload-time = "2026-01-26T02:44:48.604Z" },
+    { url = "https://files.pythonhosted.org/packages/58/18/64f5a795e7677670e872673aca234162514696274597b3708b2c0d276cce/multidict-6.7.1-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:253282d70d67885a15c8a7716f3a73edf2d635793ceda8173b9ecc21f2fb8292", size = 250031, upload-time = "2026-01-26T02:44:50.544Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/ed/e192291dbbe51a8290c5686f482084d31bcd9d09af24f63358c3d42fd284/multidict-6.7.1-cp313-cp313t-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:0b4c48648d7649c9335cf1927a8b87fa692de3dcb15faa676c6a6f1f1aabda43", size = 228596, upload-time = "2026-01-26T02:44:51.951Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/7e/3562a15a60cf747397e7f2180b0a11dc0c38d9175a650e75fa1b4d325e15/multidict-6.7.1-cp313-cp313t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:98bc624954ec4d2c7cb074b8eefc2b5d0ce7d482e410df446414355d158fe4ca", size = 257492, upload-time = "2026-01-26T02:44:53.902Z" },
+    { url = "https://files.pythonhosted.org/packages/24/02/7d0f9eae92b5249bb50ac1595b295f10e263dd0078ebb55115c31e0eaccd/multidict-6.7.1-cp313-cp313t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:1b99af4d9eec0b49927b4402bcbb58dea89d3e0db8806a4086117019939ad3dd", size = 255899, upload-time = "2026-01-26T02:44:55.316Z" },
+    { url = "https://files.pythonhosted.org/packages/00/e3/9b60ed9e23e64c73a5cde95269ef1330678e9c6e34dd4eb6b431b85b5a10/multidict-6.7.1-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6aac4f16b472d5b7dc6f66a0d49dd57b0e0902090be16594dc9ebfd3d17c47e7", size = 247970, upload-time = "2026-01-26T02:44:56.783Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/06/538e58a63ed5cfb0bd4517e346b91da32fde409d839720f664e9a4ae4f9d/multidict-6.7.1-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:21f830fe223215dffd51f538e78c172ed7c7f60c9b96a2bf05c4848ad49921c3", size = 245060, upload-time = "2026-01-26T02:44:58.195Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/2f/d743a3045a97c895d401e9bd29aaa09b94f5cbdf1bd561609e5a6c431c70/multidict-6.7.1-cp313-cp313t-musllinux_1_2_armv7l.whl", hash = "sha256:f5dd81c45b05518b9aa4da4aa74e1c93d715efa234fd3e8a179df611cc85e5f4", size = 235888, upload-time = "2026-01-26T02:44:59.57Z" },
+    { url = "https://files.pythonhosted.org/packages/38/83/5a325cac191ab28b63c52f14f1131f3b0a55ba3b9aa65a6d0bf2a9b921a0/multidict-6.7.1-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:eb304767bca2bb92fb9c5bd33cedc95baee5bb5f6c88e63706533a1c06ad08c8", size = 243554, upload-time = "2026-01-26T02:45:01.054Z" },
+    { url = "https://files.pythonhosted.org/packages/20/1f/9d2327086bd15da2725ef6aae624208e2ef828ed99892b17f60c344e57ed/multidict-6.7.1-cp313-cp313t-musllinux_1_2_ppc64le.whl", hash = "sha256:c9035dde0f916702850ef66460bc4239d89d08df4d02023a5926e7446724212c", size = 252341, upload-time = "2026-01-26T02:45:02.484Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/2c/2a1aa0280cf579d0f6eed8ee5211c4f1730bd7e06c636ba2ee6aafda302e/multidict-6.7.1-cp313-cp313t-musllinux_1_2_s390x.whl", hash = "sha256:af959b9beeb66c822380f222f0e0a1889331597e81f1ded7f374f3ecb0fd6c52", size = 246391, upload-time = "2026-01-26T02:45:03.862Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/03/7ca022ffc36c5a3f6e03b179a5ceb829be9da5783e6fe395f347c0794680/multidict-6.7.1-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:41f2952231456154ee479651491e94118229844dd7226541788be783be2b5108", size = 243422, upload-time = "2026-01-26T02:45:05.296Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/1d/b31650eab6c5778aceed46ba735bd97f7c7d2f54b319fa916c0f96e7805b/multidict-6.7.1-cp313-cp313t-win32.whl", hash = "sha256:df9f19c28adcb40b6aae30bbaa1478c389efd50c28d541d76760199fc1037c32", size = 47770, upload-time = "2026-01-26T02:45:06.754Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/5b/2d2d1d522e51285bd61b1e20df8f47ae1a9d80839db0b24ea783b3832832/multidict-6.7.1-cp313-cp313t-win_amd64.whl", hash = "sha256:d54ecf9f301853f2c5e802da559604b3e95bb7a3b01a9c295c6ee591b9882de8", size = 53109, upload-time = "2026-01-26T02:45:08.044Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/a3/cc409ba012c83ca024a308516703cf339bdc4b696195644a7215a5164a24/multidict-6.7.1-cp313-cp313t-win_arm64.whl", hash = "sha256:5a37ca18e360377cfda1d62f5f382ff41f2b8c4ccb329ed974cc2e1643440118", size = 45573, upload-time = "2026-01-26T02:45:09.349Z" },
+    { url = "https://files.pythonhosted.org/packages/91/cc/db74228a8be41884a567e88a62fd589a913708fcf180d029898c17a9a371/multidict-6.7.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:8f333ec9c5eb1b7105e3b84b53141e66ca05a19a605368c55450b6ba208cb9ee", size = 75190, upload-time = "2026-01-26T02:45:10.651Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/22/492f2246bb5b534abd44804292e81eeaf835388901f0c574bac4eeec73c5/multidict-6.7.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:a407f13c188f804c759fc6a9f88286a565c242a76b27626594c133b82883b5c2", size = 44486, upload-time = "2026-01-26T02:45:11.938Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/4f/733c48f270565d78b4544f2baddc2fb2a245e5a8640254b12c36ac7ac68e/multidict-6.7.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:0e161ddf326db5577c3a4cc2d8648f81456e8a20d40415541587a71620d7a7d1", size = 43219, upload-time = "2026-01-26T02:45:14.346Z" },
+    { url = "https://files.pythonhosted.org/packages/24/bb/2c0c2287963f4259c85e8bcbba9182ced8d7fca65c780c38e99e61629d11/multidict-6.7.1-cp314-cp314-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:1e3a8bb24342a8201d178c3b4984c26ba81a577c80d4d525727427460a50c22d", size = 245132, upload-time = "2026-01-26T02:45:15.712Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/f9/44d4b3064c65079d2467888794dea218d1601898ac50222ab8a9a8094460/multidict-6.7.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:97231140a50f5d447d3164f994b86a0bed7cd016e2682f8650d6a9158e14fd31", size = 252420, upload-time = "2026-01-26T02:45:17.293Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/13/78f7275e73fa17b24c9a51b0bd9d73ba64bb32d0ed51b02a746eb876abe7/multidict-6.7.1-cp314-cp314-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:6b10359683bd8806a200fd2909e7c8ca3a7b24ec1d8132e483d58e791d881048", size = 233510, upload-time = "2026-01-26T02:45:19.356Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/25/8167187f62ae3cbd52da7893f58cb036b47ea3fb67138787c76800158982/multidict-6.7.1-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:283ddac99f7ac25a4acadbf004cb5ae34480bbeb063520f70ce397b281859362", size = 264094, upload-time = "2026-01-26T02:45:20.834Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/e7/69a3a83b7b030cf283fb06ce074a05a02322359783424d7edf0f15fe5022/multidict-6.7.1-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:538cec1e18c067d0e6103aa9a74f9e832904c957adc260e61cd9d8cf0c3b3d37", size = 260786, upload-time = "2026-01-26T02:45:22.818Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/3b/8ec5074bcfc450fe84273713b4b0a0dd47c0249358f5d82eb8104ffe2520/multidict-6.7.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7eee46ccb30ff48a1e35bb818cc90846c6be2b68240e42a78599166722cea709", size = 248483, upload-time = "2026-01-26T02:45:24.368Z" },
+    { url = "https://files.pythonhosted.org/packages/48/5a/d5a99e3acbca0e29c5d9cba8f92ceb15dce78bab963b308ae692981e3a5d/multidict-6.7.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:fa263a02f4f2dd2d11a7b1bb4362aa7cb1049f84a9235d31adf63f30143469a0", size = 248403, upload-time = "2026-01-26T02:45:25.982Z" },
+    { url = "https://files.pythonhosted.org/packages/35/48/e58cd31f6c7d5102f2a4bf89f96b9cf7e00b6c6f3d04ecc44417c00a5a3c/multidict-6.7.1-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:2e1425e2f99ec5bd36c15a01b690a1a2456209c5deed58f95469ffb46039ccbb", size = 240315, upload-time = "2026-01-26T02:45:27.487Z" },
+    { url = "https://files.pythonhosted.org/packages/94/33/1cd210229559cb90b6786c30676bb0c58249ff42f942765f88793b41fdce/multidict-6.7.1-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:497394b3239fc6f0e13a78a3e1b61296e72bf1c5f94b4c4eb80b265c37a131cd", size = 245528, upload-time = "2026-01-26T02:45:28.991Z" },
+    { url = "https://files.pythonhosted.org/packages/64/f2/6e1107d226278c876c783056b7db43d800bb64c6131cec9c8dfb6903698e/multidict-6.7.1-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:233b398c29d3f1b9676b4b6f75c518a06fcb2ea0b925119fb2c1bc35c05e1601", size = 258784, upload-time = "2026-01-26T02:45:30.503Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/c1/11f664f14d525e4a1b5327a82d4de61a1db604ab34c6603bb3c2cc63ad34/multidict-6.7.1-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:93b1818e4a6e0930454f0f2af7dfce69307ca03cdcfb3739bf4d91241967b6c1", size = 251980, upload-time = "2026-01-26T02:45:32.603Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/9f/75a9ac888121d0c5bbd4ecf4eead45668b1766f6baabfb3b7f66a410e231/multidict-6.7.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:f33dc2a3abe9249ea5d8360f969ec7f4142e7ac45ee7014d8f8d5acddf178b7b", size = 243602, upload-time = "2026-01-26T02:45:34.043Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/e7/50bf7b004cc8525d80dbbbedfdc7aed3e4c323810890be4413e589074032/multidict-6.7.1-cp314-cp314-win32.whl", hash = "sha256:3ab8b9d8b75aef9df299595d5388b14530839f6422333357af1339443cff777d", size = 40930, upload-time = "2026-01-26T02:45:36.278Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/bf/52f25716bbe93745595800f36fb17b73711f14da59ed0bb2eba141bc9f0f/multidict-6.7.1-cp314-cp314-win_amd64.whl", hash = "sha256:5e01429a929600e7dab7b166062d9bb54a5eed752384c7384c968c2afab8f50f", size = 45074, upload-time = "2026-01-26T02:45:37.546Z" },
+    { url = "https://files.pythonhosted.org/packages/97/ab/22803b03285fa3a525f48217963da3a65ae40f6a1b6f6cf2768879e208f9/multidict-6.7.1-cp314-cp314-win_arm64.whl", hash = "sha256:4885cb0e817aef5d00a2e8451d4665c1808378dc27c2705f1bf4ef8505c0d2e5", size = 42471, upload-time = "2026-01-26T02:45:38.889Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/6d/f9293baa6146ba9507e360ea0292b6422b016907c393e2f63fc40ab7b7b5/multidict-6.7.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:0458c978acd8e6ea53c81eefaddbbee9c6c5e591f41b3f5e8e194780fe026581", size = 82401, upload-time = "2026-01-26T02:45:40.254Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/68/53b5494738d83558d87c3c71a486504d8373421c3e0dbb6d0db48ad42ee0/multidict-6.7.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:c0abd12629b0af3cf590982c0b413b1e7395cd4ec026f30986818ab95bfaa94a", size = 48143, upload-time = "2026-01-26T02:45:41.635Z" },
+    { url = "https://files.pythonhosted.org/packages/37/e8/5284c53310dcdc99ce5d66563f6e5773531a9b9fe9ec7a615e9bc306b05f/multidict-6.7.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:14525a5f61d7d0c94b368a42cff4c9a4e7ba2d52e2672a7b23d84dc86fb02b0c", size = 46507, upload-time = "2026-01-26T02:45:42.99Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/fc/6800d0e5b3875568b4083ecf5f310dcf91d86d52573160834fb4bfcf5e4f/multidict-6.7.1-cp314-cp314t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:17307b22c217b4cf05033dabefe68255a534d637c6c9b0cc8382718f87be4262", size = 239358, upload-time = "2026-01-26T02:45:44.376Z" },
+    { url = "https://files.pythonhosted.org/packages/41/75/4ad0973179361cdf3a113905e6e088173198349131be2b390f9fa4da5fc6/multidict-6.7.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7a7e590ff876a3eaf1c02a4dfe0724b6e69a9e9de6d8f556816f29c496046e59", size = 246884, upload-time = "2026-01-26T02:45:47.167Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/9c/095bb28b5da139bd41fb9a5d5caff412584f377914bd8787c2aa98717130/multidict-6.7.1-cp314-cp314t-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:5fa6a95dfee63893d80a34758cd0e0c118a30b8dcb46372bf75106c591b77889", size = 225878, upload-time = "2026-01-26T02:45:48.698Z" },
+    { url = "https://files.pythonhosted.org/packages/07/d0/c0a72000243756e8f5a277b6b514fa005f2c73d481b7d9e47cd4568aa2e4/multidict-6.7.1-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a0543217a6a017692aa6ae5cc39adb75e587af0f3a82288b1492eb73dd6cc2a4", size = 253542, upload-time = "2026-01-26T02:45:50.164Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/6b/f69da15289e384ecf2a68837ec8b5ad8c33e973aa18b266f50fe55f24b8c/multidict-6.7.1-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:f99fe611c312b3c1c0ace793f92464d8cd263cc3b26b5721950d977b006b6c4d", size = 252403, upload-time = "2026-01-26T02:45:51.779Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/76/b9669547afa5a1a25cd93eaca91c0da1c095b06b6d2d8ec25b713588d3a1/multidict-6.7.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9004d8386d133b7e6135679424c91b0b854d2d164af6ea3f289f8f2761064609", size = 244889, upload-time = "2026-01-26T02:45:53.27Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/a9/a50d2669e506dad33cfc45b5d574a205587b7b8a5f426f2fbb2e90882588/multidict-6.7.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e628ef0e6859ffd8273c69412a2465c4be4a9517d07261b33334b5ec6f3c7489", size = 241982, upload-time = "2026-01-26T02:45:54.919Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/bb/1609558ad8b456b4827d3c5a5b775c93b87878fd3117ed3db3423dfbce1b/multidict-6.7.1-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:841189848ba629c3552035a6a7f5bf3b02eb304e9fea7492ca220a8eda6b0e5c", size = 232415, upload-time = "2026-01-26T02:45:56.981Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/59/6f61039d2aa9261871e03ab9dc058a550d240f25859b05b67fd70f80d4b3/multidict-6.7.1-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:ce1bbd7d780bb5a0da032e095c951f7014d6b0a205f8318308140f1a6aba159e", size = 240337, upload-time = "2026-01-26T02:45:58.698Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/29/fdc6a43c203890dc2ae9249971ecd0c41deaedfe00d25cb6564b2edd99eb/multidict-6.7.1-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:b26684587228afed0d50cf804cc71062cc9c1cdf55051c4c6345d372947b268c", size = 248788, upload-time = "2026-01-26T02:46:00.862Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/14/a153a06101323e4cf086ecee3faadba52ff71633d471f9685c42e3736163/multidict-6.7.1-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:9f9af11306994335398293f9958071019e3ab95e9a707dc1383a35613f6abcb9", size = 242842, upload-time = "2026-01-26T02:46:02.824Z" },
+    { url = "https://files.pythonhosted.org/packages/41/5f/604ae839e64a4a6efc80db94465348d3b328ee955e37acb24badbcd24d83/multidict-6.7.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:b4938326284c4f1224178a560987b6cf8b4d38458b113d9b8c1db1a836e640a2", size = 240237, upload-time = "2026-01-26T02:46:05.898Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/60/c3a5187bf66f6fb546ff4ab8fb5a077cbdd832d7b1908d4365c7f74a1917/multidict-6.7.1-cp314-cp314t-win32.whl", hash = "sha256:98655c737850c064a65e006a3df7c997cd3b220be4ec8fe26215760b9697d4d7", size = 48008, upload-time = "2026-01-26T02:46:07.468Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/f7/addf1087b860ac60e6f382240f64fb99f8bfb532bb06f7c542b83c29ca61/multidict-6.7.1-cp314-cp314t-win_amd64.whl", hash = "sha256:497bde6223c212ba11d462853cfa4f0ae6ef97465033e7dc9940cdb3ab5b48e5", size = 53542, upload-time = "2026-01-26T02:46:08.809Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/81/4629d0aa32302ef7b2ec65c75a728cc5ff4fa410c50096174c1632e70b3e/multidict-6.7.1-cp314-cp314t-win_arm64.whl", hash = "sha256:2bbd113e0d4af5db41d5ebfe9ccaff89de2120578164f86a5d17d5a576d1e5b2", size = 44719, upload-time = "2026-01-26T02:46:11.146Z" },
+    { url = "https://files.pythonhosted.org/packages/81/08/7036c080d7117f28a4af526d794aab6a84463126db031b007717c1a6676e/multidict-6.7.1-py3-none-any.whl", hash = "sha256:55d97cc6dae627efa6a6e548885712d4864b81110ac76fa4e534c03819fa4a56", size = 12319, upload-time = "2026-01-26T02:46:44.004Z" },
+]
+
+[[package]]
+name = "oauthlib"
+version = "3.3.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0b/5f/19930f824ffeb0ad4372da4812c50edbd1434f678c90c2733e1188edfc63/oauthlib-3.3.1.tar.gz", hash = "sha256:0f0f8aa759826a193cf66c12ea1af1637f87b9b4622d46e866952bb022e538c9", size = 185918, upload-time = "2025-06-19T22:48:08.269Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/be/9c/92789c596b8df838baa98fa71844d84283302f7604ed565dafe5a6b5041a/oauthlib-3.3.1-py3-none-any.whl", hash = "sha256:88119c938d2b8fb88561af5f6ee0eec8cc8d552b7bb1f712743136eb7523b7a1", size = 160065, upload-time = "2025-06-19T22:48:06.508Z" },
+]
+
+[[package]]
+name = "ollama"
+version = "0.6.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "httpx" },
+    { name = "pydantic" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fc/72/5f12423b6b39ca8430fbe56f77fcf4ef60f63067c7c4a2e30e200ed9ec16/ollama-0.6.2.tar.gz", hash = "sha256:936d55daa684f474364c098611c933626f8d6c7d67065c5b7ae0c477b508b07f", size = 53145, upload-time = "2026-04-29T21:21:15.018Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c4/ab/d6722beeb2d10f7a3b9ff49375708904fde18f82b5609a0bc4aeb5996a4d/ollama-0.6.2-py3-none-any.whl", hash = "sha256:3ad7daab28e5a973445c36a73882a3ef698c2ebb00e21e308652741577509f7d", size = 15115, upload-time = "2026-04-29T21:21:13.794Z" },
+]
+
+[[package]]
 name = "openai"
 version = "2.37.0"
 source = { registry = "https://pypi.org/simple" }
@@ -771,26 +2266,210 @@ wheels = [
 ]
 
 [[package]]
+name = "openapi-pydantic"
+version = "0.5.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/02/2e/58d83848dd1a79cb92ed8e63f6ba901ca282c5f09d04af9423ec26c56fd7/openapi_pydantic-0.5.1.tar.gz", hash = "sha256:ff6835af6bde7a459fb93eb93bb92b8749b754fc6e51b2f1590a19dc3005ee0d", size = 60892, upload-time = "2025-01-08T19:29:27.083Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/12/cf/03675d8bd8ecbf4445504d8071adab19f5f993676795708e36402ab38263/openapi_pydantic-0.5.1-py3-none-any.whl", hash = "sha256:a3a09ef4586f5bd760a8df7f43028b60cafb6d9f61de2acba9574766255ab146", size = 96381, upload-time = "2025-01-08T19:29:25.275Z" },
+]
+
+[[package]]
+name = "openhands-sdk"
+version = "1.28.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "agent-client-protocol" },
+    { name = "deprecation" },
+    { name = "fakeredis", extra = ["lua"] },
+    { name = "fastmcp" },
+    { name = "filelock" },
+    { name = "httpx", extra = ["socks"] },
+    { name = "joserfc" },
+    { name = "litellm" },
+    { name = "lmnr" },
+    { name = "pillow" },
+    { name = "pydantic" },
+    { name = "python-frontmatter" },
+    { name = "python-json-logger" },
+    { name = "tenacity" },
+    { name = "tree-sitter" },
+    { name = "tree-sitter-bash" },
+    { name = "websockets" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7a/12/962f84a1576d5a68d4c5bdf13c573de18ecc36ec88e20dc69fef5730da95/openhands_sdk-1.28.1.tar.gz", hash = "sha256:249148599c124fa1b3221b2b47207cb6982203d0bb4f5f4fec8f55f026e7e4ce", size = 536814, upload-time = "2026-06-11T18:35:14.371Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8a/73/d3c0e0598fa5f52e984c81a852405d5bacd2e8f588e66715f705311b37c4/openhands_sdk-1.28.1-py3-none-any.whl", hash = "sha256:fce1ff4fed0a661e66d2621a489c092c67458d203ccc5a91636653c61af7f209", size = 649537, upload-time = "2026-06-11T18:35:16.67Z" },
+]
+
+[[package]]
+name = "openhands-tools"
+version = "1.28.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "binaryornot" },
+    { name = "browser-use" },
+    { name = "cachetools" },
+    { name = "func-timeout" },
+    { name = "libtmux" },
+    { name = "openhands-sdk" },
+    { name = "pydantic" },
+    { name = "tom-swe" },
+    { name = "tree-sitter" },
+    { name = "tree-sitter-bash" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b5/25/0507f0d99d87d3605395772c0e0c2d73adeeb5c0a3c9319559257582adef/openhands_tools-1.28.1.tar.gz", hash = "sha256:47667fec9b981da57a64cb1ce3d93b1e3405d2a5f408c3741668240901a72507", size = 142489, upload-time = "2026-06-11T18:35:15.544Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/66/aa/ed7c2b9874504d638260d36e63cdd6a1da5148b3459c6326fd651b9bab63/openhands_tools-1.28.1-py3-none-any.whl", hash = "sha256:9ebee79b05e20321f3f7518bf5eb74aa85cf39f0b43a63c5895c57d0a1da2dc0", size = 187637, upload-time = "2026-06-11T18:35:19.912Z" },
+]
+
+[[package]]
+name = "opentelemetry-api"
+version = "1.39.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "importlib-metadata" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/97/b9/3161be15bb8e3ad01be8be5a968a9237c3027c5be504362ff800fca3e442/opentelemetry_api-1.39.1.tar.gz", hash = "sha256:fbde8c80e1b937a2c61f20347e91c0c18a1940cecf012d62e65a7caf08967c9c", size = 65767, upload-time = "2025-12-11T13:32:39.182Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cf/df/d3f1ddf4bb4cb50ed9b1139cc7b1c54c34a1e7ce8fd1b9a37c0d1551a6bd/opentelemetry_api-1.39.1-py3-none-any.whl", hash = "sha256:2edd8463432a7f8443edce90972169b195e7d6a05500cd29e6d13898187c9950", size = 66356, upload-time = "2025-12-11T13:32:17.304Z" },
+]
+
+[[package]]
+name = "opentelemetry-exporter-otlp-proto-common"
+version = "1.39.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-proto" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e9/9d/22d241b66f7bbde88a3bfa6847a351d2c46b84de23e71222c6aae25c7050/opentelemetry_exporter_otlp_proto_common-1.39.1.tar.gz", hash = "sha256:763370d4737a59741c89a67b50f9e39271639ee4afc999dadfe768541c027464", size = 20409, upload-time = "2025-12-11T13:32:40.885Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8c/02/ffc3e143d89a27ac21fd557365b98bd0653b98de8a101151d5805b5d4c33/opentelemetry_exporter_otlp_proto_common-1.39.1-py3-none-any.whl", hash = "sha256:08f8a5862d64cc3435105686d0216c1365dc5701f86844a8cd56597d0c764fde", size = 18366, upload-time = "2025-12-11T13:32:20.2Z" },
+]
+
+[[package]]
+name = "opentelemetry-exporter-otlp-proto-grpc"
+version = "1.39.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "googleapis-common-protos" },
+    { name = "grpcio" },
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-exporter-otlp-proto-common" },
+    { name = "opentelemetry-proto" },
+    { name = "opentelemetry-sdk" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/53/48/b329fed2c610c2c32c9366d9dc597202c9d1e58e631c137ba15248d8850f/opentelemetry_exporter_otlp_proto_grpc-1.39.1.tar.gz", hash = "sha256:772eb1c9287485d625e4dbe9c879898e5253fea111d9181140f51291b5fec3ad", size = 24650, upload-time = "2025-12-11T13:32:41.429Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/81/a3/cc9b66575bd6597b98b886a2067eea2693408d2d5f39dad9ab7fc264f5f3/opentelemetry_exporter_otlp_proto_grpc-1.39.1-py3-none-any.whl", hash = "sha256:fa1c136a05c7e9b4c09f739469cbdb927ea20b34088ab1d959a849b5cc589c18", size = 19766, upload-time = "2025-12-11T13:32:21.027Z" },
+]
+
+[[package]]
+name = "opentelemetry-exporter-otlp-proto-http"
+version = "1.39.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "googleapis-common-protos" },
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-exporter-otlp-proto-common" },
+    { name = "opentelemetry-proto" },
+    { name = "opentelemetry-sdk" },
+    { name = "requests" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/80/04/2a08fa9c0214ae38880df01e8bfae12b067ec0793446578575e5080d6545/opentelemetry_exporter_otlp_proto_http-1.39.1.tar.gz", hash = "sha256:31bdab9745c709ce90a49a0624c2bd445d31a28ba34275951a6a362d16a0b9cb", size = 17288, upload-time = "2025-12-11T13:32:42.029Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/95/f1/b27d3e2e003cd9a3592c43d099d2ed8d0a947c15281bf8463a256db0b46c/opentelemetry_exporter_otlp_proto_http-1.39.1-py3-none-any.whl", hash = "sha256:d9f5207183dd752a412c4cd564ca8875ececba13be6e9c6c370ffb752fd59985", size = 19641, upload-time = "2025-12-11T13:32:22.248Z" },
+]
+
+[[package]]
+name = "opentelemetry-instrumentation"
+version = "0.60b1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-semantic-conventions" },
+    { name = "packaging" },
+    { name = "wrapt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/41/0f/7e6b713ac117c1f5e4e3300748af699b9902a2e5e34c9cf443dde25a01fa/opentelemetry_instrumentation-0.60b1.tar.gz", hash = "sha256:57ddc7974c6eb35865af0426d1a17132b88b2ed8586897fee187fd5b8944bd6a", size = 31706, upload-time = "2025-12-11T13:36:42.515Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/77/d2/6788e83c5c86a2690101681aeef27eeb2a6bf22df52d3f263a22cee20915/opentelemetry_instrumentation-0.60b1-py3-none-any.whl", hash = "sha256:04480db952b48fb1ed0073f822f0ee26012b7be7c3eac1a3793122737c78632d", size = 33096, upload-time = "2025-12-11T13:35:33.067Z" },
+]
+
+[[package]]
+name = "opentelemetry-instrumentation-threading"
+version = "0.60b1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-instrumentation" },
+    { name = "wrapt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9b/0a/e36123ec4c0910a3936b92982545a53e9bca5b26a28df06883751a783f84/opentelemetry_instrumentation_threading-0.60b1.tar.gz", hash = "sha256:20b18a68abe5801fa9474336b7c27487d4af3e00b66f6a8734e4fdd75c8b0b43", size = 8768, upload-time = "2025-12-11T13:37:16.29Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c7/a3/448738b927bcc1843ace7d4ed55dd54441a71363075eeeee89c5944dd740/opentelemetry_instrumentation_threading-0.60b1-py3-none-any.whl", hash = "sha256:92a52a60fee5e32bc6aa8f5acd749b15691ad0bc4457a310f5736b76a6d9d1de", size = 9312, upload-time = "2025-12-11T13:36:28.434Z" },
+]
+
+[[package]]
+name = "opentelemetry-proto"
+version = "1.39.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "protobuf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/49/1d/f25d76d8260c156c40c97c9ed4511ec0f9ce353f8108ca6e7561f82a06b2/opentelemetry_proto-1.39.1.tar.gz", hash = "sha256:6c8e05144fc0d3ed4d22c2289c6b126e03bcd0e6a7da0f16cedd2e1c2772e2c8", size = 46152, upload-time = "2025-12-11T13:32:48.681Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/51/95/b40c96a7b5203005a0b03d8ce8cd212ff23f1793d5ba289c87a097571b18/opentelemetry_proto-1.39.1-py3-none-any.whl", hash = "sha256:22cdc78efd3b3765d09e68bfbd010d4fc254c9818afd0b6b423387d9dee46007", size = 72535, upload-time = "2025-12-11T13:32:33.866Z" },
+]
+
+[[package]]
+name = "opentelemetry-sdk"
+version = "1.39.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-semantic-conventions" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/eb/fb/c76080c9ba07e1e8235d24cdcc4d125ef7aa3edf23eb4e497c2e50889adc/opentelemetry_sdk-1.39.1.tar.gz", hash = "sha256:cf4d4563caf7bff906c9f7967e2be22d0d6b349b908be0d90fb21c8e9c995cc6", size = 171460, upload-time = "2025-12-11T13:32:49.369Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7c/98/e91cf858f203d86f4eccdf763dcf01cf03f1dae80c3750f7e635bfa206b6/opentelemetry_sdk-1.39.1-py3-none-any.whl", hash = "sha256:4d5482c478513ecb0a5d938dcc61394e647066e0cc2676bee9f3af3f3f45f01c", size = 132565, upload-time = "2025-12-11T13:32:35.069Z" },
+]
+
+[[package]]
+name = "opentelemetry-semantic-conventions"
+version = "0.60b1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/91/df/553f93ed38bf22f4b999d9be9c185adb558982214f33eae539d3b5cd0858/opentelemetry_semantic_conventions-0.60b1.tar.gz", hash = "sha256:87c228b5a0669b748c76d76df6c364c369c28f1c465e50f661e39737e84bc953", size = 137935, upload-time = "2025-12-11T13:32:50.487Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7a/5e/5958555e09635d09b75de3c4f8b9cae7335ca545d77392ffe7331534c402/opentelemetry_semantic_conventions-0.60b1-py3-none-any.whl", hash = "sha256:9fa8c8b0c110da289809292b0591220d3a7b53c1526a23021e977d68597893fb", size = 219982, upload-time = "2025-12-11T13:32:36.955Z" },
+]
+
+[[package]]
+name = "opentelemetry-semantic-conventions-ai"
+version = "0.4.13"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ba/e6/40b59eda51ac47009fb47afcdf37c6938594a0bd7f3b9fadcbc6058248e3/opentelemetry_semantic_conventions_ai-0.4.13.tar.gz", hash = "sha256:94efa9fb4ffac18c45f54a3a338ffeb7eedb7e1bb4d147786e77202e159f0036", size = 5368, upload-time = "2025-08-22T10:14:17.387Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/35/b5/cf25da2218910f0d6cdf7f876a06bed118c4969eacaf60a887cbaef44f44/opentelemetry_semantic_conventions_ai-0.4.13-py3-none-any.whl", hash = "sha256:883a30a6bb5deaec0d646912b5f9f6dcbb9f6f72557b73d0f2560bf25d13e2d5", size = 6080, upload-time = "2025-08-22T10:14:16.477Z" },
+]
+
+[[package]]
 name = "orjson"
 version = "3.11.9"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/7e/0c/964746fcafbd16f8ff53219ad9f6b412b34f345c75f384ad434ceaadb538/orjson-3.11.9.tar.gz", hash = "sha256:4fef17e1f8722c11587a6ef18e35902450221da0028e65dbaaa543619e68e48f", size = 5599163, upload-time = "2026-05-06T15:11:08.309Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1e/51/3fb9e65ae76ee97bd611869a503fa3fc0a6e81dd8b737cf3003f682df7ff/orjson-3.11.9-cp311-cp311-macosx_10_15_x86_64.macosx_11_0_arm64.macosx_10_15_universal2.whl", hash = "sha256:f01c4818b3fc9b0da8e096722a84318071eaa118df35f6ed2344da0e73a5444f", size = 228522, upload-time = "2026-05-06T15:09:35.362Z" },
-    { url = "https://files.pythonhosted.org/packages/16/fa/9d54b07cb3f3b0bfd57841478e42d7a0ece4a9f49f9907eecf5a45461687/orjson-3.11.9-cp311-cp311-macosx_15_0_arm64.whl", hash = "sha256:3ebca4179031ee716ed076ffadc29428e900512f6fccee8614c9983157fcf19c", size = 128463, upload-time = "2026-05-06T15:09:37.063Z" },
-    { url = "https://files.pythonhosted.org/packages/88/b1/6ceafc2eefd0a553e3be77ce6c49d107e772485d9568629376171c50e634/orjson-3.11.9-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:48ee05097750de0ff69ed5b7bbcf0732182fd57a24043dcc2a1da780a5ead3a5", size = 132306, upload-time = "2026-05-06T15:09:38.299Z" },
-    { url = "https://files.pythonhosted.org/packages/ea/76/f11311285324a40aab1e3031385c50b635a7cd0734fdaf60c7e89a696f60/orjson-3.11.9-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:a6082706765a95a6680d812e1daf1c0cfe8adec7831b3ff3b625693f3b461b1c", size = 127988, upload-time = "2026-05-06T15:09:39.597Z" },
-    { url = "https://files.pythonhosted.org/packages/9e/85/0ef63bcf1337f44031ce9b91b1919563f62a37527b3ea4368bb15a22e5d7/orjson-3.11.9-cp311-cp311-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:277fefe9d76ee17eb14debf399e3533d4d63b5f677a4d3719eb763536af1f4bd", size = 135188, upload-time = "2026-05-06T15:09:40.957Z" },
-    { url = "https://files.pythonhosted.org/packages/05/94/b0d27090ea8a2095db3c2bd1b1c96f96f19bbb494d7fef33130e846e613d/orjson-3.11.9-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:03db380e3780fa0015ed776a90f20e8e20bb11dde13b216ce19e5718e3dfba62", size = 145937, upload-time = "2026-05-06T15:09:42.249Z" },
-    { url = "https://files.pythonhosted.org/packages/09/eb/75d50c29c05b8054013e221e598820a365c8e64065312e75e202ed880709/orjson-3.11.9-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:33d7d766701847dc6729846362dc27895d2f2d2251264f9d10e7cb9878194877", size = 132758, upload-time = "2026-05-06T15:09:43.945Z" },
-    { url = "https://files.pythonhosted.org/packages/49/bd/360686f39348aa88827cb6fbf7dc606fd41c831a35235e1abf1db8e3a9e6/orjson-3.11.9-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:147302878da387104b66bb4a8b0227d1d487e976ce41a8501916161072ed87b1", size = 133971, upload-time = "2026-05-06T15:09:45.239Z" },
-    { url = "https://files.pythonhosted.org/packages/0e/30/3178eb16f3221aeef068b6f1f1ebe05f656ea5c6dffe9f6c917329fe17a3/orjson-3.11.9-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:3513550321f8c8c811a7c3297b8a630e82dc08e4c10216d07703c997776236cd", size = 141685, upload-time = "2026-05-06T15:09:46.858Z" },
-    { url = "https://files.pythonhosted.org/packages/5f/f1/ff2f19ed0225f9680fafa42febca3570dd59444ebf190980738d376214c2/orjson-3.11.9-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:c5d001196b89fa9cf0a4ab79766cd835b991a166e4b621ba95089edc50c429ff", size = 415167, upload-time = "2026-05-06T15:09:48.312Z" },
-    { url = "https://files.pythonhosted.org/packages/9b/61/863bddf0da6e9e586765414debd54b4e58db05f560902b6d00658cb88636/orjson-3.11.9-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:16969c9d369c98eb084889c6e4d2d39b77c7eb38ceccf8da2a9fff62ae908980", size = 147913, upload-time = "2026-05-06T15:09:49.733Z" },
-    { url = "https://files.pythonhosted.org/packages/b6/8a/4081492586d75b073d60c5271a8d0f05a0955cabf1e34c8473f6fcd84235/orjson-3.11.9-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:63e0efbc991250c0b3143488fa57d95affcabbfc63c99c48d625dd37779aafe2", size = 136959, upload-time = "2026-05-06T15:09:51.311Z" },
-    { url = "https://files.pythonhosted.org/packages/0d/bd/70b6ab193594d7abb875320c0a7c8335e846f28968c432c31042409c3c8d/orjson-3.11.9-cp311-cp311-win32.whl", hash = "sha256:14ed654580c1ed2bc217352ec82f91b047aef82951aa71c7f64e0dcb03c0e180", size = 131533, upload-time = "2026-05-06T15:09:52.637Z" },
-    { url = "https://files.pythonhosted.org/packages/3f/17/1a1a228183d62d1b77e2c30d210f47dd4768b310ebe1607c63e3c0e3a71e/orjson-3.11.9-cp311-cp311-win_amd64.whl", hash = "sha256:57ea77fb70a448ce87d18fca050193202a3da5e54598f6501ca5476fb66cfe02", size = 127106, upload-time = "2026-05-06T15:09:54.204Z" },
-    { url = "https://files.pythonhosted.org/packages/b8/95/285de5fa296d09681ee9c546cd4a8aeb773b701cf343dc125994f4d52953/orjson-3.11.9-cp311-cp311-win_arm64.whl", hash = "sha256:19b72ed11572a2ee51a67a903afbe5af504f84ed6f529c0fe44b0ab3fb5cc697", size = 126848, upload-time = "2026-05-06T15:09:55.551Z" },
     { url = "https://files.pythonhosted.org/packages/16/6d/11867a3ffa3a3608d84a4de51ef4dd0896d6b5cc9132fbe1daf593e677bc/orjson-3.11.9-cp312-cp312-macosx_10_15_x86_64.macosx_11_0_arm64.macosx_10_15_universal2.whl", hash = "sha256:9ef6fe90aadef185c7b128859f40beb24720b4ecea95379fc9000931179c3a49", size = 228515, upload-time = "2026-05-06T15:09:57.265Z" },
     { url = "https://files.pythonhosted.org/packages/24/75/05912954c8b288f34fcf5cd4b9b071cb4f6e77b9961e175e56ebb258089f/orjson-3.11.9-cp312-cp312-macosx_15_0_arm64.whl", hash = "sha256:e5c9b8f28e726e97d97696c826bc7bea5d71cecd63576dba92924a32c1961291", size = 128409, upload-time = "2026-05-06T15:09:59.063Z" },
     { url = "https://files.pythonhosted.org/packages/ab/86/1c3a47df3bc8191ea9ac51603bbb872a95167a364320c269f2557911f406/orjson-3.11.9-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:26a473dbb4162108b27901492546f83c76fdcea3d0eadff00ae7a07e18dcce09", size = 132106, upload-time = "2026-05-06T15:10:00.798Z" },
@@ -844,15 +2523,6 @@ version = "1.12.2"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/12/0c/f1761e21486942ab9bb6feaebc610fa074f7c5e496e6962dea5873348077/ormsgpack-1.12.2.tar.gz", hash = "sha256:944a2233640273bee67521795a73cf1e959538e0dfb7ac635505010455e53b33", size = 39031, upload-time = "2026-01-18T20:55:28.023Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/4b/08/8b68f24b18e69d92238aa8f258218e6dfeacf4381d9d07ab8df303f524a9/ormsgpack-1.12.2-cp311-cp311-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:bd5f4bf04c37888e864f08e740c5a573c4017f6fd6e99fa944c5c935fabf2dd9", size = 378266, upload-time = "2026-01-18T20:55:59.876Z" },
-    { url = "https://files.pythonhosted.org/packages/0d/24/29fc13044ecb7c153523ae0a1972269fcd613650d1fa1a9cec1044c6b666/ormsgpack-1.12.2-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:34d5b28b3570e9fed9a5a76528fc7230c3c76333bc214798958e58e9b79cc18a", size = 203035, upload-time = "2026-01-18T20:55:30.59Z" },
-    { url = "https://files.pythonhosted.org/packages/ad/c2/00169fb25dd8f9213f5e8a549dfb73e4d592009ebc85fbbcd3e1dcac575b/ormsgpack-1.12.2-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:3708693412c28f3538fb5a65da93787b6bbab3484f6bc6e935bfb77a62400ae5", size = 210539, upload-time = "2026-01-18T20:55:48.569Z" },
-    { url = "https://files.pythonhosted.org/packages/1b/33/543627f323ff3c73091f51d6a20db28a1a33531af30873ea90c5ac95a9b5/ormsgpack-1.12.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:43013a3f3e2e902e1d05e72c0f1aeb5bedbb8e09240b51e26792a3c89267e181", size = 212401, upload-time = "2026-01-18T20:56:10.101Z" },
-    { url = "https://files.pythonhosted.org/packages/e8/5d/f70e2c3da414f46186659d24745483757bcc9adccb481a6eb93e2b729301/ormsgpack-1.12.2-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:7c8b1667a72cbba74f0ae7ecf3105a5e01304620ed14528b2cb4320679d2869b", size = 387082, upload-time = "2026-01-18T20:56:12.047Z" },
-    { url = "https://files.pythonhosted.org/packages/c0/d6/06e8dc920c7903e051f30934d874d4afccc9bb1c09dcaf0bc03a7de4b343/ormsgpack-1.12.2-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:df6961442140193e517303d0b5d7bc2e20e69a879c2d774316125350c4a76b92", size = 482346, upload-time = "2026-01-18T20:56:05.152Z" },
-    { url = "https://files.pythonhosted.org/packages/66/c4/f337ac0905eed9c393ef990c54565cd33644918e0a8031fe48c098c71dbf/ormsgpack-1.12.2-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:c6a4c34ddef109647c769d69be65fa1de7a6022b02ad45546a69b3216573eb4a", size = 425181, upload-time = "2026-01-18T20:55:37.83Z" },
-    { url = "https://files.pythonhosted.org/packages/78/29/6d5758fabef3babdf4bbbc453738cc7de9cd3334e4c38dd5737e27b85653/ormsgpack-1.12.2-cp311-cp311-win_amd64.whl", hash = "sha256:73670ed0375ecc303858e3613f407628dd1fca18fe6ac57b7b7ce66cc7bb006c", size = 117182, upload-time = "2026-01-18T20:55:31.472Z" },
-    { url = "https://files.pythonhosted.org/packages/c4/57/17a15549233c37e7fd054c48fe9207492e06b026dbd872b826a0b5f833b6/ormsgpack-1.12.2-cp311-cp311-win_arm64.whl", hash = "sha256:c2be829954434e33601ae5da328cccce3266b098927ca7a30246a0baec2ce7bd", size = 111464, upload-time = "2026-01-18T20:55:38.811Z" },
     { url = "https://files.pythonhosted.org/packages/4c/36/16c4b1921c308a92cef3bf6663226ae283395aa0ff6e154f925c32e91ff5/ormsgpack-1.12.2-cp312-cp312-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:7a29d09b64b9694b588ff2f80e9826bdceb3a2b91523c5beae1fab27d5c940e7", size = 378618, upload-time = "2026-01-18T20:55:50.835Z" },
     { url = "https://files.pythonhosted.org/packages/c0/68/468de634079615abf66ed13bb5c34ff71da237213f29294363beeeca5306/ormsgpack-1.12.2-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0b39e629fd2e1c5b2f46f99778450b59454d1f901bc507963168985e79f09c5d", size = 203186, upload-time = "2026-01-18T20:56:11.163Z" },
     { url = "https://files.pythonhosted.org/packages/73/a9/d756e01961442688b7939bacd87ce13bfad7d26ce24f910f6028178b2cc8/ormsgpack-1.12.2-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:958dcb270d30a7cb633a45ee62b9444433fa571a752d2ca484efdac07480876e", size = 210738, upload-time = "2026-01-18T20:56:09.181Z" },
@@ -896,12 +2566,342 @@ wheels = [
 ]
 
 [[package]]
+name = "pathable"
+version = "0.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/66/f3/5a20387de9bcd0607871bfc2198ee0e15836da7baa4592ccd7f24c27c986/pathable-0.6.0.tar.gz", hash = "sha256:6404b8b82aef5ff0fd478934137128b99b12212ba35afdde5525ca4f8388ea58", size = 18970, upload-time = "2026-05-19T18:15:11.911Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a2/e8/6d75ffd9784bce2e93d1ae4415649427e39a53bb172d4672b2b59c6f0a7b/pathable-0.6.0-py3-none-any.whl", hash = "sha256:82c4ca6c98c502ad12e0d4e9779b6210afee93c38990988c8c5d1b49bdcdf566", size = 18983, upload-time = "2026-05-19T18:15:10.728Z" },
+]
+
+[[package]]
+name = "pfzy"
+version = "0.3.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d9/5a/32b50c077c86bfccc7bed4881c5a2b823518f5450a30e639db5d3711952e/pfzy-0.3.4.tar.gz", hash = "sha256:717ea765dd10b63618e7298b2d98efd819e0b30cd5905c9707223dceeb94b3f1", size = 8396, upload-time = "2022-01-28T02:26:17.946Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8c/d7/8ff98376b1acc4503253b685ea09981697385ce344d4e3935c2af49e044d/pfzy-0.3.4-py3-none-any.whl", hash = "sha256:5f50d5b2b3207fa72e7ec0ef08372ef652685470974a107d0d4999fc5a903a96", size = 8537, upload-time = "2022-01-28T02:26:16.047Z" },
+]
+
+[[package]]
+name = "pillow"
+version = "12.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8c/21/c2bcdd5906101a30244eaffc1b6e6ce71a31bd0742a01eb89e660ebfac2d/pillow-12.2.0.tar.gz", hash = "sha256:a830b1a40919539d07806aa58e1b114df53ddd43213d9c8b75847eee6c0182b5", size = 46987819, upload-time = "2026-04-01T14:46:17.687Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/58/be/7482c8a5ebebbc6470b3eb791812fff7d5e0216c2be3827b30b8bb6603ed/pillow-12.2.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:2d192a155bbcec180f8564f693e6fd9bccff5a7af9b32e2e4bf8c9c69dbad6b5", size = 5308279, upload-time = "2026-04-01T14:43:13.246Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/95/0a351b9289c2b5cbde0bacd4a83ebc44023e835490a727b2a3bd60ddc0f4/pillow-12.2.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:f3f40b3c5a968281fd507d519e444c35f0ff171237f4fdde090dd60699458421", size = 4695490, upload-time = "2026-04-01T14:43:15.584Z" },
+    { url = "https://files.pythonhosted.org/packages/de/af/4e8e6869cbed569d43c416fad3dc4ecb944cb5d9492defaed89ddd6fe871/pillow-12.2.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:03e7e372d5240cc23e9f07deca4d775c0817bffc641b01e9c3af208dbd300987", size = 6284462, upload-time = "2026-04-01T14:43:18.268Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/9e/c05e19657fd57841e476be1ab46c4d501bffbadbafdc31a6d665f8b737b6/pillow-12.2.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:b86024e52a1b269467a802258c25521e6d742349d760728092e1bc2d135b4d76", size = 8094744, upload-time = "2026-04-01T14:43:20.716Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/54/1789c455ed10176066b6e7e6da1b01e50e36f94ba584dc68d9eebfe9156d/pillow-12.2.0-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7371b48c4fa448d20d2714c9a1f775a81155050d383333e0a6c15b1123dda005", size = 6398371, upload-time = "2026-04-01T14:43:23.443Z" },
+    { url = "https://files.pythonhosted.org/packages/43/e3/fdc657359e919462369869f1c9f0e973f353f9a9ee295a39b1fea8ee1a77/pillow-12.2.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:62f5409336adb0663b7caa0da5c7d9e7bdbaae9ce761d34669420c2a801b2780", size = 7087215, upload-time = "2026-04-01T14:43:26.758Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/f8/2f6825e441d5b1959d2ca5adec984210f1ec086435b0ed5f52c19b3b8a6e/pillow-12.2.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:01afa7cf67f74f09523699b4e88c73fb55c13346d212a59a2db1f86b0a63e8c5", size = 6509783, upload-time = "2026-04-01T14:43:29.56Z" },
+    { url = "https://files.pythonhosted.org/packages/67/f9/029a27095ad20f854f9dba026b3ea6428548316e057e6fc3545409e86651/pillow-12.2.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:fc3d34d4a8fbec3e88a79b92e5465e0f9b842b628675850d860b8bd300b159f5", size = 7212112, upload-time = "2026-04-01T14:43:32.091Z" },
+    { url = "https://files.pythonhosted.org/packages/be/42/025cfe05d1be22dbfdb4f264fe9de1ccda83f66e4fc3aac94748e784af04/pillow-12.2.0-cp312-cp312-win32.whl", hash = "sha256:58f62cc0f00fd29e64b29f4fd923ffdb3859c9f9e6105bfc37ba1d08994e8940", size = 6378489, upload-time = "2026-04-01T14:43:34.601Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/7b/25a221d2c761c6a8ae21bfa3874988ff2583e19cf8a27bf2fee358df7942/pillow-12.2.0-cp312-cp312-win_amd64.whl", hash = "sha256:7f84204dee22a783350679a0333981df803dac21a0190d706a50475e361c93f5", size = 7084129, upload-time = "2026-04-01T14:43:37.213Z" },
+    { url = "https://files.pythonhosted.org/packages/10/e1/542a474affab20fd4a0f1836cb234e8493519da6b76899e30bcc5d990b8b/pillow-12.2.0-cp312-cp312-win_arm64.whl", hash = "sha256:af73337013e0b3b46f175e79492d96845b16126ddf79c438d7ea7ff27783a414", size = 2463612, upload-time = "2026-04-01T14:43:39.421Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/01/53d10cf0dbad820a8db274d259a37ba50b88b24768ddccec07355382d5ad/pillow-12.2.0-cp313-cp313-ios_13_0_arm64_iphoneos.whl", hash = "sha256:8297651f5b5679c19968abefd6bb84d95fe30ef712eb1b2d9b2d31ca61267f4c", size = 4100837, upload-time = "2026-04-01T14:43:41.506Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/98/f3a6657ecb698c937f6c76ee564882945f29b79bad496abcba0e84659ec5/pillow-12.2.0-cp313-cp313-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:50d8520da2a6ce0af445fa6d648c4273c3eeefbc32d7ce049f22e8b5c3daecc2", size = 4176528, upload-time = "2026-04-01T14:43:43.773Z" },
+    { url = "https://files.pythonhosted.org/packages/69/bc/8986948f05e3ea490b8442ea1c1d4d990b24a7e43d8a51b2c7d8b1dced36/pillow-12.2.0-cp313-cp313-ios_13_0_x86_64_iphonesimulator.whl", hash = "sha256:766cef22385fa1091258ad7e6216792b156dc16d8d3fa607e7545b2b72061f1c", size = 3640401, upload-time = "2026-04-01T14:43:45.87Z" },
+    { url = "https://files.pythonhosted.org/packages/34/46/6c717baadcd62bc8ed51d238d521ab651eaa74838291bda1f86fe1f864c9/pillow-12.2.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:5d2fd0fa6b5d9d1de415060363433f28da8b1526c1c129020435e186794b3795", size = 5308094, upload-time = "2026-04-01T14:43:48.438Z" },
+    { url = "https://files.pythonhosted.org/packages/71/43/905a14a8b17fdb1ccb58d282454490662d2cb89a6bfec26af6d3520da5ec/pillow-12.2.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:56b25336f502b6ed02e889f4ece894a72612fe885889a6e8c4c80239ff6e5f5f", size = 4695402, upload-time = "2026-04-01T14:43:51.292Z" },
+    { url = "https://files.pythonhosted.org/packages/73/dd/42107efcb777b16fa0393317eac58f5b5cf30e8392e266e76e51cff28c3d/pillow-12.2.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f1c943e96e85df3d3478f7b691f229887e143f81fedab9b20205349ab04d73ed", size = 6280005, upload-time = "2026-04-01T14:43:54.242Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/68/b93e09e5e8549019e61acf49f65b1a8530765a7f812c77a7461bca7e4494/pillow-12.2.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:03f6fab9219220f041c74aeaa2939ff0062bd5c364ba9ce037197f4c6d498cd9", size = 8090669, upload-time = "2026-04-01T14:43:57.335Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/6e/3ccb54ce8ec4ddd1accd2d89004308b7b0b21c4ac3d20fa70af4760a4330/pillow-12.2.0-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5cdfebd752ec52bf5bb4e35d9c64b40826bc5b40a13df7c3cda20a2c03a0f5ed", size = 6395194, upload-time = "2026-04-01T14:43:59.864Z" },
+    { url = "https://files.pythonhosted.org/packages/67/ee/21d4e8536afd1a328f01b359b4d3997b291ffd35a237c877b331c1c3b71c/pillow-12.2.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:eedf4b74eda2b5a4b2b2fb4c006d6295df3bf29e459e198c90ea48e130dc75c3", size = 7082423, upload-time = "2026-04-01T14:44:02.74Z" },
+    { url = "https://files.pythonhosted.org/packages/78/5f/e9f86ab0146464e8c133fe85df987ed9e77e08b29d8d35f9f9f4d6f917ba/pillow-12.2.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:00a2865911330191c0b818c59103b58a5e697cae67042366970a6b6f1b20b7f9", size = 6505667, upload-time = "2026-04-01T14:44:05.381Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/1e/409007f56a2fdce61584fd3acbc2bbc259857d555196cedcadc68c015c82/pillow-12.2.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:1e1757442ed87f4912397c6d35a0db6a7b52592156014706f17658ff58bbf795", size = 7208580, upload-time = "2026-04-01T14:44:08.39Z" },
+    { url = "https://files.pythonhosted.org/packages/23/c4/7349421080b12fb35414607b8871e9534546c128a11965fd4a7002ccfbee/pillow-12.2.0-cp313-cp313-win32.whl", hash = "sha256:144748b3af2d1b358d41286056d0003f47cb339b8c43a9ea42f5fea4d8c66b6e", size = 6375896, upload-time = "2026-04-01T14:44:11.197Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/82/8a3739a5e470b3c6cbb1d21d315800d8e16bff503d1f16b03a4ec3212786/pillow-12.2.0-cp313-cp313-win_amd64.whl", hash = "sha256:390ede346628ccc626e5730107cde16c42d3836b89662a115a921f28440e6a3b", size = 7081266, upload-time = "2026-04-01T14:44:13.947Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/25/f968f618a062574294592f668218f8af564830ccebdd1fa6200f598e65c5/pillow-12.2.0-cp313-cp313-win_arm64.whl", hash = "sha256:8023abc91fba39036dbce14a7d6535632f99c0b857807cbbbf21ecc9f4717f06", size = 2463508, upload-time = "2026-04-01T14:44:16.312Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/a4/b342930964e3cb4dce5038ae34b0eab4653334995336cd486c5a8c25a00c/pillow-12.2.0-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:042db20a421b9bafecc4b84a8b6e444686bd9d836c7fd24542db3e7df7baad9b", size = 5309927, upload-time = "2026-04-01T14:44:18.89Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/de/23198e0a65a9cf06123f5435a5d95cea62a635697f8f03d134d3f3a96151/pillow-12.2.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:dd025009355c926a84a612fecf58bb315a3f6814b17ead51a8e48d3823d9087f", size = 4698624, upload-time = "2026-04-01T14:44:21.115Z" },
+    { url = "https://files.pythonhosted.org/packages/01/a6/1265e977f17d93ea37aa28aa81bad4fa597933879fac2520d24e021c8da3/pillow-12.2.0-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:88ddbc66737e277852913bd1e07c150cc7bb124539f94c4e2df5344494e0a612", size = 6321252, upload-time = "2026-04-01T14:44:23.663Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/83/5982eb4a285967baa70340320be9f88e57665a387e3a53a7f0db8231a0cd/pillow-12.2.0-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:d362d1878f00c142b7e1a16e6e5e780f02be8195123f164edf7eddd911eefe7c", size = 8126550, upload-time = "2026-04-01T14:44:26.772Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/48/6ffc514adce69f6050d0753b1a18fd920fce8cac87620d5a31231b04bfc5/pillow-12.2.0-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2c727a6d53cb0018aadd8018c2b938376af27914a68a492f59dfcaca650d5eea", size = 6433114, upload-time = "2026-04-01T14:44:29.615Z" },
+    { url = "https://files.pythonhosted.org/packages/36/a3/f9a77144231fb8d40ee27107b4463e205fa4677e2ca2548e14da5cf18dce/pillow-12.2.0-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:efd8c21c98c5cc60653bcb311bef2ce0401642b7ce9d09e03a7da87c878289d4", size = 7115667, upload-time = "2026-04-01T14:44:32.773Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/fc/ac4ee3041e7d5a565e1c4fd72a113f03b6394cc72ab7089d27608f8aaccb/pillow-12.2.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:9f08483a632889536b8139663db60f6724bfcb443c96f1b18855860d7d5c0fd4", size = 6538966, upload-time = "2026-04-01T14:44:35.252Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/a8/27fb307055087f3668f6d0a8ccb636e7431d56ed0750e07a60547b1e083e/pillow-12.2.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:dac8d77255a37e81a2efcbd1fc05f1c15ee82200e6c240d7e127e25e365c39ea", size = 7238241, upload-time = "2026-04-01T14:44:37.875Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/4b/926ab182c07fccae9fcb120043464e1ff1564775ec8864f21a0ebce6ac25/pillow-12.2.0-cp313-cp313t-win32.whl", hash = "sha256:ee3120ae9dff32f121610bb08e4313be87e03efeadfc6c0d18f89127e24d0c24", size = 6379592, upload-time = "2026-04-01T14:44:40.336Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/c4/f9e476451a098181b30050cc4c9a3556b64c02cf6497ea421ac047e89e4b/pillow-12.2.0-cp313-cp313t-win_amd64.whl", hash = "sha256:325ca0528c6788d2a6c3d40e3568639398137346c3d6e66bb61db96b96511c98", size = 7085542, upload-time = "2026-04-01T14:44:43.251Z" },
+    { url = "https://files.pythonhosted.org/packages/00/a4/285f12aeacbe2d6dc36c407dfbbe9e96d4a80b0fb710a337f6d2ad978c75/pillow-12.2.0-cp313-cp313t-win_arm64.whl", hash = "sha256:2e5a76d03a6c6dcef67edabda7a52494afa4035021a79c8558e14af25313d453", size = 2465765, upload-time = "2026-04-01T14:44:45.996Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/98/4595daa2365416a86cb0d495248a393dfc84e96d62ad080c8546256cb9c0/pillow-12.2.0-cp314-cp314-ios_13_0_arm64_iphoneos.whl", hash = "sha256:3adc9215e8be0448ed6e814966ecf3d9952f0ea40eb14e89a102b87f450660d8", size = 4100848, upload-time = "2026-04-01T14:44:48.48Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/79/40184d464cf89f6663e18dfcf7ca21aae2491fff1a16127681bf1fa9b8cf/pillow-12.2.0-cp314-cp314-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:6a9adfc6d24b10f89588096364cc726174118c62130c817c2837c60cf08a392b", size = 4176515, upload-time = "2026-04-01T14:44:51.353Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/63/703f86fd4c422a9cf722833670f4f71418fb116b2853ff7da722ea43f184/pillow-12.2.0-cp314-cp314-ios_13_0_x86_64_iphonesimulator.whl", hash = "sha256:6a6e67ea2e6feda684ed370f9a1c52e7a243631c025ba42149a2cc5934dec295", size = 3640159, upload-time = "2026-04-01T14:44:53.588Z" },
+    { url = "https://files.pythonhosted.org/packages/71/e0/fb22f797187d0be2270f83500aab851536101b254bfa1eae10795709d283/pillow-12.2.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:2bb4a8d594eacdfc59d9e5ad972aa8afdd48d584ffd5f13a937a664c3e7db0ed", size = 5312185, upload-time = "2026-04-01T14:44:56.039Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/8c/1a9e46228571de18f8e28f16fabdfc20212a5d019f3e3303452b3f0a580d/pillow-12.2.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:80b2da48193b2f33ed0c32c38140f9d3186583ce7d516526d462645fd98660ae", size = 4695386, upload-time = "2026-04-01T14:44:58.663Z" },
+    { url = "https://files.pythonhosted.org/packages/70/62/98f6b7f0c88b9addd0e87c217ded307b36be024d4ff8869a812b241d1345/pillow-12.2.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:22db17c68434de69d8ecfc2fe821569195c0c373b25cccb9cbdacf2c6e53c601", size = 6280384, upload-time = "2026-04-01T14:45:01.5Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/03/688747d2e91cfbe0e64f316cd2e8005698f76ada3130d0194664174fa5de/pillow-12.2.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7b14cc0106cd9aecda615dd6903840a058b4700fcb817687d0ee4fc8b6e389be", size = 8091599, upload-time = "2026-04-01T14:45:04.5Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/35/577e22b936fcdd66537329b33af0b4ccfefaeabd8aec04b266528cddb33c/pillow-12.2.0-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8cbeb542b2ebc6fcdacabf8aca8c1a97c9b3ad3927d46b8723f9d4f033288a0f", size = 6396021, upload-time = "2026-04-01T14:45:07.117Z" },
+    { url = "https://files.pythonhosted.org/packages/11/8d/d2532ad2a603ca2b93ad9f5135732124e57811d0168155852f37fbce2458/pillow-12.2.0-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4bfd07bc812fbd20395212969e41931001fd59eb55a60658b0e5710872e95286", size = 7083360, upload-time = "2026-04-01T14:45:09.763Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/26/d325f9f56c7e039034897e7380e9cc202b1e368bfd04d4cbe6a441f02885/pillow-12.2.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:9aba9a17b623ef750a4d11b742cbafffeb48a869821252b30ee21b5e91392c50", size = 6507628, upload-time = "2026-04-01T14:45:12.378Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/f7/769d5632ffb0988f1c5e7660b3e731e30f7f8ec4318e94d0a5d674eb65a4/pillow-12.2.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:deede7c263feb25dba4e82ea23058a235dcc2fe1f6021025dc71f2b618e26104", size = 7209321, upload-time = "2026-04-01T14:45:15.122Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/7a/c253e3c645cd47f1aceea6a8bacdba9991bf45bb7dfe927f7c893e89c93c/pillow-12.2.0-cp314-cp314-win32.whl", hash = "sha256:632ff19b2778e43162304d50da0181ce24ac5bb8180122cbe1bf4673428328c7", size = 6479723, upload-time = "2026-04-01T14:45:17.797Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/8b/601e6566b957ca50e28725cb6c355c59c2c8609751efbecd980db44e0349/pillow-12.2.0-cp314-cp314-win_amd64.whl", hash = "sha256:4e6c62e9d237e9b65fac06857d511e90d8461a32adcc1b9065ea0c0fa3a28150", size = 7217400, upload-time = "2026-04-01T14:45:20.529Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/94/220e46c73065c3e2951bb91c11a1fb636c8c9ad427ac3ce7d7f3359b9b2f/pillow-12.2.0-cp314-cp314-win_arm64.whl", hash = "sha256:b1c1fbd8a5a1af3412a0810d060a78b5136ec0836c8a4ef9aa11807f2a22f4e1", size = 2554835, upload-time = "2026-04-01T14:45:23.162Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/ab/1b426a3974cb0e7da5c29ccff4807871d48110933a57207b5a676cccc155/pillow-12.2.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:57850958fe9c751670e49b2cecf6294acc99e562531f4bd317fa5ddee2068463", size = 5314225, upload-time = "2026-04-01T14:45:25.637Z" },
+    { url = "https://files.pythonhosted.org/packages/19/1e/dce46f371be2438eecfee2a1960ee2a243bbe5e961890146d2dee1ff0f12/pillow-12.2.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:d5d38f1411c0ed9f97bcb49b7bd59b6b7c314e0e27420e34d99d844b9ce3b6f3", size = 4698541, upload-time = "2026-04-01T14:45:28.355Z" },
+    { url = "https://files.pythonhosted.org/packages/55/c3/7fbecf70adb3a0c33b77a300dc52e424dc22ad8cdc06557a2e49523b703d/pillow-12.2.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:5c0a9f29ca8e79f09de89293f82fc9b0270bb4af1d58bc98f540cc4aedf03166", size = 6322251, upload-time = "2026-04-01T14:45:30.924Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/3c/7fbc17cfb7e4fe0ef1642e0abc17fc6c94c9f7a16be41498e12e2ba60408/pillow-12.2.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:1610dd6c61621ae1cf811bef44d77e149ce3f7b95afe66a4512f8c59f25d9ebe", size = 8127807, upload-time = "2026-04-01T14:45:33.908Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/c3/a8ae14d6defd2e448493ff512fae903b1e9bd40b72efb6ec55ce0048c8ce/pillow-12.2.0-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0a34329707af4f73cf1782a36cd2289c0368880654a2c11f027bcee9052d35dd", size = 6433935, upload-time = "2026-04-01T14:45:36.623Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/32/2880fb3a074847ac159d8f902cb43278a61e85f681661e7419e6596803ed/pillow-12.2.0-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8e9c4f5b3c546fa3458a29ab22646c1c6c787ea8f5ef51300e5a60300736905e", size = 7116720, upload-time = "2026-04-01T14:45:39.258Z" },
+    { url = "https://files.pythonhosted.org/packages/46/87/495cc9c30e0129501643f24d320076f4cc54f718341df18cc70ec94c44e1/pillow-12.2.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:fb043ee2f06b41473269765c2feae53fc2e2fbf96e5e22ca94fb5ad677856f06", size = 6540498, upload-time = "2026-04-01T14:45:41.879Z" },
+    { url = "https://files.pythonhosted.org/packages/18/53/773f5edca692009d883a72211b60fdaf8871cbef075eaa9d577f0a2f989e/pillow-12.2.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:f278f034eb75b4e8a13a54a876cc4a5ab39173d2cdd93a638e1b467fc545ac43", size = 7239413, upload-time = "2026-04-01T14:45:44.705Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/e4/4b64a97d71b2a83158134abbb2f5bd3f8a2ea691361282f010998f339ec7/pillow-12.2.0-cp314-cp314t-win32.whl", hash = "sha256:6bb77b2dcb06b20f9f4b4a8454caa581cd4dd0643a08bacf821216a16d9c8354", size = 6482084, upload-time = "2026-04-01T14:45:47.568Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/13/306d275efd3a3453f72114b7431c877d10b1154014c1ebbedd067770d629/pillow-12.2.0-cp314-cp314t-win_amd64.whl", hash = "sha256:6562ace0d3fb5f20ed7290f1f929cae41b25ae29528f2af1722966a0a02e2aa1", size = 7225152, upload-time = "2026-04-01T14:45:50.032Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/6e/cf826fae916b8658848d7b9f38d88da6396895c676e8086fc0988073aaf8/pillow-12.2.0-cp314-cp314t-win_arm64.whl", hash = "sha256:aa88ccfe4e32d362816319ed727a004423aab09c5cea43c01a4b435643fa34eb", size = 2556579, upload-time = "2026-04-01T14:45:52.529Z" },
+]
+
+[[package]]
+name = "platformdirs"
+version = "4.10.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/47/e4501f49c178ae1d9f4a75073fda4204f52647993f075a9db4d14930e0c5/platformdirs-4.10.0.tar.gz", hash = "sha256:31e761a6a0ca04faf7353ea759bdba55652be214725111e5aac52dfa29d4bef7", size = 31224, upload-time = "2026-05-28T03:32:53.587Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/81/e6/cd9575ac904136b3cbf7aa7ee819ef86eedb7274e46f230e94ea4342e729/platformdirs-4.10.0-py3-none-any.whl", hash = "sha256:fb516cdb12eb0d857d0cd85a7c57cea4d060bee4578d6cf5a14dfdf8cbf8784a", size = 22743, upload-time = "2026-05-28T03:32:52.175Z" },
+]
+
+[[package]]
 name = "pluggy"
 version = "1.6.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "portalocker"
+version = "2.10.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pywin32", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ed/d3/c6c64067759e87af98cc668c1cc75171347d0f1577fab7ca3749134e3cd4/portalocker-2.10.1.tar.gz", hash = "sha256:ef1bf844e878ab08aee7e40184156e1151f228f103aa5c6bd0724cc330960f8f", size = 40891, upload-time = "2024-07-13T23:15:34.86Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9b/fb/a70a4214956182e0d7a9099ab17d50bfcba1056188e9b14f35b9e2b62a0d/portalocker-2.10.1-py3-none-any.whl", hash = "sha256:53a5984ebc86a025552264b459b46a2086e269b21823cb572f8f28ee759e45bf", size = 18423, upload-time = "2024-07-13T23:15:32.602Z" },
+]
+
+[[package]]
+name = "posthog"
+version = "7.18.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "backoff" },
+    { name = "distro" },
+    { name = "requests" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b2/56/49d06b64baf270f8ec7fdb9352eaf2469167fcf0a1cbd2facc9335ab52fb/posthog-7.18.1.tar.gz", hash = "sha256:a4a3496448aa2bc4e13880daab205d11c13f8a537570662dcf9e5ecef3696ca1", size = 231652, upload-time = "2026-06-10T14:22:28.434Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b9/c5/0db39bdf91ae2e473ba139568ed24d631e87caac6c175f466d06eedc8747/posthog-7.18.1-py3-none-any.whl", hash = "sha256:54797ae8767911dfd83541f69a9e4fda65e100cb77dc0cf093fd98a3b84916a6", size = 270818, upload-time = "2026-06-10T14:22:26.849Z" },
+]
+
+[[package]]
+name = "prompt-toolkit"
+version = "3.0.52"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "wcwidth" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a1/96/06e01a7b38dce6fe1db213e061a4602dd6032a8a97ef6c1a862537732421/prompt_toolkit-3.0.52.tar.gz", hash = "sha256:28cde192929c8e7321de85de1ddbe736f1375148b02f2e17edd840042b1be855", size = 434198, upload-time = "2025-08-27T15:24:02.057Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/84/03/0d3ce49e2505ae70cf43bc5bb3033955d2fc9f932163e84dc0779cc47f48/prompt_toolkit-3.0.52-py3-none-any.whl", hash = "sha256:9aac639a3bbd33284347de5ad8d68ecc044b91a762dc39b7c21095fcd6a19955", size = 391431, upload-time = "2025-08-27T15:23:59.498Z" },
+]
+
+[[package]]
+name = "propcache"
+version = "0.5.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ec/44/c87281c333769159c50594f22610f77398a47ccbfbbf23074e744e86f87c/propcache-0.5.2.tar.gz", hash = "sha256:01c4fc7480cd0598bb4b57022df55b9ca296da7fc5a8760bd8451a7e63a7d427", size = 50208, upload-time = "2026-05-08T21:02:12.199Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4a/cb/e27bc2b2737a0bb49962b275efa051e8f1c35a936df7d5139b6b658b7dc9/propcache-0.5.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:806719138ecd720339a12410fb9614ac9b2b2d3a5fdf8235d56981c36f4039ba", size = 95887, upload-time = "2026-05-08T21:00:11.277Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/13/b8ae04c59392f8d11c6cd9fb4011d1dc7c86b81225c770280300e259ffe1/propcache-0.5.2-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:db2b80ea58eab4f86b2beec3cc8b39e8ff9276ac20e96b7cce43c8ae84cd6b5a", size = 54654, upload-time = "2026-05-08T21:00:12.604Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/7d/49777a3e20b55863d4794384a38acd460c04157b0a00f8602b0d508b8431/propcache-0.5.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:e5cbfac9f61484f7e9f3597775500cd3ebe8274e9b050c38f9525c77c97520bf", size = 55190, upload-time = "2026-05-08T21:00:13.935Z" },
+    { url = "https://files.pythonhosted.org/packages/44/c7/085d0cd63062e84044e3f05797749c3f8e3938ff3aeb0eb2f69d43fafc91/propcache-0.5.2-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5dbc581d2814337da56222fab8dc5f161cd798a434e49bac27930aaef798e144", size = 59995, upload-time = "2026-05-08T21:00:15.526Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/42/32cf8e3009e92b2645cf1e944f701e8ea4e924dffde1ee26db860bcbf7e4/propcache-0.5.2-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:857187f381f88c8e2fa2fe56ab94879d011b883d5a2ee5a1b60a8cd2a06846d9", size = 63422, upload-time = "2026-05-08T21:00:16.824Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/1b/f112433f99fc979431b87a39ef169e3f8df070d99a72792c56d6937ac48b/propcache-0.5.2-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:178b4a2cdaac1818e2bf1c5a99b94383fa73ea5382e032a48dec07dc5668dc42", size = 64342, upload-time = "2026-05-08T21:00:18.362Z" },
+    { url = "https://files.pythonhosted.org/packages/14/15/5574111ae50dd6e879456888c0eadd4c5a869959775854e18e18a6b345f3/propcache-0.5.2-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6f328175a2cde1f0ff2c4ed8ce968b9dcfb55f3a7153f39e2957ed994da13476", size = 61639, upload-time = "2026-05-08T21:00:19.692Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/da/4d775080b1490c0ae604acda868bd71aabe3a89ed16f2aa4339eb8a283e7/propcache-0.5.2-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:5671d09a36b06d0fd4a3da0fccbcae360e9b1570924171a15e9e0997f0249fba", size = 61588, upload-time = "2026-05-08T21:00:21.155Z" },
+    { url = "https://files.pythonhosted.org/packages/04/ac/f076982cbe2195ee9cf32de5a1e46951d9fb399fc207f390562dd0fd8fb2/propcache-0.5.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:80168e2ebe4d3ec6599d10ad8f520304ae1cad9b6c5a95372aef1b66b7bfb53a", size = 60029, upload-time = "2026-05-08T21:00:22.713Z" },
+    { url = "https://files.pythonhosted.org/packages/70/60/189be62e0dd898dce3b331e1b8c7a543cd3a405ac0c81fe8ee8a9d5d77e1/propcache-0.5.2-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:45f11346f884bc47444f6e6647131055844134c3175b629f84952e2b5cd62b64", size = 56774, upload-time = "2026-05-08T21:00:24.001Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/9e/93377b9c7939c1ffae98f878dee955efadfd638078bc86dbc21f9d52f651/propcache-0.5.2-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:8e778ebd44ef4f66ed60a0416b06b489687db264a9c0b3620362f26489492913", size = 63532, upload-time = "2026-05-08T21:00:25.545Z" },
+    { url = "https://files.pythonhosted.org/packages/14/f9/590ef6cfb9b8028d516d287812ece32bb0bc5f11fbb9c8bf6b2e6313fec8/propcache-0.5.2-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:c0cb9ed24c8964e172768d455a38254c2dd8a552905729ce006cad3d3dda59b1", size = 61592, upload-time = "2026-05-08T21:00:27.186Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/5e/70958b3034c297a630bba2f17ca7abc2d5f39a803ad7e370ab79d1ecd022/propcache-0.5.2-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:1d1ad32d9d4355e2be65574fd0bfd3677e7066b009cd5b9b2dee8aa6a6393b33", size = 64788, upload-time = "2026-05-08T21:00:28.8Z" },
+    { url = "https://files.pythonhosted.org/packages/12/fd/77fe5936d8c3086ca9048f7f415f122ed82e53884a9ec193646b42deef06/propcache-0.5.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:c80f4ba3e8f00189165999a742ee526ebeccedf6c3f7beb0c7df821e9772435a", size = 62514, upload-time = "2026-05-08T21:00:30.098Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/74/66bd798b5b3be70aa1b391f5cc9d6a0a5532d7fd3b19ec0b213e72e6ad9d/propcache-0.5.2-cp312-cp312-win32.whl", hash = "sha256:8c7972d8f193740d9175f0998ab38717e6cd322d5935c5b0fef8c0d323fd9031", size = 39018, upload-time = "2026-05-08T21:00:31.622Z" },
+    { url = "https://files.pythonhosted.org/packages/61/7c/5c0d34aa3024694d6dcb9271cdbdd08c4e47c1c0ad95ec7e7bc74cdea145/propcache-0.5.2-cp312-cp312-win_amd64.whl", hash = "sha256:d9ee8826a7d47863a08ac44e1a5f611a462eefc3a194b492da242128bec75b42", size = 42322, upload-time = "2026-05-08T21:00:32.918Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/91/875812f1a3feb20ceba818ef39fbe4d92f1081e04ac815c822496d0d038b/propcache-0.5.2-cp312-cp312-win_arm64.whl", hash = "sha256:2800a4a8ead6b28cccd1ec54b59346f0def7922ee1c7598e8499c733cfbb7c84", size = 38172, upload-time = "2026-05-08T21:00:35.124Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/09/f049e45385503fe67db75a6b6186a7b9f0c3930366dc960522c312a825b1/propcache-0.5.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:099aaf4b4d1a02265b92a977edf00b5c4f63b3b17ac6de39b0d637c9cac0188a", size = 94457, upload-time = "2026-05-08T21:00:36.355Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/65/83d1d05655baf63113731bd5a1008435e14f8d1e5a06cbe4ec5b23ad7a31/propcache-0.5.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:68ce1c44c7a813a7f71ea04315a8c7b330b63db99d059a797a4651bb6f69f117", size = 53835, upload-time = "2026-05-08T21:00:38.072Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/12/a6ba6482bb5ea3260c000c9b20881c95fa11c6b30173715668259f844ed7/propcache-0.5.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:fc299c129490f55f254cd90be0deca4764e36e9a7c08b4aa588479a3bbed3098", size = 54545, upload-time = "2026-05-08T21:00:39.319Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/19/7fa086f5764c59ec8a8e157cd93aa8497acc00aba9dcdec56bfffb32602d/propcache-0.5.2-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a6ae2198be502c10f09b2516e7b5d019816924bc3183a43ce792a7bd6625e6f4", size = 59886, upload-time = "2026-05-08T21:00:40.621Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/e4/5d7663dc8235956c8f5281698a3af1d351d8820341ddd890f59d9a9127f2/propcache-0.5.2-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:6041d31504dc1779d700e1edcfb08eea334b357620b06681a4eabb57a74e574e", size = 63261, upload-time = "2026-05-08T21:00:41.775Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/4a/15a03adee24d6350da4292caeac44c34c033d2afe5e87eb370f38854560f/propcache-0.5.2-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:f7eabc04151c78a9f4d5bbb5f1faf571e4defeb4b585e0fe95b60ff2dbe4d3d7", size = 64184, upload-time = "2026-05-08T21:00:43.018Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/c6/979176efdaa3d239e36d503d5af63a0a773b36662ed8f52e5b6a6d9fd40e/propcache-0.5.2-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4db0ba63d693afd40d249bd93f842b5f144f8fcbb83de05660373bcf30517b1d", size = 61534, upload-time = "2026-05-08T21:00:44.507Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/22/63e8cd1bae4c2d2be6493b6b7d10566ddafad88137cfbc99964a1119853c/propcache-0.5.2-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:1dbcf7675229b35d31abb6547d8ebc8c27a830ac3f9a794edff6254873ec7c0a", size = 61500, upload-time = "2026-05-08T21:00:45.796Z" },
+    { url = "https://files.pythonhosted.org/packages/60/5a/28e5d9acbac1cc9ccb67045e8c1b943aa8d79fdf39c93bd73cacd68008ea/propcache-0.5.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:d310c013aad2c72f1c3f2f8dd3279d460a858c551f97aeb8c63e4693cca7b4d2", size = 59994, upload-time = "2026-05-08T21:00:47.093Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/40/db650677f554a95b9c01a7c9d93d629e93a15562f5deb4573c9ee136fed2/propcache-0.5.2-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:06187263ddad280d05b4d8a8b3bb7d164cbebd469236544a42e6d9b28ac6a4fa", size = 56884, upload-time = "2026-05-08T21:00:48.376Z" },
+    { url = "https://files.pythonhosted.org/packages/80/45/70b39b89516ff8b96bf732fa6fded8cef20f293cb1508690101c3c07ec51/propcache-0.5.2-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:3115559b8effafd63b142ea5ed53d63a16ea6469cbc63dce4ee194b42db5d853", size = 63464, upload-time = "2026-05-08T21:00:49.954Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/e2/fa59d3a89eac5534293124af4f1d0d0ada091ce4a0ab4610ce03fd2bdd8d/propcache-0.5.2-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:c60462af8e6dc30c35407c7237ea908d777b22862bbee27bc4699c0d8bcdc45a", size = 61588, upload-time = "2026-05-08T21:00:51.281Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/97/efb547a55c4bc7381cfb202d6a2239ac621045277bc1ea5dfd3a7f0516c0/propcache-0.5.2-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:40314bca9ac559716fe374094fc81c11dcc34b64fd6c585360f5775690505704", size = 64667, upload-time = "2026-05-08T21:00:52.602Z" },
+    { url = "https://files.pythonhosted.org/packages/92/56/f5c7d9b4b7595d5127da38974d791b2153f3d1eae6c674af3583ace92ad3/propcache-0.5.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:cfa21e036ce1e1db2be04ba3b85d2df1bb1702fa01932d984c5464c665228ff4", size = 62463, upload-time = "2026-05-08T21:00:54.303Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/3b/484a3a65fc9f9f60c41dcd17b428bace5389544e2c680994534a20755066/propcache-0.5.2-cp313-cp313-win32.whl", hash = "sha256:f156a3529f38063b6dbaf356e15602a7f95f8055b1295a438433a6386f10463d", size = 38621, upload-time = "2026-05-08T21:00:55.808Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/fd/3f0f10dba4dabad3bf53102be007abf55481067952bde0fdddff439e7c61/propcache-0.5.2-cp313-cp313-win_amd64.whl", hash = "sha256:dfed59d0a5aeb01e242e66ff0300bc4a265a7c05f612d30016f0b60b1017d757", size = 41649, upload-time = "2026-05-08T21:00:57.061Z" },
+    { url = "https://files.pythonhosted.org/packages/90/ec/6ce619cc32bb500a482f811f9cd509368b4e58e638d13f2c68f370d6b475/propcache-0.5.2-cp313-cp313-win_arm64.whl", hash = "sha256:ba338430e87ceb9c8f0cf754de38a9860560261e56c00376debd628698a7364f", size = 37636, upload-time = "2026-05-08T21:00:58.646Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/82/c1d268bbbf2ef981c5bf0fbbe746db617c66e3bcefe431a1aa8943fbe23a/propcache-0.5.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:a592f5f3da71c8691c788c13cb6734b6d17663d2e1cb8caddf0673d01ef8847d", size = 98872, upload-time = "2026-05-08T21:00:59.889Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/d4/52c871e73e864e6b34c0e2d58ac1ec5ccd149497ddc7ad2137ae98323a35/propcache-0.5.2-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:6a997d0489e9668a384fcfd5061b857aa5361de73191cac204d04b889cfbbafa", size = 56257, upload-time = "2026-05-08T21:01:01.195Z" },
+    { url = "https://files.pythonhosted.org/packages/67/f0/9b90ca2a210b3d09bcfcd96ecd0f55545c091535abce2a45de2775cfd357/propcache-0.5.2-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:10734b5484ea113152ee25a91dccedf81631791805d2c9ccb054958e51842c94", size = 56696, upload-time = "2026-05-08T21:01:02.941Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/0e/6e9d4ba07c8e56e21ddec1e75f12148142b21ca83a51871babce095334f4/propcache-0.5.2-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:cafca7e56c12bb02ae16d283742bef25a61122e9dab2b5b3f2ccbe589ce32164", size = 62378, upload-time = "2026-05-08T21:01:04.475Z" },
+    { url = "https://files.pythonhosted.org/packages/65/19/c10badaa463dde8a27ce884f8ee2ec37e6035b7c9f5ff0c8f74f06f08dac/propcache-0.5.2-cp313-cp313t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:f064f8d2b59177878b7615df1735cd8fe3462ed6be8c7b217d17a276489c2b7f", size = 65283, upload-time = "2026-05-08T21:01:05.959Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/b6/93bea99ca80e19cef6512a8580e5b7857bbe09422d9daa7fd4ef5723306c/propcache-0.5.2-cp313-cp313t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:f78abfa8dfc32376fd1aacf597b2f2fbbe0ea751419aee718af5d4f82537ef8c", size = 66616, upload-time = "2026-05-08T21:01:07.228Z" },
+    { url = "https://files.pythonhosted.org/packages/83/e4/5c7462e50625f051f37fb38b8224f7639f667184bbd34424ec83819bb1b7/propcache-0.5.2-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f7467da8a9822bf1a55336f877340c5bcbd3c482afc43a99771169f74a26dedc", size = 63773, upload-time = "2026-05-08T21:01:08.514Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/b6/99238894047b13c823be25027e736626cd414a52a5e30d2c3347c2733529/propcache-0.5.2-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:a6ddc6ac9e25de626c1f129c1b467d7ecd33ce2237d3fd0c4e429feef0a7ee1f", size = 63664, upload-time = "2026-05-08T21:01:09.874Z" },
+    { url = "https://files.pythonhosted.org/packages/85/1e/a3a1a63116a2b8edb415a8bb9a6f0c34bd03830b1e18e8ce2904e1dc1cf4/propcache-0.5.2-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:2f22cbbac9e26a8e864c0985ff1268d5d939d53d9d9411a9824279097e03a2cb", size = 62643, upload-time = "2026-05-08T21:01:11.132Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/03/893cf147de2fc6543c5eaa07ad833170e7e2a2385725bbebe8c0503723bb/propcache-0.5.2-cp313-cp313t-musllinux_1_2_armv7l.whl", hash = "sha256:fc76378c62a0f04d0cd82fbb1a2cd2d7e28fcb40d5873f28a6c44e388aaa2751", size = 59595, upload-time = "2026-05-08T21:01:12.387Z" },
+    { url = "https://files.pythonhosted.org/packages/86/3b/04c1a2e12c57766568ba75ba72b3bf2042818d4c1425fab6fc07155c7cff/propcache-0.5.2-cp313-cp313t-musllinux_1_2_ppc64le.whl", hash = "sha256:acd2c8edba48e31e58a363b8cf4e5c7db3b04b3f9e371f601df30d9b0d244836", size = 65711, upload-time = "2026-05-08T21:01:13.676Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/34/80f8d0099f8d6bacc4de1624c85672681c8cd1149ca2da0e38fd120b817f/propcache-0.5.2-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:452b5065457eb9991ec5eb38ff41d6cd4c991c9ac7c531c4d5849ae473a9a13f", size = 64247, upload-time = "2026-05-08T21:01:14.936Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/1a/8b08f3a5f1037e9e370c55883ceeeee0f6dd0416fb2d2d67b8bfc91f2a79/propcache-0.5.2-cp313-cp313t-musllinux_1_2_s390x.whl", hash = "sha256:3430bb2bfe1331885c427745a751e774ee679fd4344f80b97bf879815fe8fa55", size = 67102, upload-time = "2026-05-08T21:01:16.281Z" },
+    { url = "https://files.pythonhosted.org/packages/34/68/8bdb7bb7756d76e005490649d10e4a8369e610c74d619f71e1aedf889e9c/propcache-0.5.2-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:cef6cea3922890dd6c9654971001fa797b526c16ab5e1e46c05fd6f877be7568", size = 64964, upload-time = "2026-05-08T21:01:17.57Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/aa/50fb0b5d3968b61a510926ff8b8465f1d6e976b3ab74496d7a4b9fc42515/propcache-0.5.2-cp313-cp313t-win32.whl", hash = "sha256:72d61e16dd78228b58c5d47be830ff3da7e5f139abdf0aef9d86cde1c5cf2191", size = 42546, upload-time = "2026-05-08T21:01:18.946Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/4c/0ddbae64321bd4a95bcbfc19307238016b5b1fee645c84626c8d539e5b74/propcache-0.5.2-cp313-cp313t-win_amd64.whl", hash = "sha256:0958834041a0166d343b8d2cedcd8bcbaeb4fdbe0cf08320c5379f143c3be6e7", size = 46330, upload-time = "2026-05-08T21:01:20.162Z" },
+    { url = "https://files.pythonhosted.org/packages/00/d9/9cddc8efb78d8af264c5ec9f6d10b62f57c515feda8d321595f56010fb23/propcache-0.5.2-cp313-cp313t-win_arm64.whl", hash = "sha256:6de8bd93ddde9b992cf2b2e0d796d501a19026b5b9fd87356d7d0779531a8d96", size = 40521, upload-time = "2026-05-08T21:01:21.399Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/ea/23ee535d90ce8bcc465a3028eb3cc0ce3bd1005f4bb27710b30587de798d/propcache-0.5.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:46088abff4cba581dea21ae0467a480526cb25aa5f3c269e909f800328bc3999", size = 94662, upload-time = "2026-05-08T21:01:22.683Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/06/c5a52f419b5d8972f8d46a7577476090d8e3263ff589ce40b5ca4968d5be/propcache-0.5.2-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:fc88b26f08d634f7bc819a7852e5214f5802641ab8d9fd5326892292eee1993e", size = 53928, upload-time = "2026-05-08T21:01:23.986Z" },
+    { url = "https://files.pythonhosted.org/packages/63/b1/4260d67d6bd85e58a66b72d54ce15d5de789b6f3870cc6bedf8ff9667401/propcache-0.5.2-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:97797ebb098e670a2f92dd66f32897e30d7615b14e7f59711de23e30a9072539", size = 54650, upload-time = "2026-05-08T21:01:25.305Z" },
+    { url = "https://files.pythonhosted.org/packages/70/06/2f46c318e3307cd7a6a7481def374ce838c0fe20084b39dd54b0879d0e99/propcache-0.5.2-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ba57fffe4ac99c5d30076161b5866336d97600769bad35cc68f7774b15298a4e", size = 59912, upload-time = "2026-05-08T21:01:26.545Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/29/fe1aebec2ce57ab985a9c382bded1124431f85078113aa222c5d278430d4/propcache-0.5.2-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:583c19759d9eec1e5b69e2fbef36a7d9c326041be9746cb822d335c8cedc2979", size = 63300, upload-time = "2026-05-08T21:01:27.937Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/18/2334b26768b6c82be8c69e83671b767d5ef426aa09b0cba6c2ea47816774/propcache-0.5.2-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:d0326e2e5e1f3163fa306c834e48e8d490e5fae607a097a40c0648109b47ba80", size = 64208, upload-time = "2026-05-08T21:01:29.484Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/76/7f1bfd6afff4c5e38e36a3c6d68eb5f4b7311ea80baf693db78d95b603c4/propcache-0.5.2-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e00820e192c8dbebcafb383ebbf99030895f09905e7a0eb2e0340a0bcc2bc825", size = 61633, upload-time = "2026-05-08T21:01:31.068Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/46/b3ff8aba2b4953a3e50de2cf72f1b5748b8eca93b15f3dc2c84339084c09/propcache-0.5.2-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:c66afea89b1e43725731d2004732a046fe6fe955d51f952c3e95a7314a284a39", size = 61724, upload-time = "2026-05-08T21:01:32.374Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/01/814cfcafbcff954f94c01cf30e097ddc88a076b5440fbcf4570753437d40/propcache-0.5.2-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:d4dc37dec6c6cdad0b57881a5658fd14fbf53e333b1a86cf86559f190e1d9ec4", size = 60069, upload-time = "2026-05-08T21:01:33.67Z" },
+    { url = "https://files.pythonhosted.org/packages/da/68/5c6f7622d510cc666a300687e06fd060c1a43361c0c9b20d284f06d8096a/propcache-0.5.2-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:5570dbcc97571c15f68068e529c92715a12f8d54030e272d264b377e22bd17a5", size = 57099, upload-time = "2026-05-08T21:01:34.915Z" },
+    { url = "https://files.pythonhosted.org/packages/55/27/9cb0b4c679124085327957d42521c99dba04c88c90c3e55a6f0b633ebccc/propcache-0.5.2-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:f814362777a9f841adddb200ecdf8f5cb1e5a3c4b7a86378edbd6ccb26edd702", size = 63391, upload-time = "2026-05-08T21:01:36.231Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/9d/7258aaa5bdf60fc6f27591eef6fe52768cb0beda7140be477c8b12c9794a/propcache-0.5.2-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:196913dea116aeb5a2ba95af4ddcb7ea85559ae07d8eee8751688310d09168c3", size = 61626, upload-time = "2026-05-08T21:01:37.545Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/0d/41c602003e8a9b16fe1e7eadf62c7bfba9d5474370b24200bf48b315f45f/propcache-0.5.2-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:6e7b8719005dd1175be4ab1cd25e9b98659a5e0347331506ec6760d2773a7fb5", size = 64781, upload-time = "2026-05-08T21:01:38.83Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/f3/38e66b1856e9bd079deea015bc4a55f7767c0e4db2f7dcf69e7e680ba4ce/propcache-0.5.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:51f96d685ab16e88cab128cd37a52c5da540809c8b879fa047731bfcb4ad35a4", size = 62570, upload-time = "2026-05-08T21:01:40.415Z" },
+    { url = "https://files.pythonhosted.org/packages/95/ca/bbfe9b910ce57dde8bb4876b4520fc02a4e89497c10de26be936758a3aaa/propcache-0.5.2-cp314-cp314-win32.whl", hash = "sha256:cc6fc3cc62e8501d3ed62894425040d2728ecddb1ed072737a5c70bd537aa9f0", size = 39436, upload-time = "2026-05-08T21:01:41.654Z" },
+    { url = "https://files.pythonhosted.org/packages/61/d2/45c9defbaa1ea297035d9d4cce9e8f80daafbf19319c6007f157c6256ea9/propcache-0.5.2-cp314-cp314-win_amd64.whl", hash = "sha256:81e3a30b0bb60caa22033dd0f8a3618d1d67356212514f62c57db75cb0ef410c", size = 42373, upload-time = "2026-05-08T21:01:43.041Z" },
+    { url = "https://files.pythonhosted.org/packages/44/68/9ea5103f41d5217d7d6ec24db90018e23aebec070c3f9a6e54d12b841fd8/propcache-0.5.2-cp314-cp314-win_arm64.whl", hash = "sha256:0d2c9bf8528f135dbb805ce027567e09164f7efa51a2be07458a2c0420f292d0", size = 38554, upload-time = "2026-05-08T21:01:44.336Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/81/fadf555f42d3b762eea8a53950b0489fdc0aa9da5f8ed9e10ce0a4e01b48/propcache-0.5.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:4bc8ff1feffc6a61c7002ffe84634c41b822e104990ae009f44a0834430070bb", size = 99395, upload-time = "2026-05-08T21:01:45.883Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/c9/c61e134a686949cf7971af3a390148b1156f7be81c73bc0cd12c873e2d48/propcache-0.5.2-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:79aa3ff0a9b566633b642fa9caf7e21ed1c13d6feca718187873f199e1514078", size = 56653, upload-time = "2026-05-08T21:01:47.307Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/73/daf935ea7048ddd7ec8eec5345b4a40b619d2d178b3c0a0900796bc3c794/propcache-0.5.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:1b31822f4474c4036bae62de9402710051d431a606d6a0f907fec79935a071aa", size = 56914, upload-time = "2026-05-08T21:01:48.573Z" },
+    { url = "https://files.pythonhosted.org/packages/79/9f/aba959b435ea18617edd7cf0a7ad0b9c574b8fc7e3d2cd55fb59cb255d33/propcache-0.5.2-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:13fef48778b5a2a756523fdb781326b028ca75e32858b04f2cdd19f394564917", size = 62567, upload-time = "2026-05-08T21:01:49.903Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/a1/859942de9a791ff42f6141736f5b37749b8f53e65edfa49638c67dd67e6a/propcache-0.5.2-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:8b73ab70f1a3351fbc71f663b3e645af6dd0329100c353081cf69c37433fc6fe", size = 65542, upload-time = "2026-05-08T21:01:51.204Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/61/315bc0fd6c0fc7f80a528b8afd209e5fc4a875ea79571b91b8f50f442907/propcache-0.5.2-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:5538d2c13d93e4698af7e092b57bc7298fd35d1d58e656ae18f23ee0d0378e03", size = 66845, upload-time = "2026-05-08T21:01:52.539Z" },
+    { url = "https://files.pythonhosted.org/packages/47/f7/9f8122e3132e8e354ac41975ef8f1099be7d5a16bc7ae562734e993665c0/propcache-0.5.2-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:cd645f03898405cabe694fb8bc35241e3a9c332ec85627584fe3de201452b335", size = 63985, upload-time = "2026-05-08T21:01:53.847Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/54/c317819ec157cbf6f35df9df9657a6f82daf34d5faf15948b2f639c2192e/propcache-0.5.2-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:a473b3440261e0c60706e732b2ed2f517857344fc21bf48fdfe211e2d98eb285", size = 63999, upload-time = "2026-05-08T21:01:55.179Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/56/387e3f7dfce0a9233df41fb888aa1c30222cb4bbbf09537c02dd9bd85fe2/propcache-0.5.2-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:7afa37062e6650640e932e4cc9297d81f9f42d9944029cc386b8247dea4da837", size = 62779, upload-time = "2026-05-08T21:01:57.489Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/9c/596784cb5824ed61ee960d3f8655a3f0993e107c6e98ab6c818b7fb92ccb/propcache-0.5.2-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:8a90efd5777e996e42d568db9ac740b944d691e565cbfd31b2f7832f9184b2b8", size = 59796, upload-time = "2026-05-08T21:01:58.736Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/3d/1a6cfa1726a48542c1e8784a0761421476a5b68e09b7f36bf95eb954aaba/propcache-0.5.2-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:f19bb891234d72535764d703bfed1153cc34f4214d5bd7150aee1eec9e8f4366", size = 66023, upload-time = "2026-05-08T21:02:00.228Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/0e/05fd6990369477076e4e280bcb970de760fddf0161a46e988bc95f7940ec/propcache-0.5.2-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:32775082acd2d807ee3db715c7770d38767b817870acfa08c29e057f3c4d5b56", size = 64448, upload-time = "2026-05-08T21:02:01.888Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/86/5f8da315a4309c62c10c0b2516b17492d5d3bbe1bb862b96604db67e2a37/propcache-0.5.2-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:9282fb1a3bccd038da9f768b927b24a0c753e466c086b7c4f3c6982851eefb2d", size = 67329, upload-time = "2026-05-08T21:02:03.484Z" },
+    { url = "https://files.pythonhosted.org/packages/da/d3/3368efe79ab21f0cdf86ef49895811c9cc933131d4cde1f28a624e22e712/propcache-0.5.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:cc49723e2f60d6b32a0f0b08a3fd6d13203c07f1cd9566cfce0f12a917c967a2", size = 65172, upload-time = "2026-05-08T21:02:04.745Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/07/127e8b0bacfb325396196f9d976a22453049b89b9b2b08477cc3145faa44/propcache-0.5.2-cp314-cp314t-win32.whl", hash = "sha256:2d7aa89ebca5acc98cba9d1472d976e394782f587bad6661003602a619fd1821", size = 43813, upload-time = "2026-05-08T21:02:06.025Z" },
+    { url = "https://files.pythonhosted.org/packages/88/fb/46dad6c0ae49ed230ab1b16c890c2b6314e2403e6c412976f4a72d64a527/propcache-0.5.2-cp314-cp314t-win_amd64.whl", hash = "sha256:d447bb0b3054be5818458fbb171208b1d9ff11eba14e18ca18b90cbb45767370", size = 47764, upload-time = "2026-05-08T21:02:07.353Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/c4/a47d0a63aa309d10d59ede6e9d4cff03a344a79d1f0f4cd0cd74997b53e0/propcache-0.5.2-cp314-cp314t-win_arm64.whl", hash = "sha256:fe67a3d11cd9b4efabfa45c3d00ffba2b26811442a73a581a94b67c2b5faccf6", size = 41140, upload-time = "2026-05-08T21:02:09.065Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/ed/1cdcab6ba3d6ab7feca11fc14f0eeea80755bb53ef4e892079f31b10a25f/propcache-0.5.2-py3-none-any.whl", hash = "sha256:be1ddfcbb376e3de5d2e2db1d58d6d67463e6b4f9f040c000de8e300295465fe", size = 14036, upload-time = "2026-05-08T21:02:10.673Z" },
+]
+
+[[package]]
+name = "proto-plus"
+version = "1.28.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "protobuf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c9/56/e647b0c675392d2da368da7b6f158f7368b18542fd6f7d7400a2f39de000/proto_plus-1.28.0.tar.gz", hash = "sha256:38e5696342835b08fc116f30a25665b29531cda9d5d5643e9b81fc312385abd9", size = 57221, upload-time = "2026-05-07T08:04:50.811Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7c/20/b122d4626976acb81132036d2ad1bb35a1a8775fceb837ec30964622516a/proto_plus-1.28.0-py3-none-any.whl", hash = "sha256:a630604310899e73c59ec302e5765c058d412b2f090b9c79c8822589f14955b8", size = 50410, upload-time = "2026-05-07T08:03:31.962Z" },
+]
+
+[[package]]
+name = "protobuf"
+version = "6.33.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/66/70/e908e9c5e52ef7c3a6c7902c9dfbb34c7e29c25d2f81ade3856445fd5c94/protobuf-6.33.6.tar.gz", hash = "sha256:a6768d25248312c297558af96a9f9c929e8c4cee0659cb07e780731095f38135", size = 444531, upload-time = "2026-03-18T19:05:00.988Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fc/9f/2f509339e89cfa6f6a4c4ff50438db9ca488dec341f7e454adad60150b00/protobuf-6.33.6-cp310-abi3-win32.whl", hash = "sha256:7d29d9b65f8afef196f8334e80d6bc1d5d4adedb449971fefd3723824e6e77d3", size = 425739, upload-time = "2026-03-18T19:04:48.373Z" },
+    { url = "https://files.pythonhosted.org/packages/76/5d/683efcd4798e0030c1bab27374fd13a89f7c2515fb1f3123efdfaa5eab57/protobuf-6.33.6-cp310-abi3-win_amd64.whl", hash = "sha256:0cd27b587afca21b7cfa59a74dcbd48a50f0a6400cfb59391340ad729d91d326", size = 437089, upload-time = "2026-03-18T19:04:50.381Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/01/a3c3ed5cd186f39e7880f8303cc51385a198a81469d53d0fdecf1f64d929/protobuf-6.33.6-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:9720e6961b251bde64edfdab7d500725a2af5280f3f4c87e57c0208376aa8c3a", size = 427737, upload-time = "2026-03-18T19:04:51.866Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/90/b3c01fdec7d2f627b3a6884243ba328c1217ed2d978def5c12dc50d328a3/protobuf-6.33.6-cp39-abi3-manylinux2014_aarch64.whl", hash = "sha256:e2afbae9b8e1825e3529f88d514754e094278bb95eadc0e199751cdd9a2e82a2", size = 324610, upload-time = "2026-03-18T19:04:53.096Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/ca/25afc144934014700c52e05103c2421997482d561f3101ff352e1292fb81/protobuf-6.33.6-cp39-abi3-manylinux2014_s390x.whl", hash = "sha256:c96c37eec15086b79762ed265d59ab204dabc53056e3443e702d2681f4b39ce3", size = 339381, upload-time = "2026-03-18T19:04:54.616Z" },
+    { url = "https://files.pythonhosted.org/packages/16/92/d1e32e3e0d894fe00b15ce28ad4944ab692713f2e7f0a99787405e43533a/protobuf-6.33.6-cp39-abi3-manylinux2014_x86_64.whl", hash = "sha256:e9db7e292e0ab79dd108d7f1a94fe31601ce1ee3f7b79e0692043423020b0593", size = 323436, upload-time = "2026-03-18T19:04:55.768Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/72/02445137af02769918a93807b2b7890047c32bfb9f90371cbc12688819eb/protobuf-6.33.6-py3-none-any.whl", hash = "sha256:77179e006c476e69bf8e8ce866640091ec42e1beb80b213c3900006ecfba6901", size = 170656, upload-time = "2026-03-18T19:04:59.826Z" },
+]
+
+[[package]]
+name = "psutil"
+version = "7.2.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/aa/c6/d1ddf4abb55e93cebc4f2ed8b5d6dbad109ecb8d63748dd2b20ab5e57ebe/psutil-7.2.2.tar.gz", hash = "sha256:0746f5f8d406af344fd547f1c8daa5f5c33dbc293bb8d6a16d80b4bb88f59372", size = 493740, upload-time = "2026-01-28T18:14:54.428Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/51/08/510cbdb69c25a96f4ae523f733cdc963ae654904e8db864c07585ef99875/psutil-7.2.2-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:2edccc433cbfa046b980b0df0171cd25bcaeb3a68fe9022db0979e7aa74a826b", size = 130595, upload-time = "2026-01-28T18:14:57.293Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/f5/97baea3fe7a5a9af7436301f85490905379b1c6f2dd51fe3ecf24b4c5fbf/psutil-7.2.2-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:e78c8603dcd9a04c7364f1a3e670cea95d51ee865e4efb3556a3a63adef958ea", size = 131082, upload-time = "2026-01-28T18:14:59.732Z" },
+    { url = "https://files.pythonhosted.org/packages/37/d6/246513fbf9fa174af531f28412297dd05241d97a75911ac8febefa1a53c6/psutil-7.2.2-cp313-cp313t-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1a571f2330c966c62aeda00dd24620425d4b0cc86881c89861fbc04549e5dc63", size = 181476, upload-time = "2026-01-28T18:15:01.884Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/b5/9182c9af3836cca61696dabe4fd1304e17bc56cb62f17439e1154f225dd3/psutil-7.2.2-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:917e891983ca3c1887b4ef36447b1e0873e70c933afc831c6b6da078ba474312", size = 184062, upload-time = "2026-01-28T18:15:04.436Z" },
+    { url = "https://files.pythonhosted.org/packages/16/ba/0756dca669f5a9300d0cbcbfae9a4c30e446dfc7440ffe43ded5724bfd93/psutil-7.2.2-cp313-cp313t-win_amd64.whl", hash = "sha256:ab486563df44c17f5173621c7b198955bd6b613fb87c71c161f827d3fb149a9b", size = 139893, upload-time = "2026-01-28T18:15:06.378Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/61/8fa0e26f33623b49949346de05ec1ddaad02ed8ba64af45f40a147dbfa97/psutil-7.2.2-cp313-cp313t-win_arm64.whl", hash = "sha256:ae0aefdd8796a7737eccea863f80f81e468a1e4cf14d926bd9b6f5f2d5f90ca9", size = 135589, upload-time = "2026-01-28T18:15:08.03Z" },
+    { url = "https://files.pythonhosted.org/packages/81/69/ef179ab5ca24f32acc1dac0c247fd6a13b501fd5534dbae0e05a1c48b66d/psutil-7.2.2-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:eed63d3b4d62449571547b60578c5b2c4bcccc5387148db46e0c2313dad0ee00", size = 130664, upload-time = "2026-01-28T18:15:09.469Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/64/665248b557a236d3fa9efc378d60d95ef56dd0a490c2cd37dafc7660d4a9/psutil-7.2.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7b6d09433a10592ce39b13d7be5a54fbac1d1228ed29abc880fb23df7cb694c9", size = 131087, upload-time = "2026-01-28T18:15:11.724Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/2e/e6782744700d6759ebce3043dcfa661fb61e2fb752b91cdeae9af12c2178/psutil-7.2.2-cp314-cp314t-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1fa4ecf83bcdf6e6c8f4449aff98eefb5d0604bf88cb883d7da3d8d2d909546a", size = 182383, upload-time = "2026-01-28T18:15:13.445Z" },
+    { url = "https://files.pythonhosted.org/packages/57/49/0a41cefd10cb7505cdc04dab3eacf24c0c2cb158a998b8c7b1d27ee2c1f5/psutil-7.2.2-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e452c464a02e7dc7822a05d25db4cde564444a67e58539a00f929c51eddda0cf", size = 185210, upload-time = "2026-01-28T18:15:16.002Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/2c/ff9bfb544f283ba5f83ba725a3c5fec6d6b10b8f27ac1dc641c473dc390d/psutil-7.2.2-cp314-cp314t-win_amd64.whl", hash = "sha256:c7663d4e37f13e884d13994247449e9f8f574bc4655d509c3b95e9ec9e2b9dc1", size = 141228, upload-time = "2026-01-28T18:15:18.385Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/fc/f8d9c31db14fcec13748d373e668bc3bed94d9077dbc17fb0eebc073233c/psutil-7.2.2-cp314-cp314t-win_arm64.whl", hash = "sha256:11fe5a4f613759764e79c65cf11ebdf26e33d6dd34336f8a337aa2996d71c841", size = 136284, upload-time = "2026-01-28T18:15:19.912Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/36/5ee6e05c9bd427237b11b3937ad82bb8ad2752d72c6969314590dd0c2f6e/psutil-7.2.2-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:ed0cace939114f62738d808fdcecd4c869222507e266e574799e9c0faa17d486", size = 129090, upload-time = "2026-01-28T18:15:22.168Z" },
+    { url = "https://files.pythonhosted.org/packages/80/c4/f5af4c1ca8c1eeb2e92ccca14ce8effdeec651d5ab6053c589b074eda6e1/psutil-7.2.2-cp36-abi3-macosx_11_0_arm64.whl", hash = "sha256:1a7b04c10f32cc88ab39cbf606e117fd74721c831c98a27dc04578deb0c16979", size = 129859, upload-time = "2026-01-28T18:15:23.795Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/70/5d8df3b09e25bce090399cf48e452d25c935ab72dad19406c77f4e828045/psutil-7.2.2-cp36-abi3-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:076a2d2f923fd4821644f5ba89f059523da90dc9014e85f8e45a5774ca5bc6f9", size = 155560, upload-time = "2026-01-28T18:15:25.976Z" },
+    { url = "https://files.pythonhosted.org/packages/63/65/37648c0c158dc222aba51c089eb3bdfa238e621674dc42d48706e639204f/psutil-7.2.2-cp36-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b0726cecd84f9474419d67252add4ac0cd9811b04d61123054b9fb6f57df6e9e", size = 156997, upload-time = "2026-01-28T18:15:27.794Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/13/125093eadae863ce03c6ffdbae9929430d116a246ef69866dad94da3bfbc/psutil-7.2.2-cp36-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:fd04ef36b4a6d599bbdb225dd1d3f51e00105f6d48a28f006da7f9822f2606d8", size = 148972, upload-time = "2026-01-28T18:15:29.342Z" },
+    { url = "https://files.pythonhosted.org/packages/04/78/0acd37ca84ce3ddffaa92ef0f571e073faa6d8ff1f0559ab1272188ea2be/psutil-7.2.2-cp36-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:b58fabe35e80b264a4e3bb23e6b96f9e45a3df7fb7eed419ac0e5947c61e47cc", size = 148266, upload-time = "2026-01-28T18:15:31.597Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/90/e2159492b5426be0c1fef7acba807a03511f97c5f86b3caeda6ad92351a7/psutil-7.2.2-cp37-abi3-win_amd64.whl", hash = "sha256:eb7e81434c8d223ec4a219b5fc1c47d0417b12be7ea866e24fb5ad6e84b3d988", size = 137737, upload-time = "2026-01-28T18:15:33.849Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/c7/7bb2e321574b10df20cbde462a94e2b71d05f9bbda251ef27d104668306a/psutil-7.2.2-cp37-abi3-win_arm64.whl", hash = "sha256:8c233660f575a5a89e6d4cb65d9f938126312bca76d8fe087b947b3a1aaac9ee", size = 134617, upload-time = "2026-01-28T18:15:36.514Z" },
+]
+
+[[package]]
+name = "py-key-value-aio"
+version = "0.4.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "beartype" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fb/e2/d689d922894a7ecde73b6daeaf9b13dab5aae06fe6aaaf7514722644d382/py_key_value_aio-0.4.5.tar.gz", hash = "sha256:c6563a2c6abe5da5e20f4f9e875c2a9b425a2244a54fadbf46cf140a9eea45d7", size = 107547, upload-time = "2026-05-27T16:37:08.107Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f6/95/b8ba862968712caa12a19666175334fa979e1f198b896a430adb3bacfe87/py_key_value_aio-0.4.5-py3-none-any.whl", hash = "sha256:ab862adbcb8c72547d1c57821f22cbbb71ab86509039c96f36e914e0336c8dd7", size = 170005, upload-time = "2026-05-27T16:37:06.629Z" },
+]
+
+[package.optional-dependencies]
+filetree = [
+    { name = "aiofile" },
+    { name = "anyio" },
+]
+keyring = [
+    { name = "keyring" },
+]
+memory = [
+    { name = "cachetools" },
+]
+
+[[package]]
+name = "pyasn1"
+version = "0.6.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5c/5f/6583902b6f79b399c9c40674ac384fd9cd77805f9e6205075f828ef11fb2/pyasn1-0.6.3.tar.gz", hash = "sha256:697a8ecd6d98891189184ca1fa05d1bb00e2f84b5977c481452050549c8a72cf", size = 148685, upload-time = "2026-03-17T01:06:53.382Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5d/a0/7d793dce3fa811fe047d6ae2431c672364b462850c6235ae306c0efd025f/pyasn1-0.6.3-py3-none-any.whl", hash = "sha256:a80184d120f0864a52a073acc6fc642847d0be408e7c7252f31390c0f4eadcde", size = 83997, upload-time = "2026-03-17T01:06:52.036Z" },
+]
+
+[[package]]
+name = "pyasn1-modules"
+version = "0.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyasn1" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e9/e6/78ebbb10a8c8e4b61a59249394a4a594c1a7af95593dc933a349c8d00964/pyasn1_modules-0.4.2.tar.gz", hash = "sha256:677091de870a80aae844b1ca6134f54652fa2c8c5a52aa396440ac3106e941e6", size = 307892, upload-time = "2025-03-28T02:41:22.17Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/47/8d/d529b5d697919ba8c11ad626e835d4039be708a35b0d22de83a269a6682c/pyasn1_modules-0.4.2-py3-none-any.whl", hash = "sha256:29253a9207ce32b64c3ac6600edc75368f98473906e8fd1043bd6b5b1de2c14a", size = 181259, upload-time = "2025-03-28T02:41:19.028Z" },
 ]
 
 [[package]]
@@ -928,6 +2928,11 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/fd/7b/122376b1fd3c62c1ed9dc80c931ace4844b3c55407b6fb2d199377c9736f/pydantic-2.13.4-py3-none-any.whl", hash = "sha256:45a282cde31d808236fd7ea9d919b128653c8b38b393d1c4ab335c62924d9aba", size = 472262, upload-time = "2026-05-06T13:43:02.641Z" },
 ]
 
+[package.optional-dependencies]
+email = [
+    { name = "email-validator" },
+]
+
 [[package]]
 name = "pydantic-core"
 version = "2.46.4"
@@ -937,21 +2942,6 @@ dependencies = [
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/9d/56/921726b776ace8d8f5db44c4ef961006580d91dc52b803c489fafd1aa249/pydantic_core-2.46.4.tar.gz", hash = "sha256:62f875393d7f270851f20523dd2e29f082bcc82292d66db2b64ea71f64b6e1c1", size = 471464, upload-time = "2026-05-06T13:37:06.98Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5c/fa/6d7708d2cfc1a832acb6aeb0cd16e801902df8a0f583bb3b4b527fde022e/pydantic_core-2.46.4-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:0e96592440881c74a213e5ad528e2b24d3d4f940de2766bed9010ab1d9e51594", size = 2111872, upload-time = "2026-05-06T13:40:27.596Z" },
-    { url = "https://files.pythonhosted.org/packages/ae/6f/aa064a3e74b5745afbdf250594f38e7ead05e2d651bcb35994b9417a0d4d/pydantic_core-2.46.4-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:e0d65b8c354be7fb5f720c3caa8bc940bc2d20ce749c8e06135f07f8ed95dd7c", size = 1948255, upload-time = "2026-05-06T13:39:12.574Z" },
-    { url = "https://files.pythonhosted.org/packages/43/3a/41114a9f7569b84b4d84e7a018c57c56347dac30c0d4a872946ec4e36c46/pydantic_core-2.46.4-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7bfb192b3f4b9e8a89b6277b6ce787564f62cfd272055f6e685726b111dc7826", size = 1972827, upload-time = "2026-05-06T13:38:19.841Z" },
-    { url = "https://files.pythonhosted.org/packages/ef/25/1ab42e8048fe551934d9884e8d64daa7e990ad386f310a15981aeb6a5b08/pydantic_core-2.46.4-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:9037063db01f09b09e237c282b6792bd4da634b5402c4e7f0c61effed7701a04", size = 2041051, upload-time = "2026-05-06T13:38:10.447Z" },
-    { url = "https://files.pythonhosted.org/packages/94/c2/1a934597ddf08da410385b3b7aae91956a5a76c635effef456074fad7e88/pydantic_core-2.46.4-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:fc010ab034c8c7452522748bf937df58020d256ccae0874463d1f4d01758af8e", size = 2221314, upload-time = "2026-05-06T13:40:13.089Z" },
-    { url = "https://files.pythonhosted.org/packages/02/6d/9e8ad178c9c4df27ad3c8f25d1fe2a7ab0d2ba0559fad4aee5d3d1f16771/pydantic_core-2.46.4-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:8c5dac79fa1614d1e06ca695109c6105923bd9c7d1d6c918d4e637b7e6b32fd3", size = 2285146, upload-time = "2026-05-06T13:38:59.224Z" },
-    { url = "https://files.pythonhosted.org/packages/80/50/540cd3aeefc041beb111125c4bff779831a2111fc6b15a9138cda277d32c/pydantic_core-2.46.4-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f9fa868638bf362d3d138ea55829cefb3d5f4b0d7f142234382a15e2485dbec4", size = 2089685, upload-time = "2026-05-06T13:38:17.762Z" },
-    { url = "https://files.pythonhosted.org/packages/6b/a4/b440ad35f05f6a38f89fa0f149accb3f0e02be94ca5e15f3c449a61b4bc9/pydantic_core-2.46.4-cp311-cp311-manylinux_2_31_riscv64.whl", hash = "sha256:17299feefe090f2caa5b8e37222bb5f663e4935a8bfa6931d4102e5df1a9f398", size = 2115420, upload-time = "2026-05-06T13:37:58.195Z" },
-    { url = "https://files.pythonhosted.org/packages/99/61/de4f55db8dfd57bfdfa9a12ec90fe1b57c4f41062f7ca86f08586b3e0ac0/pydantic_core-2.46.4-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:4c63ebc82684aa89d9a3bcbd13d515b3be44250dc68dd3bd81526c1cb31286c3", size = 2165122, upload-time = "2026-05-06T13:37:01.167Z" },
-    { url = "https://files.pythonhosted.org/packages/f7/52/7c529d7bdb2d1068bd52f51fe32572c8301f9a4febf1948f10639f1436f5/pydantic_core-2.46.4-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:aaa2a54443eff1950ba5ddc6b6ccda0d9c84a364276a62f969bdf2a390650848", size = 2182573, upload-time = "2026-05-06T13:38:45.04Z" },
-    { url = "https://files.pythonhosted.org/packages/37/b3/7c40325848ba78247f2812dcf9c7274e38cd801820ca6dd9fe63bcfb0eb4/pydantic_core-2.46.4-cp311-cp311-musllinux_1_1_armv7l.whl", hash = "sha256:18e5ceec2ab67e6d5f1a9085e5a24c9c4e2ac4545730bfe668680bca05e555f3", size = 2317139, upload-time = "2026-05-06T13:37:15.539Z" },
-    { url = "https://files.pythonhosted.org/packages/d9/37/f913f81a657c865b75da6c0dbed79876073c2a43b5bd9edbe8da785e4d49/pydantic_core-2.46.4-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:a0f62d0a58f4e7da165457e995725421e0064f2255d8eccebc49f41bbc23b109", size = 2360433, upload-time = "2026-05-06T13:37:30.099Z" },
-    { url = "https://files.pythonhosted.org/packages/c4/67/6acaa1be2567f9256b056d8477158cac7240813956ce86e49deae8e173b4/pydantic_core-2.46.4-cp311-cp311-win32.whl", hash = "sha256:041bde0a48fd37cf71cab1c9d56d3e8625a3793fef1f7dd232b3ff37e978ecda", size = 1985513, upload-time = "2026-05-06T13:38:15.669Z" },
-    { url = "https://files.pythonhosted.org/packages/aa/e6/c505f83dfeda9a2e5c995cfd872949e4d05e12f7feb3dca72f633daefa94/pydantic_core-2.46.4-cp311-cp311-win_amd64.whl", hash = "sha256:6f2eeda33a839975441c86a4119e1383c50b47faf0cbb5176985565c6bb02c33", size = 2071114, upload-time = "2026-05-06T13:40:35.416Z" },
-    { url = "https://files.pythonhosted.org/packages/0f/da/7a263a96d965d9d0df5e8de8a475f33495451117035b09acb110288c381f/pydantic_core-2.46.4-cp311-cp311-win_arm64.whl", hash = "sha256:14f4c5d6db102bd796a627bbb3a17b4cf4574b9ae861d8b7c9a9661c6dd3362d", size = 2044298, upload-time = "2026-05-06T13:38:29.754Z" },
     { url = "https://files.pythonhosted.org/packages/ce/8c/af022f0af448d7747c5154288d46b5f2bc5f17366eaa0e23e9aa04d59f3b/pydantic_core-2.46.4-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:3245406455a5d98187ec35530fd772b1d799b26667980872c8d4614991e2c4a2", size = 2106158, upload-time = "2026-05-06T13:38:57.215Z" },
     { url = "https://files.pythonhosted.org/packages/19/95/6195171e385007300f0f5574592e467c568becce2d937a0b6804f218bc49/pydantic_core-2.46.4-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:962ccbab7b642487b1d8b7df90ef677e03134cf1fd8880bf698649b22a69371f", size = 1951724, upload-time = "2026-05-06T13:37:02.697Z" },
     { url = "https://files.pythonhosted.org/packages/8e/bc/f47d1ff9cbb1620e1b5b697eef06010035735f07820180e74178226b27b3/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8233f2947cf85404441fd7e0085f53b10c93e0ee78611099b5c7237e36aacbf7", size = 1975742, upload-time = "2026-05-06T13:37:09.448Z" },
@@ -1012,22 +3002,10 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/30/a6/9f9f380dbb301f67023bf8f707aaa75daadf84f7152d95c410fd7e81d994/pydantic_core-2.46.4-cp314-cp314t-win32.whl", hash = "sha256:e846ae7835bf0703ae43f534ab79a867146dadd59dc9ca5c8b53d5c8f7c9ef02", size = 1955575, upload-time = "2026-05-06T13:38:51.116Z" },
     { url = "https://files.pythonhosted.org/packages/40/1f/f1eb9eb350e795d1af8586289746f5c5677d16043040d63710e22abc43c9/pydantic_core-2.46.4-cp314-cp314t-win_amd64.whl", hash = "sha256:2108ba5c1c1eca18030634489dc544844144ee36357f2f9f780b93e7ddbb44b5", size = 2051624, upload-time = "2026-05-06T13:38:21.672Z" },
     { url = "https://files.pythonhosted.org/packages/f6/d2/42dd53d0a85c27606f316d3aa5d2869c4e8470a5ed6dec30e4a1abe19192/pydantic_core-2.46.4-cp314-cp314t-win_arm64.whl", hash = "sha256:4fcbe087dbc2068af7eda3aa87634eba216dbda64d1ae73c8684b621d33f6596", size = 2017325, upload-time = "2026-05-06T13:40:52.723Z" },
-    { url = "https://files.pythonhosted.org/packages/ee/a4/73995fd4ebbb46ba0ee51e6fa049b8f02c40daebb762208feda8a6b7894d/pydantic_core-2.46.4-graalpy311-graalpy242_311_native-macosx_10_12_x86_64.whl", hash = "sha256:14d4edf427bdcf950a8a02d7cb44a08614388dd6e1bdcbf4f67504fa7887da9c", size = 2111589, upload-time = "2026-05-06T13:37:10.817Z" },
-    { url = "https://files.pythonhosted.org/packages/fb/7f/f37d3a5e8bfcc2e403f5c57a730f2d815693fb42119e8ea48b3789335af1/pydantic_core-2.46.4-graalpy311-graalpy242_311_native-macosx_11_0_arm64.whl", hash = "sha256:0ce40cd7b21210e99342afafbd4d0f76d784eb5b1d60f3bdc566be4983c6c73b", size = 1944552, upload-time = "2026-05-06T13:36:56.717Z" },
-    { url = "https://files.pythonhosted.org/packages/15/3c/d7eb777b3ff43e8433a4efb39a17aa8fd98a4ee8561a24a67ef5db07b2d6/pydantic_core-2.46.4-graalpy311-graalpy242_311_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:90884113d8b48f760e9587002789ddd741e76ab9f89518cd1e43b1f1a52ec44b", size = 1982984, upload-time = "2026-05-06T13:39:06.207Z" },
-    { url = "https://files.pythonhosted.org/packages/63/87/70b9f40170a81afd55ca26c9b2acb25c20d64bcfbf888fafecb3ba077d4c/pydantic_core-2.46.4-graalpy311-graalpy242_311_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:66ce7632c22d837c95301830e111ad0128a32b8207533b60896a96c4915192ea", size = 2138417, upload-time = "2026-05-06T13:39:45.476Z" },
     { url = "https://files.pythonhosted.org/packages/9d/1d/8987ad40f65ae1432753072f214fb5c74fe47ffbd0698bb9cbbb585664f8/pydantic_core-2.46.4-graalpy312-graalpy250_312_native-macosx_10_12_x86_64.whl", hash = "sha256:1d8ba486450b14f3b1d63bc521d410ec7565e52f887b9fb671791886436a42f7", size = 2095527, upload-time = "2026-05-06T13:39:52.283Z" },
     { url = "https://files.pythonhosted.org/packages/64/d3/84c282a7eee1d3ac4c0377546ef5a1ea436ce26840d9ac3b7ed54a377507/pydantic_core-2.46.4-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:3009f12e4e90b7f88b4f9adb1b0c4a3d58fe7820f3238c190047209d148026df", size = 1936024, upload-time = "2026-05-06T13:40:15.671Z" },
     { url = "https://files.pythonhosted.org/packages/d7/ca/eac61596cdeb4d7e174d3dc0bd8a6238f14f75f97a24e7b7db4c7e7340a0/pydantic_core-2.46.4-graalpy312-graalpy250_312_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ad785e92e6dc634c21555edc8bd6b64957ab844541bcb96a1366c202951ae526", size = 1990696, upload-time = "2026-05-06T13:38:34.717Z" },
     { url = "https://files.pythonhosted.org/packages/fa/c3/7c8b240552251faf6b3a957db200fcfbbcec36763c050428b601e0c9b83b/pydantic_core-2.46.4-graalpy312-graalpy250_312_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:00c603d540afdd6b80eb39f078f33ebd46211f02f33e34a32d9f053bba711de0", size = 2147590, upload-time = "2026-05-06T13:39:29.883Z" },
-    { url = "https://files.pythonhosted.org/packages/11/cb/428de0385b6c8d44b716feba566abfacfbd23ee3c4439faa789a1456242f/pydantic_core-2.46.4-pp311-pypy311_pp73-macosx_10_12_x86_64.whl", hash = "sha256:0c563b08bca408dc7f65f700633d8442fffb2421fc47b8101377e9fd65051ff0", size = 2112782, upload-time = "2026-05-06T13:37:04.016Z" },
-    { url = "https://files.pythonhosted.org/packages/0b/b5/6a17bdadd0fc1f170adfd05a20d37c832f52b117b4d9131da1f41bb097ce/pydantic_core-2.46.4-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:db06ffe51636ffe9ca531fe9023dd64bdd794be8754cb5df57c5498ae5b518a7", size = 1952146, upload-time = "2026-05-06T13:39:43.092Z" },
-    { url = "https://files.pythonhosted.org/packages/2a/dc/03734d80e362cd43ef65428e9de77c730ce7f2f11c60d2b1e1b39f0fbf99/pydantic_core-2.46.4-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:133878133d271ade3d41d1bfb2a45ec38dbdbda40bc065921c6b04e4630127e2", size = 2134492, upload-time = "2026-05-06T13:36:58.124Z" },
-    { url = "https://files.pythonhosted.org/packages/de/df/5e5ffc085ed07cc22d298134d3d911c63e91f6a0eb91fe646750a3209910/pydantic_core-2.46.4-pp311-pypy311_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:9bc519fbf2b7578398853d815009ae5e4d4603d12f4e3f91da8c06852d3da3e9", size = 2156604, upload-time = "2026-05-06T13:37:49.88Z" },
-    { url = "https://files.pythonhosted.org/packages/81/44/6e112a4253e56f5705467cbab7ab5e91ee7398ba3d56d358635958893d3e/pydantic_core-2.46.4-pp311-pypy311_pp73-musllinux_1_1_aarch64.whl", hash = "sha256:c7a7bd4e39e8e4c12c39cd480356842b6a8a06e41b23a55a5e3e191718838ddf", size = 2183828, upload-time = "2026-05-06T13:37:43.053Z" },
-    { url = "https://files.pythonhosted.org/packages/ac/ad/5565071e937d8e752842ac241463944c9eb14c87e2d269f2658a5bd05e98/pydantic_core-2.46.4-pp311-pypy311_pp73-musllinux_1_1_armv7l.whl", hash = "sha256:d396ec2b979760aaf3218e76c24e65bd0aca24983298653b3a9d7a45f9e47b30", size = 2310000, upload-time = "2026-05-06T13:37:56.694Z" },
-    { url = "https://files.pythonhosted.org/packages/4f/c3/66883a5cec183e7fba4d024b4cbbe61851a63750ef606b0afecc46d1f2bf/pydantic_core-2.46.4-pp311-pypy311_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:86e1a4418c6cd97d60c95c71164158eaf7324fae7b0923264016baa993eba6fc", size = 2361286, upload-time = "2026-05-06T13:40:05.667Z" },
-    { url = "https://files.pythonhosted.org/packages/4b/2d/69abac8f838090bbecd5df894befb2c2619e7996a98ddb949db9f3b93225/pydantic_core-2.46.4-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:d51026d73fcfd93610abc7b27789c26b313920fcfb20e27462d74a7f8b06e983", size = 2193071, upload-time = "2026-05-06T13:38:08.682Z" },
 ]
 
 [[package]]
@@ -1068,6 +3046,2924 @@ crypto = [
 ]
 
 [[package]]
+name = "pyobjc"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-accessibility", marker = "platform_release >= '20.0'" },
+    { name = "pyobjc-framework-accounts", marker = "platform_release >= '12.0'" },
+    { name = "pyobjc-framework-addressbook" },
+    { name = "pyobjc-framework-adservices", marker = "platform_release >= '20.0'" },
+    { name = "pyobjc-framework-adsupport", marker = "platform_release >= '18.0'" },
+    { name = "pyobjc-framework-applescriptkit" },
+    { name = "pyobjc-framework-applescriptobjc", marker = "platform_release >= '10.0'" },
+    { name = "pyobjc-framework-applicationservices" },
+    { name = "pyobjc-framework-apptrackingtransparency", marker = "platform_release >= '20.0'" },
+    { name = "pyobjc-framework-arkit", marker = "platform_release >= '25.0'" },
+    { name = "pyobjc-framework-audiovideobridging", marker = "platform_release >= '12.0'" },
+    { name = "pyobjc-framework-authenticationservices", marker = "platform_release >= '19.0'" },
+    { name = "pyobjc-framework-automaticassessmentconfiguration", marker = "platform_release >= '19.0'" },
+    { name = "pyobjc-framework-automator" },
+    { name = "pyobjc-framework-avfoundation", marker = "platform_release >= '11.0'" },
+    { name = "pyobjc-framework-avkit", marker = "platform_release >= '13.0'" },
+    { name = "pyobjc-framework-avrouting", marker = "platform_release >= '22.0'" },
+    { name = "pyobjc-framework-backgroundassets", marker = "platform_release >= '22.0'" },
+    { name = "pyobjc-framework-browserenginekit", marker = "platform_release >= '23.4'" },
+    { name = "pyobjc-framework-businesschat", marker = "platform_release >= '18.0'" },
+    { name = "pyobjc-framework-calendarstore", marker = "platform_release >= '9.0'" },
+    { name = "pyobjc-framework-callkit", marker = "platform_release >= '20.0'" },
+    { name = "pyobjc-framework-carbon" },
+    { name = "pyobjc-framework-cfnetwork" },
+    { name = "pyobjc-framework-cinematic", marker = "platform_release >= '23.0'" },
+    { name = "pyobjc-framework-classkit", marker = "platform_release >= '20.0'" },
+    { name = "pyobjc-framework-cloudkit", marker = "platform_release >= '14.0'" },
+    { name = "pyobjc-framework-cocoa" },
+    { name = "pyobjc-framework-collaboration", marker = "platform_release >= '9.0'" },
+    { name = "pyobjc-framework-colorsync", marker = "platform_release >= '17.0'" },
+    { name = "pyobjc-framework-compositorservices", marker = "platform_release >= '25.0'" },
+    { name = "pyobjc-framework-contacts", marker = "platform_release >= '15.0'" },
+    { name = "pyobjc-framework-contactsui", marker = "platform_release >= '15.0'" },
+    { name = "pyobjc-framework-coreaudio" },
+    { name = "pyobjc-framework-coreaudiokit" },
+    { name = "pyobjc-framework-corebluetooth", marker = "platform_release >= '14.0'" },
+    { name = "pyobjc-framework-coredata" },
+    { name = "pyobjc-framework-corehaptics", marker = "platform_release >= '19.0'" },
+    { name = "pyobjc-framework-corelocation", marker = "platform_release >= '10.0'" },
+    { name = "pyobjc-framework-coremedia", marker = "platform_release >= '11.0'" },
+    { name = "pyobjc-framework-coremediaio", marker = "platform_release >= '11.0'" },
+    { name = "pyobjc-framework-coremidi" },
+    { name = "pyobjc-framework-coreml", marker = "platform_release >= '17.0'" },
+    { name = "pyobjc-framework-coremotion", marker = "platform_release >= '19.0'" },
+    { name = "pyobjc-framework-coreservices" },
+    { name = "pyobjc-framework-corespotlight", marker = "platform_release >= '17.0'" },
+    { name = "pyobjc-framework-coretext" },
+    { name = "pyobjc-framework-corewlan", marker = "platform_release >= '10.0'" },
+    { name = "pyobjc-framework-cryptotokenkit", marker = "platform_release >= '14.0'" },
+    { name = "pyobjc-framework-datadetection", marker = "platform_release >= '21.0'" },
+    { name = "pyobjc-framework-devicecheck", marker = "platform_release >= '19.0'" },
+    { name = "pyobjc-framework-devicediscoveryextension", marker = "platform_release >= '24.0'" },
+    { name = "pyobjc-framework-dictionaryservices", marker = "platform_release >= '9.0'" },
+    { name = "pyobjc-framework-discrecording" },
+    { name = "pyobjc-framework-discrecordingui" },
+    { name = "pyobjc-framework-diskarbitration" },
+    { name = "pyobjc-framework-dvdplayback" },
+    { name = "pyobjc-framework-eventkit", marker = "platform_release >= '12.0'" },
+    { name = "pyobjc-framework-exceptionhandling" },
+    { name = "pyobjc-framework-executionpolicy", marker = "platform_release >= '19.0'" },
+    { name = "pyobjc-framework-extensionkit", marker = "platform_release >= '22.0'" },
+    { name = "pyobjc-framework-externalaccessory", marker = "platform_release >= '17.0'" },
+    { name = "pyobjc-framework-fileprovider", marker = "platform_release >= '19.0'" },
+    { name = "pyobjc-framework-fileproviderui", marker = "platform_release >= '19.0'" },
+    { name = "pyobjc-framework-findersync", marker = "platform_release >= '14.0'" },
+    { name = "pyobjc-framework-fsevents", marker = "platform_release >= '9.0'" },
+    { name = "pyobjc-framework-fskit", marker = "platform_release >= '24.4'" },
+    { name = "pyobjc-framework-gamecenter", marker = "platform_release >= '12.0'" },
+    { name = "pyobjc-framework-gamecontroller", marker = "platform_release >= '13.0'" },
+    { name = "pyobjc-framework-gamekit", marker = "platform_release >= '12.0'" },
+    { name = "pyobjc-framework-gameplaykit", marker = "platform_release >= '15.0'" },
+    { name = "pyobjc-framework-gamesave", marker = "platform_release >= '25.0'" },
+    { name = "pyobjc-framework-healthkit", marker = "platform_release >= '22.0'" },
+    { name = "pyobjc-framework-imagecapturecore", marker = "platform_release >= '10.0'" },
+    { name = "pyobjc-framework-inputmethodkit", marker = "platform_release >= '9.0'" },
+    { name = "pyobjc-framework-installerplugins" },
+    { name = "pyobjc-framework-instantmessage", marker = "platform_release >= '9.0'" },
+    { name = "pyobjc-framework-intents", marker = "platform_release >= '16.0'" },
+    { name = "pyobjc-framework-intentsui", marker = "platform_release >= '21.0'" },
+    { name = "pyobjc-framework-iobluetooth" },
+    { name = "pyobjc-framework-iobluetoothui" },
+    { name = "pyobjc-framework-iosurface", marker = "platform_release >= '10.0'" },
+    { name = "pyobjc-framework-ituneslibrary", marker = "platform_release >= '10.0'" },
+    { name = "pyobjc-framework-kernelmanagement", marker = "platform_release >= '20.0'" },
+    { name = "pyobjc-framework-latentsemanticmapping" },
+    { name = "pyobjc-framework-launchservices" },
+    { name = "pyobjc-framework-libdispatch", marker = "platform_release >= '12.0'" },
+    { name = "pyobjc-framework-libxpc", marker = "platform_release >= '12.0'" },
+    { name = "pyobjc-framework-linkpresentation", marker = "platform_release >= '19.0'" },
+    { name = "pyobjc-framework-localauthentication", marker = "platform_release >= '14.0'" },
+    { name = "pyobjc-framework-localauthenticationembeddedui", marker = "platform_release >= '21.0'" },
+    { name = "pyobjc-framework-mailkit", marker = "platform_release >= '21.0'" },
+    { name = "pyobjc-framework-mapkit", marker = "platform_release >= '13.0'" },
+    { name = "pyobjc-framework-mediaaccessibility", marker = "platform_release >= '13.0'" },
+    { name = "pyobjc-framework-mediaextension", marker = "platform_release >= '24.0'" },
+    { name = "pyobjc-framework-medialibrary", marker = "platform_release >= '13.0'" },
+    { name = "pyobjc-framework-mediaplayer", marker = "platform_release >= '16.0'" },
+    { name = "pyobjc-framework-mediatoolbox", marker = "platform_release >= '13.0'" },
+    { name = "pyobjc-framework-metal", marker = "platform_release >= '15.0'" },
+    { name = "pyobjc-framework-metalfx", marker = "platform_release >= '22.0'" },
+    { name = "pyobjc-framework-metalkit", marker = "platform_release >= '15.0'" },
+    { name = "pyobjc-framework-metalperformanceshaders", marker = "platform_release >= '17.0'" },
+    { name = "pyobjc-framework-metalperformanceshadersgraph", marker = "platform_release >= '20.0'" },
+    { name = "pyobjc-framework-metrickit", marker = "platform_release >= '21.0'" },
+    { name = "pyobjc-framework-mlcompute", marker = "platform_release >= '20.0'" },
+    { name = "pyobjc-framework-modelio", marker = "platform_release >= '15.0'" },
+    { name = "pyobjc-framework-multipeerconnectivity", marker = "platform_release >= '14.0'" },
+    { name = "pyobjc-framework-naturallanguage", marker = "platform_release >= '18.0'" },
+    { name = "pyobjc-framework-netfs", marker = "platform_release >= '10.0'" },
+    { name = "pyobjc-framework-network", marker = "platform_release >= '18.0'" },
+    { name = "pyobjc-framework-networkextension", marker = "platform_release >= '15.0'" },
+    { name = "pyobjc-framework-notificationcenter", marker = "platform_release >= '14.0'" },
+    { name = "pyobjc-framework-opendirectory", marker = "platform_release >= '10.0'" },
+    { name = "pyobjc-framework-osakit" },
+    { name = "pyobjc-framework-oslog", marker = "platform_release >= '19.0'" },
+    { name = "pyobjc-framework-passkit", marker = "platform_release >= '20.0'" },
+    { name = "pyobjc-framework-pencilkit", marker = "platform_release >= '19.0'" },
+    { name = "pyobjc-framework-phase", marker = "platform_release >= '21.0'" },
+    { name = "pyobjc-framework-photos", marker = "platform_release >= '15.0'" },
+    { name = "pyobjc-framework-photosui", marker = "platform_release >= '15.0'" },
+    { name = "pyobjc-framework-preferencepanes" },
+    { name = "pyobjc-framework-pushkit", marker = "platform_release >= '19.0'" },
+    { name = "pyobjc-framework-quartz" },
+    { name = "pyobjc-framework-quicklookthumbnailing", marker = "platform_release >= '19.0'" },
+    { name = "pyobjc-framework-replaykit", marker = "platform_release >= '20.0'" },
+    { name = "pyobjc-framework-safariservices", marker = "platform_release >= '16.0'" },
+    { name = "pyobjc-framework-safetykit", marker = "platform_release >= '22.0'" },
+    { name = "pyobjc-framework-scenekit", marker = "platform_release >= '11.0'" },
+    { name = "pyobjc-framework-screencapturekit", marker = "platform_release >= '21.4'" },
+    { name = "pyobjc-framework-screensaver" },
+    { name = "pyobjc-framework-screentime", marker = "platform_release >= '20.0'" },
+    { name = "pyobjc-framework-scriptingbridge", marker = "platform_release >= '9.0'" },
+    { name = "pyobjc-framework-searchkit" },
+    { name = "pyobjc-framework-security" },
+    { name = "pyobjc-framework-securityfoundation" },
+    { name = "pyobjc-framework-securityinterface" },
+    { name = "pyobjc-framework-securityui", marker = "platform_release >= '24.4'" },
+    { name = "pyobjc-framework-sensitivecontentanalysis", marker = "platform_release >= '23.0'" },
+    { name = "pyobjc-framework-servicemanagement", marker = "platform_release >= '10.0'" },
+    { name = "pyobjc-framework-sharedwithyou", marker = "platform_release >= '22.0'" },
+    { name = "pyobjc-framework-sharedwithyoucore", marker = "platform_release >= '22.0'" },
+    { name = "pyobjc-framework-shazamkit", marker = "platform_release >= '21.0'" },
+    { name = "pyobjc-framework-social", marker = "platform_release >= '12.0'" },
+    { name = "pyobjc-framework-soundanalysis", marker = "platform_release >= '19.0'" },
+    { name = "pyobjc-framework-speech", marker = "platform_release >= '19.0'" },
+    { name = "pyobjc-framework-spritekit", marker = "platform_release >= '13.0'" },
+    { name = "pyobjc-framework-storekit", marker = "platform_release >= '11.0'" },
+    { name = "pyobjc-framework-symbols", marker = "platform_release >= '23.0'" },
+    { name = "pyobjc-framework-syncservices" },
+    { name = "pyobjc-framework-systemconfiguration" },
+    { name = "pyobjc-framework-systemextensions", marker = "platform_release >= '19.0'" },
+    { name = "pyobjc-framework-threadnetwork", marker = "platform_release >= '22.0'" },
+    { name = "pyobjc-framework-uniformtypeidentifiers", marker = "platform_release >= '20.0'" },
+    { name = "pyobjc-framework-usernotifications", marker = "platform_release >= '18.0'" },
+    { name = "pyobjc-framework-usernotificationsui", marker = "platform_release >= '20.0'" },
+    { name = "pyobjc-framework-videosubscriberaccount", marker = "platform_release >= '18.0'" },
+    { name = "pyobjc-framework-videotoolbox", marker = "platform_release >= '12.0'" },
+    { name = "pyobjc-framework-virtualization", marker = "platform_release >= '20.0'" },
+    { name = "pyobjc-framework-vision", marker = "platform_release >= '17.0'" },
+    { name = "pyobjc-framework-webkit" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/00/09/68336c2ed662cecc8dc71e3bdcde2666430f3eb981cbd86661e7aa260cab/pyobjc-12.2.tar.gz", hash = "sha256:7074dcb0999e611e456b12cf94b7289cf6327094359b2c21c5ae593048b909bf", size = 11841, upload-time = "2026-05-30T12:28:53.751Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bf/25/f988de6a2028550fbd79f386938c4d99ac0f6b7652ad212cd8b74654924c/pyobjc-12.2-py3-none-any.whl", hash = "sha256:f3b0d4cdb7d0be242a37ff27c9f0b3ef182fe8ebdbac6ae0c40ef87539fe7d77", size = 4225, upload-time = "2026-05-30T09:44:22.344Z" },
+]
+
+[[package]]
+name = "pyobjc-core"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2a/e8/a6cc12669211e7c9b29e8f26bf2159e67c7a73555dc229018abf46d8167a/pyobjc_core-12.2.tar.gz", hash = "sha256:51d7de4cfa32f508c6a7aac31f131b12d5e196a8dcf588e6e8d7e6337224f66d", size = 1062064, upload-time = "2026-05-30T12:29:55.417Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/24/be/4771f4fd786f0e1a2bd6d8931a72a5f3929b7bb1b28a1fe6ca8a08371c55/pyobjc_core-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:7677ed758a367bbbb5589d6f5276fb360a45c89168276c26162f61840b0fa03d", size = 6421145, upload-time = "2026-05-30T10:17:41.992Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/ed/6e62d038992bc7ef9091d95ec97c3c221686fe52a993a6501e961c757613/pyobjc_core-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:9287c7c46d6ae8676b4c6c0389a8f4b5381f42ae53a47151900c08b157e5a992", size = 6428611, upload-time = "2026-05-30T10:21:33.83Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/0b/d492110202f4d1050a5e590620ebd1e730cf89f9880a26cf18205e0f5800/pyobjc_core-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:515ecf2afe168301feb66a7230d700584ce2e4b8a0ac178e19450b8898384139", size = 6677992, upload-time = "2026-05-30T10:44:13.039Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/b2/ecfbd0c80e7688ed6f3db23414758443c69c3a9d318f2036e26530ede955/pyobjc_core-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:a51352e478785cd7fce1604b9902125a286139caea0759cb340e59d75b594992", size = 6421372, upload-time = "2026-05-30T10:47:27.907Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/89/ecd5cb62573fba9a95f8bdb838a9860a360907104a0724af6611d3b20512/pyobjc_core-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:3137b2d14f9f2154fb5b1c092c38d15e164f68ab190c18335d76e4e7e1583f79", size = 6676789, upload-time = "2026-05-30T10:59:33.811Z" },
+    { url = "https://files.pythonhosted.org/packages/74/24/5091d156b19df0f657127f42b08eada11c9b9cc5df49fedb91bb354d9821/pyobjc_core-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:1e4216f2ec962dc13cf7f31b9bc3a7190337a0f401e7dc9de6b2d8c08b9dbb7a", size = 6476112, upload-time = "2026-05-30T11:21:46.914Z" },
+    { url = "https://files.pythonhosted.org/packages/77/e2/ee91ea8a0ad28e759f351ed8654027c34fc62ad5e207672522025a6a3fc2/pyobjc_core-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:ac952bac8057dd0b97ee7b311c39f97cad7430b7cfbd67ca0a30135a7d17d2ab", size = 6718365, upload-time = "2026-05-30T11:51:47.35Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-accessibility"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+    { name = "pyobjc-framework-quartz" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/76/31/ddc59bea6388a37461e919f25d2120bd93df0b30f552c606fab2804c52c3/pyobjc_framework_accessibility-12.2.tar.gz", hash = "sha256:86f82cc21db65c73c72ae93b7536381f1e12a1c89d4c554a216217dacdf60bb3", size = 34357, upload-time = "2026-05-30T12:29:58.741Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/45/6c/dc7cf2eca4239e69942d68ab16b5708707975548a197f081c8fdc3445262/pyobjc_framework_accessibility-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:4c2e2965bf539e356ccb92aa3ea4e9fc764629e5fa7d5a9c52387970ee021038", size = 11545, upload-time = "2026-05-30T11:51:53.936Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/1d/d13365b48fc989b5217ef94facec719f7c7ab2878e573462cf822095cb3b/pyobjc_framework_accessibility-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:e60d910261d018770722ad0987291e94229e09aef0e919073c87a30cf677686d", size = 11564, upload-time = "2026-05-30T11:51:55.545Z" },
+    { url = "https://files.pythonhosted.org/packages/28/22/2f3ebe592655f5106a072cf1f1fe331f7c9ba06b24ac8e3dcdc9e9294d03/pyobjc_framework_accessibility-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:535a3e2ccb36e707dd72ed54f7f1772ef41526cebe6fe52acc081d45a10ede15", size = 11732, upload-time = "2026-05-30T11:51:57.41Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/68/898391808390d55e38d97ba9bf975e5cd9f64692c051d290ee8f366269cf/pyobjc_framework_accessibility-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:a6b1bcadaee86389775288a2f44658fa6a5b150ecb8bd3ff694ed9a0c2a62e7d", size = 11626, upload-time = "2026-05-30T11:51:59.164Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/1e/070f0260e49efdf2e96b805efc6a5b03f7f0e7d85f9f07aaa6c8660c7869/pyobjc_framework_accessibility-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:3c52e73046cc32830ddc494d10ce76292c13f8f16b1e8dd96af3e9a972755e23", size = 11809, upload-time = "2026-05-30T11:52:01.081Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/b2/8fdcf94b5f25b6b8410ab3ae5106b6edadbc6131ce133cc8be76f4f7a8b3/pyobjc_framework_accessibility-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:4a998d5fa8bfa43de83554187cee3ef3db2c2b144d5799eac5852266c1d1fa7c", size = 11615, upload-time = "2026-05-30T11:52:02.811Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/3d/a4908231fbf37ff60cafd7c66cc080ba1c3265090810e2a416ecf5dc8444/pyobjc_framework_accessibility-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:76495fbe29ad10051cfd66d1f9e54283a82b22e70b0a25ee6481f8f7e0de5b9d", size = 11805, upload-time = "2026-05-30T11:52:04.54Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-accounts"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d3/ec/aea64ed95dda48f2c1a049c638be39822f731e79ef9fb4202dd2b3d87b86/pyobjc_framework_accounts-12.2.tar.gz", hash = "sha256:823b61e3ed964efde365e6c83b605692f72cb7f7e0782dafea674f2de8e3f8ed", size = 16208, upload-time = "2026-05-30T12:30:00.949Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b2/fa/61661645bdc59e6aa9c92791731d688c76b84260362849f8c768e48558ea/pyobjc_framework_accounts-12.2-py2.py3-none-any.whl", hash = "sha256:a1638b7758e6371f59e7ea9f912922530062ce9640a0f1d1e66a0702bff7f8e3", size = 5104, upload-time = "2026-05-30T11:52:05.957Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-addressbook"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ba/03/76bd426954723343854c2f4da82bbcd61048eccce31c00381dbfb7677c85/pyobjc_framework_addressbook-12.2.tar.gz", hash = "sha256:5f763983c1c32e70f7b742e35a025530be4bf6742ff4ac98f71ab0bfeb5cf9bd", size = 47681, upload-time = "2026-05-30T12:30:04.791Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/17/f0/0eefbd03448706f71580ea82254cb72a0aff70d6df6fc49e2e6ad915fa56/pyobjc_framework_addressbook-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:9cdafcbad3d9e145a32390dd026bf27da3be1aadf337c3d56c08ee4a791755a6", size = 12805, upload-time = "2026-05-30T11:52:11.851Z" },
+    { url = "https://files.pythonhosted.org/packages/81/bc/d3afc72e56b2e49580ada60dff250669f2b80ee1e2c59bdd3e577f32d0cd/pyobjc_framework_addressbook-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:37dbd5a712c2ff71ec80cc5a86d96c98b1d5e26eb2c7bc4d251f84eb1a3c8893", size = 12826, upload-time = "2026-05-30T11:52:13.667Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/a6/9d0a9433e3b76ee9e6d728d463377d1833389450315a6122342e4d42c5c1/pyobjc_framework_addressbook-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:899b19c7c2c4a8ee7020a20022a8c64daf86dccd163da03a41bbd585565d18ed", size = 12981, upload-time = "2026-05-30T11:52:15.771Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/2d/4bbd5dc76233c3c1ad4529536b3c47fd7c20faaa88a915f509baaea1050c/pyobjc_framework_addressbook-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:6ea77ba8de1ffa9a05836081bd36ec3828cadc0215f1fcd64446b80228e69775", size = 12886, upload-time = "2026-05-30T11:52:17.742Z" },
+    { url = "https://files.pythonhosted.org/packages/95/79/f76414b5643f3828fa8e03c6f2cb91307c27785f930a02a37ca0299e522a/pyobjc_framework_addressbook-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:76839a5441cdbecf3b0984d83385a80e926f38234f98063af297b646fe9dc658", size = 13043, upload-time = "2026-05-30T11:52:19.566Z" },
+    { url = "https://files.pythonhosted.org/packages/95/dc/9d748ad57fde50831b59704c13f82cf658869d6f8de428455f127a49324b/pyobjc_framework_addressbook-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:155f285e181a8b4c72dcc559a044c8a2c2af5271ab5926356ad67daa5a0600ca", size = 12877, upload-time = "2026-05-30T11:52:21.45Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/20/c03dc03da793fbdbf3bf381979c1301b66642cdc43a42ac768715283c2f1/pyobjc_framework_addressbook-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:b0b3c2e00500d4ee3ebb62df367473cc8c92b1ece7b4ad65384e1ac56d6a7c68", size = 13042, upload-time = "2026-05-30T11:52:23.251Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-adservices"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/04/05/fb43d284efe7e48b43abe2507f79b91a4c9ebce4f76c552fc228b647c0b9/pyobjc_framework_adservices-12.2.tar.gz", hash = "sha256:77a3cf0acdf5e83c29c26be60a63e35a31ad5076ac60188a52268fe53de7cee0", size = 12249, upload-time = "2026-05-30T12:30:06.574Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/53/2b/230ad0f52e7f960a560afbae80dacdfc831a01a3507989e1ee41755ab793/pyobjc_framework_adservices-12.2-py2.py3-none-any.whl", hash = "sha256:7c1b1f78689f66fa724c23fd20dac56e8ea3190e868d9859d08294a58e26cb33", size = 3485, upload-time = "2026-05-30T11:52:24.532Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-adsupport"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9e/6d/6041af76d08da1ddae42804dfff3b5fb0fb27c2da8eb7a1a04ece4532e46/pyobjc_framework_adsupport-12.2.tar.gz", hash = "sha256:fe8e730c102a6579fe905b20e497423a080fd1f6a75eabf7356d2394467f64a4", size = 12112, upload-time = "2026-05-30T12:30:08.196Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/29/b7/956f2d841a8709ab7cae6726dcd953a54650768f9b78cf9821fb732c6cca/pyobjc_framework_adsupport-12.2-py2.py3-none-any.whl", hash = "sha256:39ca7e3c336c32c5d9d5780eba7606f4d53034bb53bc7b55c8a5a2e430ad7c66", size = 3402, upload-time = "2026-05-30T11:52:25.922Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-applescriptkit"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/92/e8/1af0305da68a6923d269806f6f60b900e473b3ac03279a8614d71e224592/pyobjc_framework_applescriptkit-12.2.tar.gz", hash = "sha256:1e1f91966b42f902d954a570a2aab8a4e24af465833525863e30c8a5b47ee4f1", size = 11690, upload-time = "2026-05-30T12:30:09.765Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/45/2b/3abd0d61208205b5617590e6c9cc35f744a41a2bdb81b5e18eba7810b9ae/pyobjc_framework_applescriptkit-12.2-py2.py3-none-any.whl", hash = "sha256:4b2a2f02e159c3c13834c3a605c1445563592f41d57ef6cdca2bd39e6409270d", size = 4352, upload-time = "2026-05-30T11:52:27.452Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-applescriptobjc"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/86/bc/4bcbb2fdae7a4526432619ec9a15fb7ee8ef22358be422e7b3c23c280f6f/pyobjc_framework_applescriptobjc-12.2.tar.gz", hash = "sha256:118abccae98c0af67e7c850058e4651748256eba52da382a2cd58e0e7c74418e", size = 11787, upload-time = "2026-05-30T12:30:11.487Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6b/a8/bb375c57509a1553e5ee51758caad3f946a98180577680b33a509f65bd9f/pyobjc_framework_applescriptobjc-12.2-py2.py3-none-any.whl", hash = "sha256:0a3019b16959dd8bef9fb581894901e89e027fa0b8b21b8515deda13a3cd9b34", size = 4452, upload-time = "2026-05-30T11:52:28.996Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-applicationservices"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+    { name = "pyobjc-framework-coretext" },
+    { name = "pyobjc-framework-quartz" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a9/ab/1776ac62687cb3d81e59517ca55970f26efa5a96bbf3ebcea57afcdd6b06/pyobjc_framework_applicationservices-12.2.tar.gz", hash = "sha256:4f6c4027405f709872e5b098f3cd86961bdf262fb80679a548725a02171bb0cf", size = 109325, upload-time = "2026-05-30T12:30:18.7Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b8/e4/0c7c5a48f88ab7510365559facf060f7c059dd4d5e39571d07d96a2b84a8/pyobjc_framework_applicationservices-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:36a03ae7168657379e3ad96397f3ebb15e6c617b96901a919c7610ce2de0007a", size = 32736, upload-time = "2026-05-30T11:52:38.386Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/28/8c85ef2dff09fb4c6adf2161bf1d32ff81dca497863682ba46107e38bbb9/pyobjc_framework_applicationservices-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:7119c75ad2c0e21b0bd44865641944e691e80abce0d5805fa344730238b16b15", size = 32754, upload-time = "2026-05-30T11:52:41.299Z" },
+    { url = "https://files.pythonhosted.org/packages/61/ee/4be28e61319055092d3a963514c2fb4daba86785d4044f073a4135273bb0/pyobjc_framework_applicationservices-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:0492c478b175005f38c887523f895382a9ed47c0810ab786c6712d3fda245832", size = 33017, upload-time = "2026-05-30T11:52:44.534Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/60/43c4e2697971bb9ec7766d6fe00861ef2055f3fa7d733c407676fcd5cbac/pyobjc_framework_applicationservices-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:d157ace1d768665f180cf9711fb31ddb29006e5df545e7e3ebf2be5054c6170d", size = 32896, upload-time = "2026-05-30T11:52:47.456Z" },
+    { url = "https://files.pythonhosted.org/packages/03/12/4f0662012b77b9c15afb6c52fa92e069d2a6793dcfcd9864bfef4c7d3c4b/pyobjc_framework_applicationservices-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:9be6f6866f532fca35f7d62f27f43df6a95c8b195030d44b9d68ed63ecb1e1f0", size = 33135, upload-time = "2026-05-30T11:52:50.587Z" },
+    { url = "https://files.pythonhosted.org/packages/36/9d/91c93ad58e6b52035da745c2ddcbb32018a03091d9f139e077f53089a002/pyobjc_framework_applicationservices-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:01afa4ef373edc58cd3fa55f5fe5d7db5dda22b8e6ff65f743a509180149dab7", size = 32888, upload-time = "2026-05-30T11:52:53.487Z" },
+    { url = "https://files.pythonhosted.org/packages/33/f5/c25b153ea0be05a749915bc45b4f9d85e7d84d2fbafc81efe68cae29540e/pyobjc_framework_applicationservices-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:8e14e97fc6bbedc95479f7b408f00e3b4aaaafafc23f9e2a955210beca15b474", size = 33128, upload-time = "2026-05-30T11:52:56.477Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-apptrackingtransparency"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c6/08/28b67c30aae6b1d870aac62ef63e7f518f3507a5c8c34378ca2cd89d2f7d/pyobjc_framework_apptrackingtransparency-12.2.tar.gz", hash = "sha256:7887b9c574c8a4edafbf8e34649a77ea91aab93dcf92b22e272ab01341d9e404", size = 12778, upload-time = "2026-05-30T12:30:20.58Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3a/65/1a2b950fb8c7c98ee6ab894e5466094039846ff10986ceb04d4c29ce3118/pyobjc_framework_apptrackingtransparency-12.2-py2.py3-none-any.whl", hash = "sha256:f0b51c30dc8c32882aa88e891ec13e52a0b339a3bb52ab7eed162a9640b76b4a", size = 3905, upload-time = "2026-05-30T11:52:57.929Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-arkit"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/2b/27/94cce926f3a8d95050bcfa14b1fe4e6d45ff86b93f3aa53f336a9eb3e5b6/pyobjc_framework_arkit-12.2.tar.gz", hash = "sha256:48f7241f07c03a5caad05b8998ee23210f9fd2395be69b635fdcd41d11329cf3", size = 40141, upload-time = "2026-05-30T12:30:23.719Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/83/cf/7fc4248af3c7ef766137ffa831dbe999efeaef48df108e62d35099aa6b5e/pyobjc_framework_arkit-12.2-py2.py3-none-any.whl", hash = "sha256:6a8065f5e49c6efddfa9250f14845b5a5fc0cada5444a87d1f96fcf72ac71f19", size = 8305, upload-time = "2026-05-30T11:52:59.499Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-audiovideobridging"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e3/cb/4e941fbd2e199b92accbee50839a7841dee74d63d6b199c0d37e7df0e40c/pyobjc_framework_audiovideobridging-12.2.tar.gz", hash = "sha256:7019abd29ab7b232618a5ab7135670e6f1e15744167b8d4f841133893914ebf5", size = 44219, upload-time = "2026-05-30T12:30:27.156Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9e/82/41160cab1bf637d7b5f7a048dd79d78a72971b2be7556d9071cbac47e51c/pyobjc_framework_audiovideobridging-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:7d97571f76a0da68a30b2cf717b4b200d26dfcbad73a040c3c86b4b0ef341c3a", size = 11060, upload-time = "2026-05-30T11:53:05.296Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/d0/146911872702f1e2e25fd3274d29e796ace042d863f076947344158ffbca/pyobjc_framework_audiovideobridging-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:7b07278a182e177f0e6417d8252df6ad6b885e17d6b7d09965d35510983bf9c6", size = 11074, upload-time = "2026-05-30T11:53:07.266Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/48/3f73eba1e79e0eea83fe8504f64fe62688178c51ea6ec4b1f90aabeeaf3c/pyobjc_framework_audiovideobridging-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:46e962bda54b81fa0e84bd58ccd0284ee680689891c04b869542bdcbb7c3870e", size = 11249, upload-time = "2026-05-30T11:53:09.207Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/75/2aa2210ee0892a2076c58918f9ee53f5c9f62fd5f9b70b4a2e5a56384a1a/pyobjc_framework_audiovideobridging-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:d439e659e732b5da958543a2979a7c518374aa2fa2009dccc5bc823043e0f647", size = 11132, upload-time = "2026-05-30T11:53:10.755Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/11/5ce0c697668f3df9aa56c748180e52e0cf93c63cac9622f981751e882ed9/pyobjc_framework_audiovideobridging-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:f11f209a1fe86c82ffe0e9dcb5ac22a1c1ccc5ea1133e2dbd43d93218969b4a3", size = 11311, upload-time = "2026-05-30T11:53:12.436Z" },
+    { url = "https://files.pythonhosted.org/packages/16/01/f1e8ec87cfcded57e1ad86d2a6e369cb39ba5bcb64878813dbf2acda9d0b/pyobjc_framework_audiovideobridging-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:98986494aee8c8e70b92757fd3e159ca1a9bbe049062a481ff11bd60ec6ee0b0", size = 11131, upload-time = "2026-05-30T11:53:14.193Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/ec/8cd87e9f4b74cf52332269dca22bd34c9db94ec50c6f1f240eef43ace4eb/pyobjc_framework_audiovideobridging-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:b85588556c9987e64f458eb7beb99773f7b854a804ffe025c492f8eb04f996a6", size = 11309, upload-time = "2026-05-30T11:53:15.883Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-authenticationservices"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/93/a6/973aca6e96097cf2121027b09720d6e564d381c8f024ae0ebb67939d184b/pyobjc_framework_authenticationservices-12.2.tar.gz", hash = "sha256:c99c11082d5ac6c454d729142709552b10e385d99e34d8e631bedca1886c8b78", size = 75719, upload-time = "2026-05-30T12:30:32.521Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3e/c9/6f1a312a3d5705ae3bd20660b19b1fb1fa8e8b8bd80d5df1c6e6f7fb7df1/pyobjc_framework_authenticationservices-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:011e44ad3a42e3f27381f733931677106189c3979841ff8f2b097b1fc1ab6cf1", size = 21360, upload-time = "2026-05-30T11:53:23.218Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/ef/4cd4e3648d0187aa06de7146eb7597a2ace07fe5007dab0d99d5565c1175/pyobjc_framework_authenticationservices-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:98e3b27b9033bb21e12efe89700d0d4cc1b72a90a98ded4d19c3af7edcf8eb50", size = 21376, upload-time = "2026-05-30T11:53:25.564Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/ba/b1b41b65dcd3ee357fc3716e5f241ead2da57c9a8984b6a7b8c71f160d3e/pyobjc_framework_authenticationservices-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:0a0e966a24d0c1b9a8c6c94751c05e2cd4f4a47a06ec53822aa626677f52959b", size = 21620, upload-time = "2026-05-30T11:53:27.891Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/95/bfec54f879d12fb78a035923f9d26e08d7d16fd03a8f3c9d2ca56223525b/pyobjc_framework_authenticationservices-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:62b4fd6303ff3476637d006b4dfef0814f6e163693901f6e66b4d2102f9febf7", size = 21377, upload-time = "2026-05-30T11:53:30.272Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/e5/f52075b41a5e89fe9b5b472ce0d22975081ee3b6ccd141ff9f6394157864/pyobjc_framework_authenticationservices-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:b9efe881067d2201fbaae49fcf8df6c032e571f43921c262719f2c37c03b9d63", size = 21651, upload-time = "2026-05-30T11:53:32.539Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/09/623d86fa7a7cafda9b441e2fe1660b431172fc7a209f7bc0992f36737f2e/pyobjc_framework_authenticationservices-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:d081e3b816db301582cb516a252ac83ec0c686ea00b5011c12e42d73fa871dd5", size = 21376, upload-time = "2026-05-30T11:53:35.031Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/d4/16086f609041d5894450f2cbd64521439a16608b2d063cf368afda2537f8/pyobjc_framework_authenticationservices-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:bab948aaec62be6351712c32c56647e678add6313d07c7cac3277c222ead5e65", size = 21659, upload-time = "2026-05-30T11:53:37.524Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-automaticassessmentconfiguration"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/2f/6c/1bb82a3487454624071fe1ba5d75e005dfd82770d1472a1cbb78e4508316/pyobjc_framework_automaticassessmentconfiguration-12.2.tar.gz", hash = "sha256:dbd96b6085cc9da3f5115d418b2e052a5807a8964e49422c0d7bf7196499f78c", size = 24753, upload-time = "2026-05-30T12:30:34.91Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dd/3b/0c5344819de9ef7267fff2c773649b5d3c988207edcb74cc4399795dac3b/pyobjc_framework_automaticassessmentconfiguration-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:79076241d12df1c60d52ff9ef554f201eb010ab3d9d244ea5d015b628ef2b735", size = 9358, upload-time = "2026-05-30T11:53:42.562Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/d9/7b56f64006c83a65b38e7b58d0a2d3d499f8633d066617c5c0e1ac338970/pyobjc_framework_automaticassessmentconfiguration-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:a045df9bf1224d30727db4af8ceabc2f227356e494e93db69b4abc058b4e4edf", size = 9368, upload-time = "2026-05-30T11:53:44.189Z" },
+    { url = "https://files.pythonhosted.org/packages/98/82/1846574b7a414d29f0d81344be71a25f4d18ec5e02ad1fcf1db7c2af68c4/pyobjc_framework_automaticassessmentconfiguration-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:052e81f7a83ddb45ce5c4aeb01dc57f3cc42a5496e6117eb4174d195a2c45752", size = 9522, upload-time = "2026-05-30T11:53:45.772Z" },
+    { url = "https://files.pythonhosted.org/packages/78/80/05090a15011ad969ac8ee5565a77980b4cc35dfdfa8bd69b0ac714ffd4f2/pyobjc_framework_automaticassessmentconfiguration-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:3157826b9a7325433635cec279724c995f93dc09a64a46acc7ec26b25b9cd7c4", size = 9418, upload-time = "2026-05-30T11:53:47.32Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/bb/c84d56a921110a5f1bc2ae6d09af79eabdead30b1992a86f683a9c6f12d9/pyobjc_framework_automaticassessmentconfiguration-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:c9c5f31eb76405d74e0cdac56d8a6bc1cf2785a3a1121c91e49e852de7bbbe45", size = 9568, upload-time = "2026-05-30T11:53:48.919Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/11/dc4e0ff6a968e28354f1d5267e60b4ddd9026e9feb2f86ed9ad113d1e525/pyobjc_framework_automaticassessmentconfiguration-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:d7c8bd3537ebe74153c9d9eb1d883be44788d1116757265b7108e3dbaf48b19b", size = 9425, upload-time = "2026-05-30T11:53:50.467Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/ce/4d931993b0dafcc776d685a5566eafc8111684c9d3762cd01d420f7a23f9/pyobjc_framework_automaticassessmentconfiguration-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:793954d0a7b2d28fd21c509a897dbd78fa42433cf5f00c09091c143023659775", size = 9570, upload-time = "2026-05-30T11:53:52.047Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-automator"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a9/3f/65daacfdd38b6936cebae9c27f25b5bcb97e4de813488caaa066c80013a7/pyobjc_framework_automator-12.2.tar.gz", hash = "sha256:bf38231f0ad38115473e853e6419c5d0511f4fe6dd904ea380160da91cf27bea", size = 188951, upload-time = "2026-05-30T12:30:46.654Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8d/2b/7423f651934d5cdf44e8cc8b3a544530de173906766bb005c110ef91abbc/pyobjc_framework_automator-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:e91a72760b9e23af2e7d2848deba25e76d05d8104f7aef85cc9d955aba4bf8f3", size = 10035, upload-time = "2026-05-30T11:53:56.937Z" },
+    { url = "https://files.pythonhosted.org/packages/16/56/1749bf5de1f138f68bfd498b639a480e06ac9b108c5e50a68cdf58379175/pyobjc_framework_automator-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:949f2d403d4d6d753122fa8ece9f9fd417b8b4afe6b65f64879259a03ca6f59e", size = 10056, upload-time = "2026-05-30T11:53:58.669Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/2f/de880591ffa058c8456157f5d618d5950ab8788b7f1e8f81d62ab8afe0d7/pyobjc_framework_automator-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:038ece9097bc9441554d48dac051bf445ed5496d4ced03962c5dca2ea46cfd29", size = 10201, upload-time = "2026-05-30T11:54:00.341Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/40/6db933f50cbeec6c5665c38d5442d9ed0cea59981d6295e0cb4a25d04331/pyobjc_framework_automator-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:349b7d02f898bf16edbadf5212758d5bac89440de9bd00edfd28c302bef8bf1e", size = 10100, upload-time = "2026-05-30T11:54:02.072Z" },
+    { url = "https://files.pythonhosted.org/packages/69/1b/ecc8113beb74c41a26336485030d127ebf6232c22c7e6e14ba9e99903b7a/pyobjc_framework_automator-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:b62fa84bdf975e7c74973b37de491846fd7373eafdf5ec048d52a66b1cc24e8b", size = 10245, upload-time = "2026-05-30T11:54:03.664Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/d1/ec4ff07ee7f1ea0f3b74b1f4d91113adb79e6a77a78b00f145cf92e35b83/pyobjc_framework_automator-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:c1e1f2f64a6aa9b5d4d30db3794957d7d9d51a3d3e8c3563d0362ad10add5e83", size = 10091, upload-time = "2026-05-30T11:54:05.308Z" },
+    { url = "https://files.pythonhosted.org/packages/29/df/462ce3c16015fb1927c0b3b7a6f1a6f070ec7a4d5b0f0f270d0dbdddf6d7/pyobjc_framework_automator-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:86e9dfa9290909e999cd86686a4f7cf8f437a6c218d03dc244fea7b84cbd80b8", size = 10241, upload-time = "2026-05-30T11:54:07.731Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-avfoundation"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+    { name = "pyobjc-framework-coreaudio" },
+    { name = "pyobjc-framework-coremedia" },
+    { name = "pyobjc-framework-quartz" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f5/d4/88d226694f8e598138fbc26808bb2d3a0637500691e42d15c64f3a8c1258/pyobjc_framework_avfoundation-12.2.tar.gz", hash = "sha256:d06443acf26f3f3e16e8a9bfad42db900af3b8c3ca34c5676343d2f8e001f56b", size = 410281, upload-time = "2026-05-30T12:31:11.224Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cf/0b/491ec7a65d9b6301a8a55a1607bb9079afc18946bb6c87944d51781b5e70/pyobjc_framework_avfoundation-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:593d2ec35f6799d9011f414247570457d8eaa68a1ce1381b4df2ab1daec509f5", size = 85570, upload-time = "2026-05-30T11:54:25.89Z" },
+    { url = "https://files.pythonhosted.org/packages/42/f5/54bcdd1543663f7e90560adc2ea4daf2ed6bd7ab92f734816cec79cd2244/pyobjc_framework_avfoundation-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:67320d3c7cb0fe1caf019d29eea38e39ede81458e3f4c13c5483892dc66f3b3a", size = 85606, upload-time = "2026-05-30T11:54:32.113Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/ef/f69dc23071b4b7f7a996dbeafee8afbd9be21fe2b651de2eab5d513d6622/pyobjc_framework_avfoundation-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:4b45994d9230d2751590928d0421fb7d0b7e8988e52ec1d9ab3f1d57cb869a6b", size = 86054, upload-time = "2026-05-30T11:54:38.113Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/5c/7c2a89266936fc2a99f50810a459ce054035956b07d4d9cc33e9abc5b7aa/pyobjc_framework_avfoundation-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:6f03f0122e4f0b2add93f02d92bd7274abf09979116382c74f79715d33e6461d", size = 85825, upload-time = "2026-05-30T11:54:45.189Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/a5/78c75eca36aca64941451a61aa532bfe5305f886fc6f21fd4f4414ea4960/pyobjc_framework_avfoundation-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:d2535a7bc3e579bc7621066481791f53d1ac83c0bda16fedbbfa513271238b56", size = 86153, upload-time = "2026-05-30T11:54:51.264Z" },
+    { url = "https://files.pythonhosted.org/packages/33/5c/f872e9502fc96894474b9e0fbd9e36f6fe38052d7f186fca79f150862b8e/pyobjc_framework_avfoundation-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:b43a0d1344a062dd983881398a75e5916c46c479b299ff89c14d298ab0a0f1f0", size = 85863, upload-time = "2026-05-30T11:54:57.353Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/2a/d477d3cd1f68cc14706835711f01b87c3063fb40002e79e3d798b6d6fc58/pyobjc_framework_avfoundation-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:d60d7ee5935266907acb1a61c25a0d2750f9b1f4ffe4fa6c908440f003d1addf", size = 86205, upload-time = "2026-05-30T11:55:03.541Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-avkit"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+    { name = "pyobjc-framework-quartz" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/de/5e/baee189b339f0249b35da67ff07004412abd4fbf74fbcb63b0208534991b/pyobjc_framework_avkit-12.2.tar.gz", hash = "sha256:e93667aa0d1283e692c6709b79212438e5fc7eb621371f573a7eccf3ecaa57ee", size = 33572, upload-time = "2026-05-30T12:31:14.31Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6f/5a/3d81fbe55c5a62568810b37530631f2c50ec957add1b8cce48f8d249e655/pyobjc_framework_avkit-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:357dc1cb2f4b0ae60d89788cba6495fdacd773330d47e6687acd2b09859efda7", size = 12350, upload-time = "2026-05-30T11:55:09.154Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/58/d1737715102c83c82789fd8f68c323ef4571de79d4bc619800287af5b6a4/pyobjc_framework_avkit-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:a9867e4eb5d84c88f962118cb22a74c594909dedd3d45eea85ead9450c397e76", size = 12365, upload-time = "2026-05-30T11:55:10.836Z" },
+    { url = "https://files.pythonhosted.org/packages/53/f3/f5a8f8d154b023930534a77b2039729968d0ade2136fc1c1672b40f3500a/pyobjc_framework_avkit-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:ad719d907340151ff5c3d9b067e8c152a8a23c6d18fc8256fdbc1431b40cf7d6", size = 12557, upload-time = "2026-05-30T11:55:12.539Z" },
+    { url = "https://files.pythonhosted.org/packages/06/f6/5b226e18592b5b89419221509d37caedbd1f44ab9781c6abf9e9649ef9ba/pyobjc_framework_avkit-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:df3918f5f9bd687a6a6604dade8461a948c15fb8d755eb1aba21819271e822ea", size = 12377, upload-time = "2026-05-30T11:55:14.41Z" },
+    { url = "https://files.pythonhosted.org/packages/81/61/f2b09c245299251307ca545a3160565893fd3f6350f11b8142efaf37e87b/pyobjc_framework_avkit-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:fbe7c41d928849aa8628a893fb06b7ddd77af5f2dad9ba22e5ab88545620d295", size = 12569, upload-time = "2026-05-30T11:55:16.229Z" },
+    { url = "https://files.pythonhosted.org/packages/de/26/deefd3fba2daf5a196fd5701159d2ffac4bf9ee13677254ae2ec1eaeee33/pyobjc_framework_avkit-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:b8200fbc2744791dfb4985ca5b7387417ffed8c47b81547d36863bc177b6ea54", size = 12364, upload-time = "2026-05-30T11:55:17.822Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/c1/58b2ffdad3dce58e1d71e3baf0b2759b7edbe17f85e4a0346de21d985cee/pyobjc_framework_avkit-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:f089e1022690eed0bb2111e64dec71b1779885e5cc7fe745b7ca1f6df1545fde", size = 12563, upload-time = "2026-05-30T11:55:19.729Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-avrouting"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/55/5f/dcb7d6a4615c0f4b80492b0ba778f0b49aba6c6b4c3a727d0bf38696aa28/pyobjc_framework_avrouting-12.2.tar.gz", hash = "sha256:78affe0c4335ff47f186fed21965f8a381e46429c1a52794044cf2835b48dd4f", size = 20872, upload-time = "2026-05-30T12:31:16.386Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d2/65/b8053591a08574a7de17200a6d571193b3298ec86694b2c359126104696d/pyobjc_framework_avrouting-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:7324cf41f517328a401b5e7f4a2c0ffd08ebdc32199d3058f4088ff8ea36faf7", size = 8472, upload-time = "2026-05-30T11:55:24.633Z" },
+    { url = "https://files.pythonhosted.org/packages/43/51/2a34dab903467a34377de5ddc111b33506eb297fa1103a433e00a4352c80/pyobjc_framework_avrouting-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:72a6408801282037ded8a852c5d266d0e99b637496ef3aee1ac179cdd89b8d76", size = 8496, upload-time = "2026-05-30T11:55:26.359Z" },
+    { url = "https://files.pythonhosted.org/packages/96/28/015dca6d3acabb21f3e93942aff5cb4420f82ded98e2761d13d932837f35/pyobjc_framework_avrouting-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:feee657352beaa05d98a00d5e744d1d7a95572baa2df34f55496ee70bfc74d35", size = 8649, upload-time = "2026-05-30T11:55:28.273Z" },
+    { url = "https://files.pythonhosted.org/packages/11/c4/332d8a24c4bb5855eef4282d292763a3fe918d8630636e0dcf0e91c18115/pyobjc_framework_avrouting-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:2e86f63fa45172d92ad653af5c9977d0b68e10b36441db0157a5485df8ca3430", size = 8550, upload-time = "2026-05-30T11:55:29.814Z" },
+    { url = "https://files.pythonhosted.org/packages/80/d2/e1fb703d271cd37d9fbb9236deb6bca5fa39c11dfc3248aad68d9ebb66b8/pyobjc_framework_avrouting-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:15a2fe798b118ecdfc4c9b75057630f0fd019aac8e17b9272762e776511ab06f", size = 8710, upload-time = "2026-05-30T11:55:31.423Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/f0/3833ce715747b99867e0615f4f5990cf6466b2e04d5354b78ab66ad40c1b/pyobjc_framework_avrouting-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:3f862f47adf00f0ba38076949502025489f8c75a7782b393f7fb93cdfc016f27", size = 8538, upload-time = "2026-05-30T11:55:32.987Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/f3/e68ca2735ec81fb13dee5b7f3f4f16b0dbe95765ffa221762721ced7d658/pyobjc_framework_avrouting-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:7374ea465ea07f70eca80896701bd216bea9f32a46e3b52db55fd34da287791c", size = 8706, upload-time = "2026-05-30T11:55:34.582Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-backgroundassets"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/cf/3c/b344ae79feea1d4169c2e95684d9cd8b938391371b3db8f24abb98501c12/pyobjc_framework_backgroundassets-12.2.tar.gz", hash = "sha256:6df332f129cc025843f5ba6affe651bbf6499b6be35d781fbb12b52250adba9e", size = 29362, upload-time = "2026-05-30T12:31:19.017Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/03/45/bc0a2b94d221e5c094b8c90980f1dd89684f9124c7c63ca3f640081c4075/pyobjc_framework_backgroundassets-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:7052f3eec8ce4db24f3c513455b470a6936776878d025e081501fffa9cf2181a", size = 10925, upload-time = "2026-05-30T11:55:39.608Z" },
+    { url = "https://files.pythonhosted.org/packages/02/a9/b68ebcab2895a659cc18dcb9890aff8fb2f19f9f4e97dee2197de5608671/pyobjc_framework_backgroundassets-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:9f40f72349412f7fe9b55e083de77f1ade5c33de8be529633727c83689421a21", size = 10943, upload-time = "2026-05-30T11:55:41.4Z" },
+    { url = "https://files.pythonhosted.org/packages/68/31/5e8d83b4a2269a6b8ba98a342852c5fcd6715390396c5a088e9efa88d9f3/pyobjc_framework_backgroundassets-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:1cdb5e2c45786a6a36dea60fddc90251c6482bb6d1c05b499258ecd2a6972d05", size = 11192, upload-time = "2026-05-30T11:55:43.007Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/59/1356179290082932330c18b05ef6b2b2ee8c9d2546e316d555925d67301c/pyobjc_framework_backgroundassets-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:79e68372eb311932bd59dbd98523b3ecf5b6c3490f074be734b41b88ae276ede", size = 10992, upload-time = "2026-05-30T11:55:44.549Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/0a/3e7dd4a6abba8dde3e0aebe54122bb35c8e32d55842b15632c0955b3d03b/pyobjc_framework_backgroundassets-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:e7cc37f7cd15cbfd52c30764d31e8c983352fe9813976496d356acdd9e04b5b6", size = 11199, upload-time = "2026-05-30T11:55:46.283Z" },
+    { url = "https://files.pythonhosted.org/packages/22/96/609372b2cd4422d900ec39063ae9a033cda13d2efd57e02bd3cd10e1042f/pyobjc_framework_backgroundassets-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:d327bf09dcc25a881f72f74e3d07adbf45e1188e5d1f7bbac8f1bb814af1de15", size = 10986, upload-time = "2026-05-30T11:55:47.827Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/72/00889013075612cda22866a3e0521091f2912854ffd18fef84dfba7fb114/pyobjc_framework_backgroundassets-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:028fb2d4adbfdaab9a531943b4019de531ae3a4a57415da6e4b059ded28b7743", size = 11194, upload-time = "2026-05-30T11:55:49.565Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-browserenginekit"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+    { name = "pyobjc-framework-coreaudio" },
+    { name = "pyobjc-framework-coremedia" },
+    { name = "pyobjc-framework-quartz" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/22/57/b5529f648215f9abf7f7bb5f57737b75d2cb12936a28907258d6ce2846e8/pyobjc_framework_browserenginekit-12.2.tar.gz", hash = "sha256:f38924bc5e8ab80d1248b00554015b4a86ec3c3c17c779a3e43a0179671e4d69", size = 32610, upload-time = "2026-05-30T12:31:21.925Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e6/d2/cabd9d636204dc08935c9120db60d74a56304d9700e9ba5842d7adf3dfee/pyobjc_framework_browserenginekit-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:a5590d2301c7c0bfeabca352fc3eaa3314d918cfcb1b35b264c53c9364cb1ee3", size = 11737, upload-time = "2026-05-30T11:55:55.066Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/c4/34535b9a061dc619a2f3910d15fde604210187cda07bba4c720fedc77d26/pyobjc_framework_browserenginekit-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:e500aa3ad0c9ef5787bc72a42474d58f8b3355d16f8944dabbe5db2f15a4634d", size = 11760, upload-time = "2026-05-30T11:55:56.77Z" },
+    { url = "https://files.pythonhosted.org/packages/63/05/c0c40325e75fbcf70372b7bea10eb875b24ced3582f580205d5a58ef72e4/pyobjc_framework_browserenginekit-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:88b2b6d5cf7b1e91029e3f32fa950bbed2cf43228ef6a0869bde915caf841152", size = 11927, upload-time = "2026-05-30T11:55:58.441Z" },
+    { url = "https://files.pythonhosted.org/packages/72/c8/fee307a791f1315eecb4414429ba3b98f0571ca768ae5eb9cfea30c88087/pyobjc_framework_browserenginekit-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:87c2d039d7008ccc06b2bd8a4760d356a4d1f1cb267d680813919320e46e9202", size = 11809, upload-time = "2026-05-30T11:56:00.151Z" },
+    { url = "https://files.pythonhosted.org/packages/98/21/eeb8cd19ff856e77a96d06f51dbc7e8c0f885c71cd0673401100bfe41f07/pyobjc_framework_browserenginekit-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:79400862fc7c7bae77bdee8af2fb526877229066b6cf137a3514de8e304eab2b", size = 11995, upload-time = "2026-05-30T11:56:01.874Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/20/c3f5ded954426f8e44d831e18a5993d859b08c7a4a713a8de6c0016461a5/pyobjc_framework_browserenginekit-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:3e02e17a4c7d28eea31fa870c48908d354e8ae9d07dae0691070feef584df7c4", size = 11800, upload-time = "2026-05-30T11:56:03.688Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/f7/c468f25c1e19828ce256065d5d40b03b4f65229e3995de922d7c1569c270/pyobjc_framework_browserenginekit-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:3eabf92613a55e9adbb0e8933898622868e2ab10e1731dca25cb8885ac73f0d1", size = 11992, upload-time = "2026-05-30T11:56:05.413Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-businesschat"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8b/1a/9ad0a1f52f5c670948a71eceb295b6273fa7b3422651f660f9eaac5c3078/pyobjc_framework_businesschat-12.2.tar.gz", hash = "sha256:77809904d62b18377e0764458044f30ba380f462f616cb69628431814afb6f14", size = 12403, upload-time = "2026-05-30T12:31:23.707Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6b/19/5b9e89bf4c62bfe4ab844027f75786d171aee623fb4ca0c4dc46e67ffd7a/pyobjc_framework_businesschat-12.2-py2.py3-none-any.whl", hash = "sha256:c96bceb6796f1fb82edafcda75d5abb59e165aa0f55a6e646638ab56d94ceaa3", size = 3477, upload-time = "2026-05-30T11:56:06.861Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-calendarstore"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/ae/e6ab01011033d45501d96e388eff16185152ce2459174b13e22d90c721a1/pyobjc_framework_calendarstore-12.2.tar.gz", hash = "sha256:26fd412f9c4b9bf5243d44f87b03e24c80562012f6db4ec88c78cc2ffe63e7bd", size = 54421, upload-time = "2026-05-30T12:31:27.857Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/15/f7/356d958ef979f1dc7c01c0a94f0a0b0bf409919308b69e5eee750772f480/pyobjc_framework_calendarstore-12.2-py2.py3-none-any.whl", hash = "sha256:cc9b0cee139d0552d8b924aca13c8ea3a51caa0e2bbf57540d84f249decd3846", size = 5288, upload-time = "2026-05-30T11:56:08.493Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-callkit"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c7/63/f050271956d5742acde26d04ec6e602af9c39e6ac338c161cdd44b083016/pyobjc_framework_callkit-12.2.tar.gz", hash = "sha256:862c4e7475cfc2ee6c663f042fc4a025cbf07edb7608aa8556e64a0591e070fe", size = 32654, upload-time = "2026-05-30T12:31:30.748Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a8/14/a5cfb8c7a909836236c9f42ed4ba0e0566994828989cce99d646fb6032f7/pyobjc_framework_callkit-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:fe8d63ef451eac946864614874b03a2e68a87389e8af611aab32ba61b0e10d2f", size = 11368, upload-time = "2026-05-30T11:56:13.932Z" },
+    { url = "https://files.pythonhosted.org/packages/87/7a/4ac154b5bef806a770de93ff5bd5cb67ac92ddb92ceef697222919a8dcfe/pyobjc_framework_callkit-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:09f8e08298a46ceb53e50c1e17c5dd9e06ac2096f1bda2f956f2ba8693e91ca6", size = 11376, upload-time = "2026-05-30T11:56:15.663Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/f3/72f5b9a00b7adea3cda7d911414c8deaf0bf37e0396c9c918147fa002005/pyobjc_framework_callkit-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:b7242585de40273f82c084fe00a1658f34b0357695f008c8c468ef08c50cc2d4", size = 11590, upload-time = "2026-05-30T11:56:17.342Z" },
+    { url = "https://files.pythonhosted.org/packages/43/7f/5723741b95b838230f833a98dd9795d49810b3986534b88addf3b8779b05/pyobjc_framework_callkit-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:1548f4318427d392ba25296d84449980317a96e92ff01ad4ed77b11b69a8a5ac", size = 11366, upload-time = "2026-05-30T11:56:19.095Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/b9/43d2a04cbafee3f6ba86bbebb1767ff7678adcc8b78880725a85b9d4cd4a/pyobjc_framework_callkit-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:aa198339cb30cacf7783fce03b37a1e800e8ab297466c2e70793383a1658a701", size = 11591, upload-time = "2026-05-30T11:56:20.81Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/ad/78870edd229349f9b6473fbfbc2612662166834f62474d830d80c972e519/pyobjc_framework_callkit-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:c35bb086c67dfdc9facf0f56c8b7b3c1fb2f0ee5e373cfe6dab7cd91daf7b426", size = 11368, upload-time = "2026-05-30T11:56:22.495Z" },
+    { url = "https://files.pythonhosted.org/packages/43/74/0d66c43c2cabf383e304615bcbfcc9038ec66f9e8b7bf7becc3733625e4f/pyobjc_framework_callkit-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:e0658e53a50a4244335b840c45825845350b2d2e9269ead43d7beb1430062d18", size = 11593, upload-time = "2026-05-30T11:56:24.352Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-carbon"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/35/ee/91f41ac1e637b999ba80ee3d5d2ceafaef8d8709012dbb8d0a904136ad76/pyobjc_framework_carbon-12.2.tar.gz", hash = "sha256:965a291f5d5db032057e00666b5a6baed66c564451db66e005fd88be17ed8e27", size = 39741, upload-time = "2026-05-30T12:31:33.954Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/6c/4600816c385ad52f748bf527c4ed15a15d51fb79770bb0a5d6642c4f49a3/pyobjc_framework_carbon-12.2-py2.py3-none-any.whl", hash = "sha256:2420af5872473b91080b8000a50ab2e5053611dc68c094e257b75939f3fddef4", size = 4624, upload-time = "2026-05-30T11:56:25.712Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-cfnetwork"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ce/01/3976ae7dca6f2f35659c364c2e8454a678f730f96f50d41f8ff53cb00d8d/pyobjc_framework_cfnetwork-12.2.tar.gz", hash = "sha256:d50078305b840d1c4f9d47c7c7cb66508766189f9aec6683f4207fccd6d096ee", size = 47633, upload-time = "2026-05-30T12:31:37.914Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/01/79/29d6ba7cd1931c35b0b6590162b6ee21cae36c5a3597fe14ac69c1ff098a/pyobjc_framework_cfnetwork-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:a38c3044b4086b840c974a430db0ca4f02b28b5bb18933da56e5fd3291458667", size = 20127, upload-time = "2026-05-30T11:56:32.622Z" },
+    { url = "https://files.pythonhosted.org/packages/07/fe/f89406f7cadd648eccb03d2777860b748f04db3245fd4bc7b1355cb00cca/pyobjc_framework_cfnetwork-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:0b4c2eba6d1060b3e0e7d63bb67d2d14b46a7e51fa8ab2c2e7767cee266f548a", size = 20145, upload-time = "2026-05-30T11:56:34.838Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/5d/3bb11f406df581059d65a7807dd986796aa388a33da1c816b37238c2b889/pyobjc_framework_cfnetwork-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:f4d6db3702593b2a93cf9b793f3eaac6c0fa7d128a5abcf9f8b7a65079930e5c", size = 20449, upload-time = "2026-05-30T11:56:37.185Z" },
+    { url = "https://files.pythonhosted.org/packages/63/7d/74225d22d6b26d44f51add2e7a24ed26cd083d52daa165b8fcfe668cfe17/pyobjc_framework_cfnetwork-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:760e6dddbd91013c24161413cbb4e91f0161d20815473d66cf6eb1826d579306", size = 20190, upload-time = "2026-05-30T11:56:39.404Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/6a/a040b6e60aa9ecd4b9b4ae606891944562312bc02a067538b9eaf06ea855/pyobjc_framework_cfnetwork-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:4f0b1b47b0f230e4f24382dce5500fb1d19350c867e440eb01f31c24308002aa", size = 20432, upload-time = "2026-05-30T11:56:41.585Z" },
+    { url = "https://files.pythonhosted.org/packages/56/56/b7ecf9e748b86ceb0fd7f7b78f989b76aee05044346f1a6281e1cd095694/pyobjc_framework_cfnetwork-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:b695807bf77444a08fc944c50c6a1aa246abf502c3c507ca04815964f4407024", size = 20193, upload-time = "2026-05-30T11:56:43.808Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/52/5fbabf17e9ae99a8df2115c21f4ac69463ed91f6e5b0481484b9c6d5ad95/pyobjc_framework_cfnetwork-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:5400c56807880e58bac7ce3d48e7b9c773eda8ae1774f361e2e1c5e4afcc990e", size = 20430, upload-time = "2026-05-30T11:56:46.005Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-cinematic"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-avfoundation" },
+    { name = "pyobjc-framework-cocoa" },
+    { name = "pyobjc-framework-coremedia" },
+    { name = "pyobjc-framework-metal" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e2/dc/afc97af264e477fea0f95b54f13350119d69d6eeeb68a6698452295576ed/pyobjc_framework_cinematic-12.2.tar.gz", hash = "sha256:2bec1954c5241e5c8dbefcab6d5b300e62f76eb3907a177840357f9de8474d7a", size = 24960, upload-time = "2026-05-30T12:31:40.317Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/b6/97ff3fa5efbd7b80d40ab5be590f92b7a7ed711ce01812bd0a0a3c0453d8/pyobjc_framework_cinematic-12.2-py2.py3-none-any.whl", hash = "sha256:8df478081b8248a32e91aa2981806e05c551bc6f9ec1286b5ca2d1c64e981f6a", size = 5101, upload-time = "2026-05-30T11:56:47.469Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-classkit"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/6e/35/40a13933e42581a127334faebba2d352a01d3baab02693b31ca4622073bc/pyobjc_framework_classkit-12.2.tar.gz", hash = "sha256:41ca16e92a844bed689b634707a07ebd38bf53e1a0793bcb1005347221889d7e", size = 28943, upload-time = "2026-05-30T12:31:42.786Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/33/be5bf6a705893bc936b3bbc7f9da464b8c0911efbd787a9b2ed8e5a0d664/pyobjc_framework_classkit-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:3b54bba859c942e00a279e9a42897897b6789ab46270ae02b9826b789def898b", size = 8928, upload-time = "2026-05-30T11:56:52.582Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/54/bb0db5a07037e4745deb8f0176cf78b03e4176bcd965693998fec86f5b4e/pyobjc_framework_classkit-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:168c875649e7e43192ef2961569fdf2ac77f662a29417991a99dff5a44dd9881", size = 8940, upload-time = "2026-05-30T11:56:54.141Z" },
+    { url = "https://files.pythonhosted.org/packages/91/93/d6581548debc49ce93d94eb909d663ab1bbf15439f3febd5ba7cfda91481/pyobjc_framework_classkit-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:b593774ad4809c896d735fe3c0d69664cc74d3abe56d1a5fee809a7c05646ea6", size = 9090, upload-time = "2026-05-30T11:56:55.714Z" },
+    { url = "https://files.pythonhosted.org/packages/17/78/7354e03126de7bd6a0919a73c4daf54e8e614b257e223caf3171b8ff03ca/pyobjc_framework_classkit-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:f86e741cc43454de9560839e96800f2d0f9ab07f1e52416e82ccb343137d7e94", size = 9006, upload-time = "2026-05-30T11:56:57.601Z" },
+    { url = "https://files.pythonhosted.org/packages/03/6e/a20b725099ee4981facc259c06d674e84aafb86d6387c208f7cb595da5a3/pyobjc_framework_classkit-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:d7de8bdafa98f64f69094d067cc2a5dabad62a7b861f4837c4e95d380af20df2", size = 9160, upload-time = "2026-05-30T11:56:59.16Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/68/b8352ce9ab8e178a7c4ad719573116a6f3a4b9e268a1704c65342f28ab32/pyobjc_framework_classkit-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:21325c21ca70c38ef8536bf80a25cabb575d7cff95afcabfb8824c180945ee45", size = 9002, upload-time = "2026-05-30T11:57:00.825Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/73/9a7247e52db4d236355f8db3f1e7f94231942f491433cf6e825bd86d0cbd/pyobjc_framework_classkit-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:566d622feb6c5c45a9a8b60dca97dc9941f8b88826f7f91138e81719041288e1", size = 9163, upload-time = "2026-05-30T11:57:02.487Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-cloudkit"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-accounts" },
+    { name = "pyobjc-framework-cocoa" },
+    { name = "pyobjc-framework-coredata" },
+    { name = "pyobjc-framework-corelocation" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/19/57/418b22c326c62f03341e7a974852c5a5bae4dfce1ec88a570e22f14c662d/pyobjc_framework_cloudkit-12.2.tar.gz", hash = "sha256:7849629cc7c726c1a3e16b3324d9fac57f72b938a66f10d480f52e381bef1223", size = 71957, upload-time = "2026-05-30T12:31:47.863Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cc/01/1ad78a6eebbbac6381aa1163028dfe74ccc4111444ecfc1954b4d02a53b1/pyobjc_framework_cloudkit-12.2-py2.py3-none-any.whl", hash = "sha256:1e00a6d02ac005a4dd31aa0aa5e22fdd3e05f8324f91a175dfae7fd45d85afd1", size = 11412, upload-time = "2026-05-30T11:57:04.221Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-cocoa"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/6d/cc/927169225e72bab9c9b44285656768fb75052a0bc85fdbca62740e1ca43c/pyobjc_framework_cocoa-12.2.tar.gz", hash = "sha256:20b392e2b7241caad0538dfde12143343e5dfe48f72e7df660a7548e635903dc", size = 3125555, upload-time = "2026-05-30T12:35:09.273Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/30/66/5a91f2eddfced4f26bc2df2bcebb7f5f10c5bf5666aff6fa00ded845af07/pyobjc_framework_cocoa-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:06cb92d97d1af9d1f459ae6cf1d1a7b824c12d3aff1b709885966acd6b7208c2", size = 388093, upload-time = "2026-05-30T11:58:14.921Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/3b/1af2be2bf5204bbcfc94de215d5f87d35348c9982d9b05f54ceefbc53b8f/pyobjc_framework_cocoa-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:f0bbe0abedfb24b11ff6c71e26cdefb0df001c6482f95591fad40c2688c16498", size = 388154, upload-time = "2026-05-30T11:58:38.547Z" },
+    { url = "https://files.pythonhosted.org/packages/41/cb/c0435d64f1199210af36141b90aea2ae3344719f7313d4160b8b0dd527db/pyobjc_framework_cocoa-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:46b6681e2b21b099ed095339c140f2c8137d6ac5658653166ee90722f9e3c621", size = 392245, upload-time = "2026-05-30T11:59:02.436Z" },
+    { url = "https://files.pythonhosted.org/packages/56/4b/df8e359e5e422e8f1430bde038aa64364e8c1d4542d7f6fcc4f8a97ec0b7/pyobjc_framework_cocoa-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:aecfd44908fa12a9291fb6ca2458ebbc611102de6784f2202a35fd5ed9f56c60", size = 388334, upload-time = "2026-05-30T11:59:25.861Z" },
+    { url = "https://files.pythonhosted.org/packages/43/a2/68c0702cc9d6dbc7077edbd13ccc9aa30ac589d514f51ad6f5c3840e3bf1/pyobjc_framework_cocoa-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:ef679740f541c52118149b558b757d1f11d9dcf30c2a23344b13a6af6a99a1ab", size = 392376, upload-time = "2026-05-30T11:59:50.031Z" },
+    { url = "https://files.pythonhosted.org/packages/83/c3/e170672302e75cc1aa833546fb0d5a3bd4a126ede4124566d5a2e4a50cd6/pyobjc_framework_cocoa-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:290e544a8c2d0786a34a359d825eaad44ebaaa3b30cdd765b2755422ca39a0d2", size = 388566, upload-time = "2026-05-30T12:00:13.606Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/6b/78e98e4de11646e56cf98066f9f84b43c86adc8b273a660d85a6ceba7a31/pyobjc_framework_cocoa-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:5a0bed77b0b56074cc2b4564aae3e6e9d5da5fdf93252f50b6dbced0f7fece3a", size = 392674, upload-time = "2026-05-30T12:00:37.572Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-collaboration"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ed/72/f84e5835a01f42a8b14c165490e24ba72839ed411a24bd7217f4d37c7d54/pyobjc_framework_collaboration-12.2.tar.gz", hash = "sha256:77707156f677c502fa973bbb3028ad1cea8557875e75f1a03f605678c881289a", size = 15069, upload-time = "2026-05-30T12:35:11.891Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/49/d8/a1eb9888ca7ee599bc484feb78c43453f8c154c986bdc0daff4948fe39c7/pyobjc_framework_collaboration-12.2-py2.py3-none-any.whl", hash = "sha256:219f8e5b1f0cc25dc48460ca909c09127eb80b3aa0262cb50139cd46c84b63d1", size = 4853, upload-time = "2026-05-30T12:00:39.271Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-colorsync"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d0/7c/eefce8ea94a1817842b54a1d6d472ae184749ca6ad8d84386436b10ac757/pyobjc_framework_colorsync-12.2.tar.gz", hash = "sha256:b403820f3504b0e728f883575637c217a2043fafca5c0b315f03c88805d37958", size = 26911, upload-time = "2026-05-30T12:35:14.46Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e0/c7/0562840adbfaa21c37ced637653e4ade70618e911a151974c53d25c8f5d9/pyobjc_framework_colorsync-12.2-py2.py3-none-any.whl", hash = "sha256:5d2ce9acd7ec28133facf0af900fc4a5d36971083811eb6da775be4b659f9b77", size = 6006, upload-time = "2026-05-30T12:00:40.915Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-compositorservices"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+    { name = "pyobjc-framework-metal" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c1/da/0f975d3bb2efbcd305d76f9c8869b5918116731e739cf071630ac3e1f818/pyobjc_framework_compositorservices-12.2.tar.gz", hash = "sha256:2c1e940959270aeded95b573ed57c9edd7d3da0ccd45fb5be262c93cc62e2704", size = 24919, upload-time = "2026-05-30T12:35:16.745Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ad/86/f172e0a687dec40e7809e1efdffeb666c8d369cb73c7e50cb6f84d0b49cf/pyobjc_framework_compositorservices-12.2-py2.py3-none-any.whl", hash = "sha256:486f5e70250892122ba90f2923dc955a3622c4a047536ee3a0b15bd3568cd171", size = 5972, upload-time = "2026-05-30T12:00:42.699Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-contacts"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3d/fd/b1569ca626fef30123f0fa5d3cb6126e171cea0900434e4b629f15c5f403/pyobjc_framework_contacts-12.2.tar.gz", hash = "sha256:117989ffed4f41d0bbf7e81dde8154a31995d2adf1fe898c2917bc6e9c1dc122", size = 48703, upload-time = "2026-05-30T12:35:20.347Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/aa/03/2a6cd96ffa4d3d11216808d877913ee4a527adbfed56660ec7b577c568c8/pyobjc_framework_contacts-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:50a4b3b1ba1a27691dce40db61deff1b6e52889e063076411bcf797dd958d299", size = 12152, upload-time = "2026-05-30T12:00:48.331Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/79/609e55416da80222dbce2ca761f70ced7e45c85244f7b66e8713eb26dae8/pyobjc_framework_contacts-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:1ee92445cb2c5168df0b25bb6d897b1389d55571eb6bba229431c1d933940a7a", size = 12164, upload-time = "2026-05-30T12:00:50.096Z" },
+    { url = "https://files.pythonhosted.org/packages/18/36/701eff1da16bb3d89dc28d0db6acf5604650dad6b722cbcba2ad9c8a6233/pyobjc_framework_contacts-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:91748bc3a42723d088f7ded819cf0155868b9bca16ed8cd753695bc71710f45d", size = 12325, upload-time = "2026-05-30T12:00:51.734Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/f3/1c272535422ab8642ce251accceef3ab29695742be5f1e658a41b0027a99/pyobjc_framework_contacts-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:63abb417bf2d3565dfc79cd8febdb2499040ec44900a972c7aeba02120bc27f1", size = 12237, upload-time = "2026-05-30T12:00:53.552Z" },
+    { url = "https://files.pythonhosted.org/packages/02/98/59a842bb85f1524996eb884a62d8e4303c28b0c480aaf221a95c0f480040/pyobjc_framework_contacts-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:4cd0d97c47a4c6a6822fd213612a0b9a48a6f37f76f9b19bfa922b58a5ef061c", size = 12393, upload-time = "2026-05-30T12:00:55.355Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/dd/244f231b713ceda4873cac2f57e2c05ac77d6dbb37066223509b8042f3fc/pyobjc_framework_contacts-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:37d4e0b512de0586f90b306a4cc4ddc0752edf7ae8caad11317516da7d17d63a", size = 12231, upload-time = "2026-05-30T12:00:57.042Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/1e/870fbb8b096150a89159aec4d23f1ce0fa4ca0ffb532c5b4575a2234bb4a/pyobjc_framework_contacts-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:8d50405ecf31ab5370f9ad5fe4aa4d69e0bca5c8fff0991671bb88f65ebdf3c0", size = 12392, upload-time = "2026-05-30T12:00:58.798Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-contactsui"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+    { name = "pyobjc-framework-contacts" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e1/e1/8f51114ec751ad746cd0aaefcb130f5dd3b09537a326425b4c8f47fc1345/pyobjc_framework_contactsui-12.2.tar.gz", hash = "sha256:ca1ab431b8838240877d8c8c1776d58c7eae9f9a7b193b0cc761162f6baf58bb", size = 19347, upload-time = "2026-05-30T12:35:22.591Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5e/b1/e95a20c1a090db78be1ab46b0d36e808dcfe8c759627359bd30c7830ffb5/pyobjc_framework_contactsui-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:22aa70253b9c1087f5a1af645c87792096cba494d5a34edd964a2d8a4ad1cb1b", size = 7895, upload-time = "2026-05-30T12:01:03.734Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/e9/e4433cf42edaf26aaec04a4c059733b98ad9c0982a5e72da192309fbe391/pyobjc_framework_contactsui-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:8ac61436333c416fada5053c9d8b1879f82efa9bd96fbd5027da6ffcde0728b4", size = 7903, upload-time = "2026-05-30T12:01:05.63Z" },
+    { url = "https://files.pythonhosted.org/packages/db/c2/cc3c32d9811798adf6404b8204731f855714869dd0e0476b6b4d6302ef42/pyobjc_framework_contactsui-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:2c7a4f5e89a22eafc056a52caa07e96f35b82a628b42a9c47d0720634ee01099", size = 8051, upload-time = "2026-05-30T12:01:07.166Z" },
+    { url = "https://files.pythonhosted.org/packages/49/b0/e65fb4c42eaa394e568aa7585baebe765a10076c868c552dc4eded593441/pyobjc_framework_contactsui-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:91e82a66a34fe939274f4f6867e157adb608e0aa52b9dcbff7c0a199871195ac", size = 7961, upload-time = "2026-05-30T12:01:09.008Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/6d/f922216e36b461d9ddb348beaa300a21df6189ba85718be34bb230d0ad66/pyobjc_framework_contactsui-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:583c884823816c0c890e070fc738522dd0c2081eb3663db1c64647ee1e76002c", size = 8114, upload-time = "2026-05-30T12:01:10.512Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/5c/163409abc851ea4b79097d1d08033c8ee1ca01df21093b74fc16bdbd8d0d/pyobjc_framework_contactsui-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:eacd68ff0b2dcbeca2ba272799aba34bd2d966d3289a00aa8e4684b2870b96af", size = 7965, upload-time = "2026-05-30T12:01:12.191Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/eb/29970ba97be46f444e24c7e669f9fa87e6f2429d089bdedb4487bf3f7879/pyobjc_framework_contactsui-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:993702a013f381d763be9b2bb45a363439562dbfe6238846c76c798305e3afb5", size = 8111, upload-time = "2026-05-30T12:01:13.649Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-coreaudio"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c3/d0/6e4adb375b81c06fbf28d758ea60281cf78f5675a68f7f3613d5ca28aa71/pyobjc_framework_coreaudio-12.2.tar.gz", hash = "sha256:1990be9a9311869b551e6a997ee84bee12ea38fc978d5fa7fc0119caff2f9ba5", size = 78669, upload-time = "2026-05-30T12:35:28.189Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b4/11/b2c641e4aaf79ff664c081ea09a79366c60406b36e80bece6faec83bf7a5/pyobjc_framework_coreaudio-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:038293a480ec3afc902541ece05404fffdb915f0a6ad60fc81156beeb256cc5f", size = 35395, upload-time = "2026-05-30T12:01:22.951Z" },
+    { url = "https://files.pythonhosted.org/packages/14/3a/d2905ed8f0bfd74d7284e4018e11bf22f027e3ce7921a3298322d2273b4b/pyobjc_framework_coreaudio-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:505564f35227b6bf3bcfcc950edeae81628724202eb2a49f4bf213be39589521", size = 35423, upload-time = "2026-05-30T12:01:25.959Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/33/cf17a929f444bca49a88f4c059868eda4ecf94ab7ab89e4d47b943d5a824/pyobjc_framework_coreaudio-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:1640bf44b001c960ae7ae84a43382141711bfbee439c88dea3872c64556e0308", size = 38179, upload-time = "2026-05-30T12:01:29.23Z" },
+    { url = "https://files.pythonhosted.org/packages/75/e8/6fa5951c9c2f87fa7c973fe179d53245f49e0878221305e01eb0444a218b/pyobjc_framework_coreaudio-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:27ef90a6414bbb156a8f2ea22afff5af080fc7fcfb570f215739c1ca136544e1", size = 36672, upload-time = "2026-05-30T12:01:32.506Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/ef/227b913bca61d3cf1c7be13b3fc8b60eb4895a6dd6a2371540f75cd1c2e2/pyobjc_framework_coreaudio-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:3fa7e25e6b90dab26bc9f94ad058e0346424604daa103d03ebbb6c2636772c1a", size = 38281, upload-time = "2026-05-30T12:01:35.743Z" },
+    { url = "https://files.pythonhosted.org/packages/68/de/d4c9de8311c73db5de4f75de88ac049990574c1f3dc7f2fe60879b84f482/pyobjc_framework_coreaudio-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:4aba12b357f4e429a5c8a1bf6ccb7b5902ee8726863744284e3f6ae9b76fbdbf", size = 36706, upload-time = "2026-05-30T12:01:38.854Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/77/84f082096c107dd15956ad4752105e794efbcee415db5595bb2a376a5f17/pyobjc_framework_coreaudio-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:7f8ebd42735ca954d457c87e815da632e2ccd3b55ea501cda488389dd1f37093", size = 38314, upload-time = "2026-05-30T12:01:42.106Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-coreaudiokit"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+    { name = "pyobjc-framework-coreaudio" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c1/d0/189f067979cd117cfb1464dac24bd64e1d4127b09366fbf17a9bec84984b/pyobjc_framework_coreaudiokit-12.2.tar.gz", hash = "sha256:cb743400fff2cc0ee5837d124c1665135559d8505d28996423ed4a609221614c", size = 20916, upload-time = "2026-05-30T12:35:30.615Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/33/84/b9b3436b22c97d0c8fd56214d49c1f41f90787377aad6e9c8abd1984ffd0/pyobjc_framework_coreaudiokit-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:9ca439517d0780dfa9d85175a6a1db29b89ec2c55d1cd8711ba6a6433f9d637d", size = 7272, upload-time = "2026-05-30T12:01:47.161Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/e4/d59c8bc9f0dc3c953887fa9b5be06ffb6b007e3fe931b4faebb533c10e1b/pyobjc_framework_coreaudiokit-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:1da5bdab7f4d3c3f6b420f3d57e28a05c620e71cd3310499d415db0bb1f65c7f", size = 7286, upload-time = "2026-05-30T12:01:48.762Z" },
+    { url = "https://files.pythonhosted.org/packages/06/69/e46f04648626f8c70cfb5e024fd52a3ab3c832e40039b7d125fe62d2a49c/pyobjc_framework_coreaudiokit-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:baaa6b2c32fe2cd2d554f0503b773710f21e061ad544773c86d7df95ddd983ab", size = 7449, upload-time = "2026-05-30T12:01:50.363Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/cc/0a8102a256bfbda603b94856ccf4c840658956e3b469725559af132984b5/pyobjc_framework_coreaudiokit-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:bf135b76cb36ef940ef340cafe233882edce97391e591ad635c6c1fbaa60565f", size = 7352, upload-time = "2026-05-30T12:01:51.811Z" },
+    { url = "https://files.pythonhosted.org/packages/28/c4/9a05f93a0efdb13b1edd0422d9b5508e334d13bcfecf59afae98665b2572/pyobjc_framework_coreaudiokit-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:680800157ff8e1b3f8f3654fc9d1f92b3919aa550c4be2fc926859b87374e20f", size = 7508, upload-time = "2026-05-30T12:01:53.289Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/9f/97cc6d01cd4d31c76ede65ad85a63ef32171b5c40edaa56b6efe0a41efc2/pyobjc_framework_coreaudiokit-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:42471d1aa5240df4596d0c236b3d037827be66f6b4faa86fba743d2016902160", size = 7347, upload-time = "2026-05-30T12:01:54.741Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/72/b333b5ea068ad7c4bee7c83259f95c8a703532049650c828da09039fb90d/pyobjc_framework_coreaudiokit-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:e06953ff761da08123cd18225d008f6b6c35f1809862d46bfe825f618409acc8", size = 7500, upload-time = "2026-05-30T12:01:56.203Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-corebluetooth"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/52/df/bee7ba216f9fb513710aac1701b78c97b087b37fca8ec1806f8572e0bbb3/pyobjc_framework_corebluetooth-12.2.tar.gz", hash = "sha256:8b4e5ca99953c360c391a695b0782a5328fcecafd56fdf790ad709e932feb306", size = 37552, upload-time = "2026-05-30T12:35:33.863Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8b/9a/99e61547e61b0e38cb13c67931f9ca9bbd1dc72c1ff78322c7c3af805e8b/pyobjc_framework_corebluetooth-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:31da3686ea55e9f7f8fc321fe2fcdf23827acd24c91ae1798e47e1f3a8355ab7", size = 13191, upload-time = "2026-05-30T12:02:01.811Z" },
+    { url = "https://files.pythonhosted.org/packages/25/eb/04f0ea541e6df3b7a328fe63ed1f508898d84910be66ae0f4d08103ad5a1/pyobjc_framework_corebluetooth-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:b43a21eb9388453c867ce82bf5d475cfce4fe2ceaea974474071f1cfd178f40f", size = 13205, upload-time = "2026-05-30T12:02:03.831Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/b7/502b1e5ff1feede7fbed1f28e1fd14604cf564e4a4f5d4f33c93a4706739/pyobjc_framework_corebluetooth-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:162623f74c85041bb8a2c9a8862cee6674531d603ad7a8d65a3efc81619f84c5", size = 13389, upload-time = "2026-05-30T12:02:05.647Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/ef/a75bd6c17e012f7d73a8a2d94e324528a82dc06451b6019d910b1a993864/pyobjc_framework_corebluetooth-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:8a3b35a1253de626d5efe705dda36a4f1fb8753e48aafdc4dbf99dc9c9526d86", size = 13196, upload-time = "2026-05-30T12:02:07.462Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/d7/11a8a90463e6a3928274e65bd17acaa3f0bfbd9c19a68b93c61cbc4fa379/pyobjc_framework_corebluetooth-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:bd0b9e7bc2fffcfa4843d7f103e1e927ce37817a70932d080378e1e29a073381", size = 13387, upload-time = "2026-05-30T12:02:09.431Z" },
+    { url = "https://files.pythonhosted.org/packages/10/d0/d5cc4ba6dbe21f6f4c90e8f0087254f1f742134580394b763025416ab7d2/pyobjc_framework_corebluetooth-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:a2dd4bd8fde13b97a3339a42d6703c9c9b148663e2e23a184ffe2877c8e51470", size = 13192, upload-time = "2026-05-30T12:02:11.41Z" },
+    { url = "https://files.pythonhosted.org/packages/25/a0/964b18affc8f6b582ed891f3b59413452fd95acce4adbf070a389b5197e4/pyobjc_framework_corebluetooth-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:42db087cd3a328abc620c76c7f708d7c2b451f3dbc0779983812a0c84320fe60", size = 13394, upload-time = "2026-05-30T12:02:13.443Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-coredata"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/dc/67/e3eb3661c72ee1bd97eab9f6fc5121987f8f8f78f47d07418c1ef6f8fd1c/pyobjc_framework_coredata-12.2.tar.gz", hash = "sha256:1942049d656e264f47177c2fbd84314839bf55f61a825ae49f4fc7b0ebb078da", size = 143296, upload-time = "2026-05-30T12:35:43.03Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/33/54/ceac7d7f2c0a56ba8daa931c8ce44b9d050c9c2a46e20ad7bc75b18c27d2/pyobjc_framework_coredata-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:32a28504e3fd2ba2f4da8019a5325010f21d1395062946f143ed9672cb6a244c", size = 16525, upload-time = "2026-05-30T12:02:19.832Z" },
+    { url = "https://files.pythonhosted.org/packages/26/44/0cec6323ea515dd5a8b5382f78e871f905aa295858716b53d4db8162d645/pyobjc_framework_coredata-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:36c1fa33a8221339983eef98c2bc9894813a51f650c30e92fbd3cd1e9f51921d", size = 16539, upload-time = "2026-05-30T12:02:21.888Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/a7/844e5e193cd8a5ac4620f40fb40d1d039282e17cdc19e1f50addf36e415a/pyobjc_framework_coredata-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:4ed76ef3c44a0f7f488ac445fe06878e90fedd55c6077841efbded1b125f33ea", size = 16694, upload-time = "2026-05-30T12:02:24.118Z" },
+    { url = "https://files.pythonhosted.org/packages/94/a8/5dd670a58f82fb4adc1b5b9634e66572d6331a7e849e02ac36265b4d2753/pyobjc_framework_coredata-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:1c68b2fac8f9bf591296253f54742804eaa3c99844b487988e0090f51e69a645", size = 16597, upload-time = "2026-05-30T12:02:26.178Z" },
+    { url = "https://files.pythonhosted.org/packages/de/b5/bbd4e22732cce98979a2a7ba8798f52a91342036fbb89ea30df9f3ca1b34/pyobjc_framework_coredata-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:1b48293e6d4f2dd2fc661e1aec65e71e2b4ec4fea9c61ae41eb265e61d4b89cc", size = 16756, upload-time = "2026-05-30T12:02:28.349Z" },
+    { url = "https://files.pythonhosted.org/packages/66/36/8592d816be70e5e64fcc02489f65d7fa55fb8ba7706e396a356d550a7d7b/pyobjc_framework_coredata-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:1145c11f4d0eeb7ec51818318027cd0bef8e65400186463d6f4ea5102ec2f160", size = 16594, upload-time = "2026-05-30T12:02:30.298Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/f7/96f9c101562f3f6f4b7bfb728be64eb10730d696a9c2e923df91b2156a48/pyobjc_framework_coredata-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:262a9cdaa31a38bdf9087c4f89b235b389d1c778ab554a881559c3e0640ce540", size = 16750, upload-time = "2026-05-30T12:02:32.612Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-corehaptics"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/38/c0/fa97c71176260bf0fb764809034e2ac4a6f3e47701d7526ff5844da8a1cf/pyobjc_framework_corehaptics-12.2.tar.gz", hash = "sha256:d55b39ea4d998dd50f980e8c1800df2558099b96a99f25813bed702ebc2bf43e", size = 24902, upload-time = "2026-05-30T12:35:45.559Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/59/19/b4842ca6182d754360289384aa3b4adf3775a6c4ec30818c8b8c1c473792/pyobjc_framework_corehaptics-12.2-py2.py3-none-any.whl", hash = "sha256:c04c64212e7e7a0859b23b939a4375a349176317cb2b11553d388965d9a8fec8", size = 5413, upload-time = "2026-05-30T12:02:34.2Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-corelocation"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/81/f074ac32e9af964ba873ac646ceac9d372057ff8d1db01d31e8f5586a1f6/pyobjc_framework_corelocation-12.2.tar.gz", hash = "sha256:1e0f389140707ece2bb4d08def421e25b792dcc2a34000dfb128dec2e685d725", size = 60306, upload-time = "2026-05-30T12:35:57.942Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/55/43/65d5d913e2aff660c71cfe6acec29adb6e461dcce3443a18c2bae03e6d67/pyobjc_framework_corelocation-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:4f556f56955e9b909fbb0ab510449c89802f2f9e287bad402d0cd1b5c4e73c4b", size = 12822, upload-time = "2026-05-30T12:02:39.922Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/af/a8cf57caa11c1ce96bb19855ff02fd17a7e7f1d1ba3a890369be1f731f72/pyobjc_framework_corelocation-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:8b355dcc544a2ab525744b777431cb902c951fbbf2281350b86323eb64c4b409", size = 12843, upload-time = "2026-05-30T12:02:41.759Z" },
+    { url = "https://files.pythonhosted.org/packages/11/f8/4d1aa9f9736efa013cb73022df9f58beca9639d922613be0f2be16e0c709/pyobjc_framework_corelocation-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:7515eda941b03c4e4f1e6d596383d4788997a05e30ce210ae250326ca418f240", size = 12969, upload-time = "2026-05-30T12:02:43.671Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/e2/90e8bb8654bda885e6acc8f15be2544f1c7cdb58503389b970dca5ae5324/pyobjc_framework_corelocation-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:a3b70cca208369e8c68afd8cbe865d25829c34b338309a61b3b354d3824055a2", size = 12822, upload-time = "2026-05-30T12:02:45.678Z" },
+    { url = "https://files.pythonhosted.org/packages/84/70/4e8ad2a3c4649af2f5f2f132d800a13e1743581d3871304e80d8dad32e67/pyobjc_framework_corelocation-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:54d47d7f8df4383a1e3d1201a80520068222fad373caffb8adbb134ef16b9b7d", size = 12971, upload-time = "2026-05-30T12:02:47.454Z" },
+    { url = "https://files.pythonhosted.org/packages/59/95/13c20405ab3f561e20c13d2b7bdc4d1b2deddf9f00476b50c74a9be705d3/pyobjc_framework_corelocation-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:472b95e1a6ec6f14545d1d523f03a688d60a32ad722a267a3f9539d7d38cc94f", size = 12809, upload-time = "2026-05-30T12:02:49.443Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/76/23c7147aeaaf7c85a6e3c140c560244de5feedc8f9834b5f65e526f05815/pyobjc_framework_corelocation-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:0f24d4ecd314691d773b98276880864dc3899605b2d708c75532acaf9c517074", size = 12961, upload-time = "2026-05-30T12:02:51.232Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-coremedia"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/6e/63/9b25f9abb14e8faee219e72953c3cc4bed48b0de4b86f767f073fd2fdc35/pyobjc_framework_coremedia-12.2.tar.gz", hash = "sha256:95ed2063cc48d73f6eb06f4e603372515b5b009bd2d6e547f90bbe9e64217206", size = 98236, upload-time = "2026-05-30T12:36:10.943Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/99/db/966cad806594831379785af07669e5f2c1784e88c775a381cbcba215cfa3/pyobjc_framework_coremedia-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:2eaddb2f4e25d7b6f32d4b85b828cc89ce6ae5502d531c2913b90d93f85fc2ae", size = 29400, upload-time = "2026-05-30T12:02:59.537Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/00/412b4b98b6c6b266a73be2862453d98a6f7f95e911c216ad2117831d2b18/pyobjc_framework_coremedia-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:e992147e7b0c8c435f1bb786c8c610511453cf54bdf6c6b4a17e05936bacc44b", size = 29412, upload-time = "2026-05-30T12:03:02.254Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/61/e3285f4b7a889a334ba06c6daef78f32e39de40ca7b061443e39e0faf42a/pyobjc_framework_coremedia-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:d9586fb8ae22ab1a500e812e5c16dde09b3ea75613a8b5ed61d17cd9ba75c809", size = 29472, upload-time = "2026-05-30T12:03:04.911Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/6e/66ff680d04e1e16321aca36524ef3b442de89330edd06275b9e2303b6af9/pyobjc_framework_coremedia-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:c1adf7b6fcfb4c88bc2150c6f0366c19774e46c6978ebcfb7c70d02753bc0183", size = 29454, upload-time = "2026-05-30T12:03:07.771Z" },
+    { url = "https://files.pythonhosted.org/packages/74/dd/e61aaf92b4b7074b4f2609cd1a9c485410e76549a7f68ff10394e95396da/pyobjc_framework_coremedia-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:9b75c3228732d78dacfac7a39f52470606e949f07c940b45ba73588db41fe73c", size = 29500, upload-time = "2026-05-30T12:03:10.304Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/aa/b3b65aeeb52cb08fc151fc6102d3127bc308e7ebd078410ff6832001d562/pyobjc_framework_coremedia-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:fff54b5907cd346daea1bf4d6554fd6da1d69ee9bf012774c3b4ec972f4257a6", size = 29485, upload-time = "2026-05-30T12:03:13.023Z" },
+    { url = "https://files.pythonhosted.org/packages/48/b4/5c25ce6eaefc509a90c8f6efbb0a2a27e223552d4551c32cca514bd84ee5/pyobjc_framework_coremedia-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:ee5889c07f61d16f8d195a793a7f0ebf7f5c4eef4d1ef2fdbf5c823c74e242d0", size = 29541, upload-time = "2026-05-30T12:03:15.744Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-coremediaio"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/40/24/7c8b41310cb874bd308c875252ec6872198f19f3be27aacdafcd98a4b27e/pyobjc_framework_coremediaio-12.2.tar.gz", hash = "sha256:38f656ebe897262463277d4551fc6cca4ac766629476576f040b34e84c956506", size = 56592, upload-time = "2026-05-30T12:36:15.218Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/29/ab/0e0cc4faca5bdb958c5da765de9d10a43f65ab57c1d400e06497a94221c6/pyobjc_framework_coremediaio-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:2543d464db2b169571ec757241813c761abfe31033a533830f6e62d044a31edd", size = 17335, upload-time = "2026-05-30T12:03:22.155Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/4b/65ed6a4af11af67ee64b5fafbf12ef2d56dd38020e88d9b67aed2128703c/pyobjc_framework_coremediaio-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:95cfaa7b8a0c970cfacdc620991345a3b55ba641a8091a1467a94310fc11b279", size = 17306, upload-time = "2026-05-30T12:03:24.356Z" },
+    { url = "https://files.pythonhosted.org/packages/51/6a/4b04551647534735d788919a8a62b5261b249654b6e427f27d12f7e5377f/pyobjc_framework_coremediaio-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:f03e5f735b99508706f9ccf5233eaae4c53399459b6c87670112dcf1c0cd791c", size = 17627, upload-time = "2026-05-30T12:03:26.42Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/af/e39b0afd12229c9fc21945307d80f27f2e8548171d04327e4b6c8a601220/pyobjc_framework_coremediaio-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:057d63ce28a64589d4ad103c5e9b0ef1c23e45e63693314eb75de9aba78ae7ff", size = 17325, upload-time = "2026-05-30T12:03:28.423Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/22/f206988eab96acd7e7203b93109d93a2812dcdf320892657a8b5cdd27221/pyobjc_framework_coremediaio-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:03b68e48f0820f9aac4f2250ceed138c097fb806cdbbd064ccc463709e828b68", size = 17622, upload-time = "2026-05-30T12:03:30.479Z" },
+    { url = "https://files.pythonhosted.org/packages/12/2a/4afa7f2fb64b3903e0ec4eedf51130856aa768c73de9bfb90720d706d259/pyobjc_framework_coremediaio-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:6fe8353ca1165120f69f8bc0aabc4041cdeda9b6fc4f3bda4ded601680df3061", size = 17346, upload-time = "2026-05-30T12:03:32.506Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/07/f7006431545f928f02eb1779abdf8e042238740469f137d20d0f0501670d/pyobjc_framework_coremediaio-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:9ce96c501bd64fbeb52e23332b72633f8b1d2f9390f01c5e1787c8f711eb4646", size = 17628, upload-time = "2026-05-30T12:03:34.549Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-coremidi"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a9/ca/ccc156899161481cc2c22529645d590a6f570c0583567ab6ba4a0df71bbf/pyobjc_framework_coremidi-12.2.tar.gz", hash = "sha256:a00e1d906f1a1fca302c867406ed8e1e23651b1551ce1943e9495e7665b6b0d3", size = 63475, upload-time = "2026-05-30T12:36:19.463Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f8/d0/5c7de6a375f63dd3bf772be75661f0cf1ed1949acdd89f539a32537fb03b/pyobjc_framework_coremidi-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:4d480a526fca15ea16bb9e7fc7e5a7107c6263c8f791efc673525928f45a3c30", size = 24556, upload-time = "2026-05-30T12:03:42.158Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/a5/b87175347becf46c8ade3593da8fc660d46a5fbf2794f5d7fcb0ca4694b6/pyobjc_framework_coremidi-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:86c7114af6e06650a84eeb781b90bfb3569304f36a40e38eb2e6113e72385444", size = 24584, upload-time = "2026-05-30T12:03:44.625Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/d8/2953bc296baaed3a4207131d9b90797b6a12ebee204c92addc14b6c7ac8b/pyobjc_framework_coremidi-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:ae8c2e5113fe8a4afa4ce9c5231a5bf8a2c25dccc909b80d0fdd9ca0996e6d1d", size = 24734, upload-time = "2026-05-30T12:03:47.053Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/17/098da114f1f628551a48570a077747505afeedc63c3e6639dd7d17421e1b/pyobjc_framework_coremidi-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:2d962b3f77f60fe608b845b903845585d0a47aed6345192d5a22d3b1ed205f1a", size = 24626, upload-time = "2026-05-30T12:03:49.642Z" },
+    { url = "https://files.pythonhosted.org/packages/36/d4/10a32149671d8813251ad1688fcac5c1d500fa40ea98c9f7581ad4fef18c/pyobjc_framework_coremidi-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:ff07b6a479c2a273276f156e598c02c59c9c1cf4ba8b34c7e1e938df484388a0", size = 24791, upload-time = "2026-05-30T12:03:52.111Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/24/8f30c3f25775a2458d0cd4003ba72fec22f2b9de776f6c4553785b699749/pyobjc_framework_coremidi-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:cd719cbd917606fff46e5eb937c472f10986036d1f00c7af237742825ac67b81", size = 24614, upload-time = "2026-05-30T12:03:54.578Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/7a/3bd8616d43311564b7286926b2e071de3cf0db2711e3c59f9474de12533f/pyobjc_framework_coremidi-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:2f7e8a895852b4c3cfcc20cee8a1bd63af7577e0fe79a2e79de87d4da8ee671a", size = 24779, upload-time = "2026-05-30T12:03:57Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-coreml"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e5/a5/ee39e19017348fcba998de71f4f425abf0563b693fcf5bf7f4b84232d538/pyobjc_framework_coreml-12.2.tar.gz", hash = "sha256:884f1f68c7a74c56d26858051da8a1e19848be97f2c4b06b32ae93e505109583", size = 49266, upload-time = "2026-05-30T12:36:23.498Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a2/55/8bf3985e5639d95a44ee6431ee00f1ee823a36f9d1d5a5fe5efb60427386/pyobjc_framework_coreml-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:011dc67f11144817c9cf728cb7ae3d520001c4e099f9efb6a4c9fec4c19e6413", size = 11950, upload-time = "2026-05-30T12:04:02.515Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/42/93b24114d5334d7a1a5031788947f14f487c0aec4529ccfd7f78611c69b9/pyobjc_framework_coreml-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:64b66797b9cc1b20d726476f78ee2e69540fad60676d5dbb120530fbd429d3c7", size = 11966, upload-time = "2026-05-30T12:04:04.368Z" },
+    { url = "https://files.pythonhosted.org/packages/08/da/ccec3d91d7a740156d720056002befda423f3960691e4290460910d352e3/pyobjc_framework_coreml-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:774a28259888c1bc247e8ed5ad14d7fc8baa975591c89669cd952e1756cd7d48", size = 12188, upload-time = "2026-05-30T12:04:06.09Z" },
+    { url = "https://files.pythonhosted.org/packages/99/27/577ae403c3d2dc6c49dc18e8b16d315c54fcf31cdbdc839523ea40af4777/pyobjc_framework_coreml-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:0ab804c7fdeedaea8fd6e1ec832a23d57913b280d3cc40419adabb0032271160", size = 12009, upload-time = "2026-05-30T12:04:07.798Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/4d/605604165c57a329141436b750a0ac48860f59d73a015ca1a8abeed316d5/pyobjc_framework_coreml-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:f55eb83825308fd759e053dcb9844ae5106e371645e7dcdb0777f161d59f8280", size = 12184, upload-time = "2026-05-30T12:04:09.554Z" },
+    { url = "https://files.pythonhosted.org/packages/97/e8/048beb8ab0df464b493a9c376b830d8cc1c84123d2ea44e5e80e0bd6a60e/pyobjc_framework_coreml-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:f5ebf148cedb1ee9b5183003cdb64033e97c7f50b4d073684e0fb54e63761259", size = 12004, upload-time = "2026-05-30T12:04:11.184Z" },
+    { url = "https://files.pythonhosted.org/packages/de/9e/b20114d45562f0f35ef0feb9aad604aac28a587ad7942b8c121cb9e6a85b/pyobjc_framework_coreml-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:82dded9d153db057aae965539cb28b4dc43391e5e07f38ac60db83061a9453ca", size = 12182, upload-time = "2026-05-30T12:04:12.841Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-coremotion"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9d/38/90010239d5d6721d8670cbb0edb71c39a1abca0cf22cecbeba7cbd490de5/pyobjc_framework_coremotion-12.2.tar.gz", hash = "sha256:8a2a06809b78a72cad52f27aa830c883e19ca36b57f8418ccfaf29773c5dc5ac", size = 38055, upload-time = "2026-05-30T12:36:26.711Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/15/f9/4ef3ac3cb071cef44fafa2de17d3e482c9c519ae5c1cdf00e3a6aa86351f/pyobjc_framework_coremotion-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:5b987d542146d75c890c205bc8c125b546c7bc35afb14d5156ffdba16914bed7", size = 10428, upload-time = "2026-05-30T12:04:17.943Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/62/606ca7aa90686f1eeb48d9870409bb1132ade70afc185816f12f0bce8f30/pyobjc_framework_coremotion-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:554bd583a6c36c659e83102832b65e6829c9f4c5d7dfe30f76e4fc62ab2ae13a", size = 10449, upload-time = "2026-05-30T12:04:19.591Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/7b/b5a942442e0b716319c442dd7a8cc2232b682509034c832898bbb7ba3783/pyobjc_framework_coremotion-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:657fc69c6446878c0a6b5cc53f689f110a8c4bbf0d57ae87f1d19ebf7bfc2889", size = 10597, upload-time = "2026-05-30T12:04:21.265Z" },
+    { url = "https://files.pythonhosted.org/packages/39/ef/dc1a28f9f1fe86dd2b8b84bd1273cb1dbbf9fcd150097002fccc679eb4a4/pyobjc_framework_coremotion-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:f5d1d3b4921cb334a4951623c85d3d5a2e79d13262d244e5355e42ffc0fc09e8", size = 10514, upload-time = "2026-05-30T12:04:22.828Z" },
+    { url = "https://files.pythonhosted.org/packages/10/7d/b3b3300224f0c26381911d6d58214c0fc354d3fd75a4d2c214bf880784a5/pyobjc_framework_coremotion-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:03968db63df5b5898973936545b9a800165ab33ff672823186407e2a6d0e179b", size = 10665, upload-time = "2026-05-30T12:04:25.173Z" },
+    { url = "https://files.pythonhosted.org/packages/24/3e/c1e7fbb6d32e2ec0d5777e7eff11a96bcb564c70ccd99dd7bf68dbde8ad2/pyobjc_framework_coremotion-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:681b01d4677fc9ca6b0ab6da876087198957141fbf0799b5892beb71fbada5e4", size = 10503, upload-time = "2026-05-30T12:04:26.835Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/c9/a35d41cd83e9743fd26fe8fdc039b88fb8549c702524e97d94d0c864288c/pyobjc_framework_coremotion-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:55dc932bef0ffa3b23e7e07a4016f4fa36687204528187c17dcb19cc4d322456", size = 10662, upload-time = "2026-05-30T12:04:28.447Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-coreservices"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+    { name = "pyobjc-framework-fsevents" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a2/3f/92b7df81848039fa9b3eaa0181d9969f42dd8a208e8ba8b8d4a648c2cd46/pyobjc_framework_coreservices-12.2.tar.gz", hash = "sha256:ea52c77e9a162b6823c3b364f391b4369d967365e5207a0d45cf6d0e37cec0e6", size = 399867, upload-time = "2026-05-30T12:36:50.614Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/55/61/59b4c1fdbf05bdfa19bed5cc46b271c37f486dea17df67812702b3551713/pyobjc_framework_coreservices-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:0a3f9593b672b52ff31674104bcdd6ce6bf9f4560ca61380f2b35c904f8d77d0", size = 30318, upload-time = "2026-05-30T12:04:37.083Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/ae/ca8c1386df09bcd7175f5fa8c37cf09f458b72549843e5454b2562db7194/pyobjc_framework_coreservices-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:c07effb4e1bff841eec4304b759fe3ef73301a7b2ae3e5e3e203efe6c45e2bde", size = 30332, upload-time = "2026-05-30T12:04:39.951Z" },
+    { url = "https://files.pythonhosted.org/packages/58/5a/1413029dd792fec9e9c27c18c6a48fccaad3ec675698fc2db6eb46d5e51b/pyobjc_framework_coreservices-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:fb713264a7151a92bb11e6125da06af343037b96f6f8021e7cc8f8ff42897744", size = 30342, upload-time = "2026-05-30T12:04:42.727Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/f0/fc6dbfca3199ccb719c7591b478cd077746a924589383cc27bc426b64245/pyobjc_framework_coreservices-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:183a75dc6edeaa73f6f49b857bd5a61e522abcb5d7df1a3bee169896d0cac181", size = 30358, upload-time = "2026-05-30T12:04:45.682Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/2f/e3e711b8fb916d183f9e81c0871bb718680fd36277073e1eb962e29db10f/pyobjc_framework_coreservices-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:c2255f66669f8a70b3badae5d728abb323a042008c01b825333f6bcb1446e2c7", size = 30374, upload-time = "2026-05-30T12:04:48.474Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/32/ef39a7d4bd6fb67dd69e3680a3d27b7be0039055ced4027c7615a102617c/pyobjc_framework_coreservices-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:7c32519d13c882b2a8f844e4f4def32eec9bd3f29781bdff85750f80320709ee", size = 30387, upload-time = "2026-05-30T12:04:51.296Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/11/31ca4a107a68797b22daff1ba35d61e7b1bad951c17c1ca61c38059966ab/pyobjc_framework_coreservices-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:b17f2743ac0fe1245b16bccc2abc2568d4b33f0655b8f805d4bf19754284363e", size = 30398, upload-time = "2026-05-30T12:04:54.255Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-corespotlight"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e2/c7/ea47b22b51e9e0bc69dc4f70bf19d18c9282df5d1c11343138ee01f7022f/pyobjc_framework_corespotlight-12.2.tar.gz", hash = "sha256:6aefcef43d3d3bf3e7cbcffca053a7dad07c434aa11b117dbb39d5cf596ee829", size = 45678, upload-time = "2026-05-30T12:36:54.364Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b2/3a/a48e6bbe5159a23f946745d395463593bc3eea35a7ae4135a59169b7ce66/pyobjc_framework_corespotlight-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:e3d60d1dca50418143e7365b4535c25fe04c66af2f6304bcc4d06e288e783e91", size = 10003, upload-time = "2026-05-30T12:04:59.497Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/bf/79508c58d3f68ce8a564146dfa29ae661d9970f64f2f8615b6cba0b866a8/pyobjc_framework_corespotlight-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:d35028c872a89c0450e067c021d64b29c013fe980617aa16e9d9778f566e167b", size = 10019, upload-time = "2026-05-30T12:05:01.117Z" },
+    { url = "https://files.pythonhosted.org/packages/94/46/15463f342139c8c9d95efa0aa434494c3782472fad1ae6e0436f624eb34b/pyobjc_framework_corespotlight-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:c0d6b74f497e835f9de97aeacdab7a2c9a1544135dee1c9665b2074de44424a4", size = 10162, upload-time = "2026-05-30T12:05:02.737Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/94/4a9a50d83b026eb924f57399f741397ea999cc947367d78914ecb90ce51a/pyobjc_framework_corespotlight-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:884a7629a98703308b11a3b350899c89ad268aa278b005b289765a13172bb40e", size = 10081, upload-time = "2026-05-30T12:05:04.358Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/7d/a056a2d3ec4ea0e9db6ce74b99cd0c0037e5ddf7022f0b21a3f852957012/pyobjc_framework_corespotlight-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:70e9536e0992d0777ef24e6972788e72bc80290da89c03a84237b9ddb60e3510", size = 10219, upload-time = "2026-05-30T12:05:05.906Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/3f/0d7780799604d6d4a922491cfc6db8a12c77544e45228a13d1ef883ef3d4/pyobjc_framework_corespotlight-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:e472ac4d16b0485980f0632b8cd650515de4a6b44958fd370b00490a1f1a1bac", size = 10077, upload-time = "2026-05-30T12:05:07.447Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/59/08223d893ed5b902cb36cd9bdf93668c72cc8e882a092776c99f6cc5e11c/pyobjc_framework_corespotlight-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:61b331e85d12f550797a8010aa2f1d369a2fcd21990adbf3675005dc9e2475e6", size = 10211, upload-time = "2026-05-30T12:05:09.017Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-coretext"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+    { name = "pyobjc-framework-quartz" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1f/b0/e7ef99240f853d4dddde82c9c0114cc525de7355661b2bf2d5e04cfb1582/pyobjc_framework_coretext-12.2.tar.gz", hash = "sha256:82def2c281347e0677866315675124c84c36e9bc21651d62870cfdcecb7da34e", size = 97343, upload-time = "2026-05-30T12:37:00.996Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/72/8a/52cef4b31d5a6d3c9c426759bd256229fbf6757efec1b7f1ba5c2d051621/pyobjc_framework_coretext-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:c1845fbdb96f605c7146c478c5d562961d77aadba6cc40e166fade08e11a730f", size = 30091, upload-time = "2026-05-30T12:05:17.568Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/db/783ae8290da2edb57b479fc474c7d66a319f4fd5f1f32dd642af1fd962ec/pyobjc_framework_coretext-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:09daa6b6befea7c0d673a037d02ed13bb4443ed65d8948329ba6c8a08e06c763", size = 30087, upload-time = "2026-05-30T12:05:20.422Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/58/6d0a37fed6eee8ed4c950f71cc98355e8ce8d3a38c19aba1bf7ff6ac5441/pyobjc_framework_coretext-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:867e6f56c1c7703f27a7328d42d37cd184151657a3026cf46c0de207cc90a46c", size = 30635, upload-time = "2026-05-30T12:05:23.59Z" },
+    { url = "https://files.pythonhosted.org/packages/26/22/3c6dbe97cb5b121b01f61d575bf202238b0cd6f39f22f15d94179461b677/pyobjc_framework_coretext-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:88b9e705d47a663f079f6ebbca54f5b57f305bb639d5a9d943231596653520d7", size = 30075, upload-time = "2026-05-30T12:05:26.195Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/28/ffd7807c835010839678c6a43b7aa66d956816becb035c2371b8d03325b6/pyobjc_framework_coretext-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:dec9a67529615fbcc7c11a9a655e8d17a6095d94807e5df11e0bda55b37f0190", size = 30614, upload-time = "2026-05-30T12:05:28.997Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/49/8c56735a3758b6570e98a22861becf514057db33abe48f7bfd6e7f533b91/pyobjc_framework_coretext-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:639ba39b119f24198184abf878bc1633355fecb36f8eab57f32956252df30d40", size = 30080, upload-time = "2026-05-30T12:05:31.979Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/0a/5c881e86eda55bd4c7d33e7e93a8ef3b327e06203bfe45e16b7f8af0a3e8/pyobjc_framework_coretext-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:06bcb4e7de281423c212a39b3dc9873f09d9fd69da0abe93d987a59761bf265a", size = 30641, upload-time = "2026-05-30T12:05:34.814Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-corewlan"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/de/82/0393b32be2551bbaf09211eff01f92c60f9c3f964d6ace23f14847d88550/pyobjc_framework_corewlan-12.2.tar.gz", hash = "sha256:e0d81a95f6923c3dea9b0ab34fb0b028f5838930a602b5aa4bf9546eb268be9d", size = 35525, upload-time = "2026-05-30T12:37:04.208Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ce/87/d2a10c53938c5fe13548ae8cf39c8d807774b99288d25993feca36b6cf15/pyobjc_framework_corewlan-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:ded695a9b0e3f4df19325bff6ee6c1ca6f601b6838a1f94fcc02892408e81051", size = 9993, upload-time = "2026-05-30T12:05:39.816Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/31/95f9eea9b71b724a239ca7445f666ec29cef9df7cc9ae3cfa77e1b9c875b/pyobjc_framework_corewlan-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:6b922017499d6921a760bf3d359b1705ef31b87a2c4cfe763452759f9dc5a91c", size = 10001, upload-time = "2026-05-30T12:05:41.401Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/07/461ecada55a3d164f095e6e103d1bf9011e00334d2e7ce973048a0050512/pyobjc_framework_corewlan-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:3435e7c086ae69522354ec4fb74bcb3bbaefbc4b895680dffe6fef634430d533", size = 10154, upload-time = "2026-05-30T12:05:42.982Z" },
+    { url = "https://files.pythonhosted.org/packages/87/f4/4a6a649323b656cb4ec33453da378bf88b9feb12b61f086efe81efed5d5b/pyobjc_framework_corewlan-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:daac8e5a802e52aec0f1240430c785b1e20219b5fa9928d951e0d8d8f23debb5", size = 10044, upload-time = "2026-05-30T12:05:44.593Z" },
+    { url = "https://files.pythonhosted.org/packages/97/cf/6cc4473726dbcaba595a22ed707ec1dbc04b998d01b0a76088dcc3a7a216/pyobjc_framework_corewlan-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:d4116421fac622b0376220ce8dcf2769bd865412a0172fcea4fc3799f741ff05", size = 10203, upload-time = "2026-05-30T12:05:46.181Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/b8/b4751f8788bdaf029af09fec09ab352bde587465ede0c24fb73ce9531b1c/pyobjc_framework_corewlan-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:06e722024d349d421825ce2354846c13684777290cd00e525650e064e5a6db01", size = 10039, upload-time = "2026-05-30T12:05:47.861Z" },
+    { url = "https://files.pythonhosted.org/packages/45/70/7ca06f390a382a49545b7a5b4677cf62b81f3f9ffd19b6aff44ec0b43c40/pyobjc_framework_corewlan-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:5d31f40aad614fd19d6a9117f9a66f07eafe7a592ddc60258e9bf3f09d2fe552", size = 10201, upload-time = "2026-05-30T12:05:49.482Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-cryptotokenkit"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7e/73/f77f0dca70fee8a1999700dc878eea1e558d7d2e5088d3bce59e425f23e5/pyobjc_framework_cryptotokenkit-12.2.tar.gz", hash = "sha256:bf070e95f82db3bf8dcb0d67d459df3810bd9dfec63a31982adefba146d9e777", size = 38281, upload-time = "2026-05-30T12:37:07.321Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7f/63/a20a4ab7148a732353fd335511c1252b6ffb312c4062570c2afc192b7749/pyobjc_framework_cryptotokenkit-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:eed85a7bdc797abec1d57ea9af9a7e5cd30b428947a75cb33320290c7bf3ff70", size = 12694, upload-time = "2026-05-30T12:05:55.157Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/ad/deaada5bb4b9f1463d3cc8b2be809818a911edf3f6618053cf6ae5307e09/pyobjc_framework_cryptotokenkit-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:240f79011ed7750a441f9d07e971ae262551bae3e6a455f7dc2dc8641fbde6c7", size = 12713, upload-time = "2026-05-30T12:05:57.068Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/c4/36dff9b7c73eccedc57ec8bf60948b9410a95eb27d7e94bfd4bd89586ba5/pyobjc_framework_cryptotokenkit-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:eeaa4be6eb2cc48a73a2444d5db1ad9f7c383e23d15efab12272cc66c3fc11c3", size = 12898, upload-time = "2026-05-30T12:05:58.89Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/47/c5c5e9988faae629356f1fc0e57f80e26c095a9a015a21af0dcda129ae71/pyobjc_framework_cryptotokenkit-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:2ac46a8f261c465baa48c59b66fa4b80747033f6d9a252f23f6b7f24f2f2c826", size = 12691, upload-time = "2026-05-30T12:06:00.764Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/7b/9c924053856ef2d02ede6bd67b6df5608651422ae80b6086235d93645a1b/pyobjc_framework_cryptotokenkit-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:60a0fbc1191d239436892e84d526a80de7c57d07a2d1d713c7c21baf55743ef2", size = 12898, upload-time = "2026-05-30T12:06:02.588Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/4e/851f5ef1b357c0c1b0e42964920732ebbb7f939907005fd6470382ecb81a/pyobjc_framework_cryptotokenkit-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:15cf74cb05bdfc592c600dbf8b0cd24d18662158af93da399ba55762ef367020", size = 12682, upload-time = "2026-05-30T12:06:04.382Z" },
+    { url = "https://files.pythonhosted.org/packages/28/89/4054e14864f22515a9ef9c879d5ccdc77a9ac480f34701dfb5561dd68d1c/pyobjc_framework_cryptotokenkit-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:a0df6e75334f762402e18f949a4e8485c73361f9fbc94d4a0dc8351832687db7", size = 12884, upload-time = "2026-05-30T12:06:06.544Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-datadetection"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/22/fa/eb20c36de2d038e2c65629b600dc0642727ae68e96f3bc9a692cf0b7184f/pyobjc_framework_datadetection-12.2.tar.gz", hash = "sha256:5fe732751662f119c8435c608785e86edff1b2ee394fbb9f010b5613bb6703d2", size = 12676, upload-time = "2026-05-30T12:37:09.09Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e0/8c/080a4c6ecffe45a64db10912ecc8c777f4368f4c5ad859a584a73e7243e9/pyobjc_framework_datadetection-12.2-py2.py3-none-any.whl", hash = "sha256:23246bea4dce73c702e176ed2be1ba26afc48a627c713a91417716c3d5915ec0", size = 3522, upload-time = "2026-05-30T12:06:08.013Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-devicecheck"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/6e/ed/0c173fbee96920addd4f2d9ad0e69dfc22b8080c16f52f6d75acd459692c/pyobjc_framework_devicecheck-12.2.tar.gz", hash = "sha256:2750bdfc7fa11e02c88fc8d681dcf202ce2f52c4eaafc55f0afa38df1bc66369", size = 13324, upload-time = "2026-05-30T12:37:10.846Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/58/8dbb51f3f462ce1d1a880f8fafc47980f56e0ad1b7472e2a500c81d6332f/pyobjc_framework_devicecheck-12.2-py2.py3-none-any.whl", hash = "sha256:77bbc267426dbdf80799d9a63ed17545c2c8332e765da8f5ce34f40be78e7776", size = 3684, upload-time = "2026-05-30T12:06:09.443Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-devicediscoveryextension"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/33/aa/848457f81670d784c3a0b35887f7d16fd76bad805ec06be21f9c15012b9a/pyobjc_framework_devicediscoveryextension-12.2.tar.gz", hash = "sha256:2f3f21f9f2c0e0f714bd38076d7082c923650ce180a15aab77f271575b4eef04", size = 15744, upload-time = "2026-05-30T12:37:12.525Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/97/9a/eee0a7ed475068d2bc24f2fe6a8243da384a3d5c742f6b0c436322e0b592/pyobjc_framework_devicediscoveryextension-12.2-py2.py3-none-any.whl", hash = "sha256:d0f2187013cefb9dc3ff20abd8dd0260a257a6bd6cd661b4d5a364c877ee4ac7", size = 4322, upload-time = "2026-05-30T12:06:10.939Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-dictionaryservices"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-coreservices" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f0/f1/07b79048947dcd0ed0aa2582591a17990252a5649be725c094662ef9fbe5/pyobjc_framework_dictionaryservices-12.2.tar.gz", hash = "sha256:51e826c92fc04a0aa531bd04f092ca1edb6c470bce3f04c4eff84fbedb61d929", size = 10693, upload-time = "2026-05-30T12:37:14.263Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3e/af/2b7cb4c630a0f9f0588a53a290d96898bb1fc8dcb2abf311c20e250d4924/pyobjc_framework_dictionaryservices-12.2-py2.py3-none-any.whl", hash = "sha256:9257ed93dad0b4bcf82c871bc587f994d7619e5916df3662cc2510fe8f85ed5c", size = 3931, upload-time = "2026-05-30T12:06:12.609Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-discrecording"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ea/ae/ea8b74b528cb281555bea842abbaeed99db66e8270d9eec37a3b2f5a9bfa/pyobjc_framework_discrecording-12.2.tar.gz", hash = "sha256:0b1df1d250b892d1b48e1ce87c9c89e944c28a4bb708d43848f12ff2d69cc396", size = 61967, upload-time = "2026-05-30T12:37:18.532Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0b/f6/629885ead33cf4425d9be95c9b6f0bfa95f20444d2017fe2d07508b6de87/pyobjc_framework_discrecording-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:2cd8b5260ae022ddd314fdfb92741cb6ed72e87206148a8b1018f064e4903852", size = 14565, upload-time = "2026-05-30T12:06:18.747Z" },
+    { url = "https://files.pythonhosted.org/packages/85/18/da0b7c2bf4d4cc9f6a3863ef635d72206cd6c3959ac27471db0c6b5969d8/pyobjc_framework_discrecording-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:23e4012a55a51e5af9d5a9526697efc1a0d55a1234541c58a27b464c2fdd4e2e", size = 14567, upload-time = "2026-05-30T12:06:20.632Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/24/e9abce96b6f19979e9701dd1dada13ac0e344425e144ee2e684ae5e62bcd/pyobjc_framework_discrecording-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:067095747927b85baf7395d16c033be15db14a61c3fa8f6d2d6ce1b06ab36517", size = 14743, upload-time = "2026-05-30T12:06:22.564Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/0f/c0a93c4cc41c16ec0e71800b24e75a54e0262b895340900dd01118276850/pyobjc_framework_discrecording-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:99ef86ec82079ae4c413433ad6efe5fc526a3307cb9317f1614cc0acb55cfbae", size = 14625, upload-time = "2026-05-30T12:06:24.513Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/50/27aa4acb61f8c6275c1f188b7ffadb5c47bed5fe47a26c18edddf954453a/pyobjc_framework_discrecording-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:457a08b5f3d685e8b3802aa1e3d78dcb425616a20a38d2dbaa7ba987311437ab", size = 14806, upload-time = "2026-05-30T12:06:26.434Z" },
+    { url = "https://files.pythonhosted.org/packages/81/14/3c27363911d8ab60441c9d09a5ea900a89db4da01fc1c087b5afc5c1d802/pyobjc_framework_discrecording-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:dd4ca56fea006923bc9a581955b6f75e3f5989f76611a451d52dd3c029d1d72e", size = 14633, upload-time = "2026-05-30T12:06:28.443Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/e9/004c04389aa5d2e0cb64ba246d15e287b0294b0f63791f9b4a3cbd22937d/pyobjc_framework_discrecording-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:df4b4a6badb024dc56127614712e2666a186ec3efeafeccb6c2cc3b7f10db75e", size = 14804, upload-time = "2026-05-30T12:06:30.375Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-discrecordingui"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+    { name = "pyobjc-framework-discrecording" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ad/a6/3f94dfd9508f98aa5d152f8e56dbcdd8a0ddf2bbb9f7e180a5561772a839/pyobjc_framework_discrecordingui-12.2.tar.gz", hash = "sha256:932175c1c2df93673ffd87e4d5270bd03591548e26e39664d813b5e1b0c0a47b", size = 19543, upload-time = "2026-05-30T12:37:20.559Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5f/bc/3d75efba436c907629af9f17414f10bf105581e6e6803d20d0ab097a4b44/pyobjc_framework_discrecordingui-12.2-py2.py3-none-any.whl", hash = "sha256:4ae5d1ec84ff47cf041973c112024f7b3b7c6eb0d5cbd3cecc393998efa0f654", size = 4701, upload-time = "2026-05-30T12:06:31.841Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-diskarbitration"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4e/f8/aff13f6577bae073682c7e413ce725e51a11e2262c82956b5664621caadf/pyobjc_framework_diskarbitration-12.2.tar.gz", hash = "sha256:b5ce6750cec175066ed6dc6ccc9548201642f246130c1a82d01690747028505d", size = 18162, upload-time = "2026-05-30T12:37:22.608Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/51/c1/93db22bbc25358cf523e7a66a76de6fdfff4719ce60e86a87d368587520d/pyobjc_framework_diskarbitration-12.2-py2.py3-none-any.whl", hash = "sha256:9952012b50f8d87849ca74c56a8b6fcd9373e8b5aa4566f628165cd4a2458a25", size = 4889, upload-time = "2026-05-30T12:06:33.405Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-dvdplayback"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/64/87/6a2aa2a54df1b18f9543a2c64baa290be6e59d98b31b46559ea47b49b5d9/pyobjc_framework_dvdplayback-12.2.tar.gz", hash = "sha256:2f504e578a809ae8544e50d9958bc2101fbb0a35921f370c810b575b70d8096e", size = 34810, upload-time = "2026-05-30T12:37:25.641Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/da/70/c7cbd09f8a84f1fc904206f855688c76feb02aaae1ab4efb6f1858f0ec0b/pyobjc_framework_dvdplayback-12.2-py2.py3-none-any.whl", hash = "sha256:37d0b460e0783c78c3099a653ae1a7db8158b12e4da6ca91d513ec708514baa6", size = 8244, upload-time = "2026-05-30T12:06:34.978Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-eventkit"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fd/63/1acab761201e3ba2ddaa093470bb94373a11cee4f406587fb687e31062ab/pyobjc_framework_eventkit-12.2.tar.gz", hash = "sha256:c4e96235a1f0e43ea9699054c289369efb9d7645254a6169559c671b4ed21f86", size = 33759, upload-time = "2026-05-30T12:37:28.465Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/90/c0/257069ea9e34c3b0dc473f6ac9c03c95029e9b3c686875ae8f1c564eb0ac/pyobjc_framework_eventkit-12.2-py2.py3-none-any.whl", hash = "sha256:b56a736182365eff268b6a8c958a663d53432bac5befd3116570d3f1e4ec8b1a", size = 6924, upload-time = "2026-05-30T12:06:36.781Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-exceptionhandling"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/6c/77/2ecf87e8ddffb3c43e0c79bba7e1113436b45c3bc30ee76a82e94f5028ec/pyobjc_framework_exceptionhandling-12.2.tar.gz", hash = "sha256:c11ab2b122b6f2d1dc4625d163a2c5713df5ec3b0372394d3b6ed875a49397f5", size = 17168, upload-time = "2026-05-30T12:37:30.505Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c3/24/9ab5cba61d04445d36ef2bd52ff871056cedde22c3a2a4ff60f111d1f25b/pyobjc_framework_exceptionhandling-12.2-py2.py3-none-any.whl", hash = "sha256:14a76583bec99e18c5d0b0fd1db554d6f75b614f2912435836bc4abe6e1220c5", size = 7114, upload-time = "2026-05-30T12:06:38.383Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-executionpolicy"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f0/e6/ad5d770d04c5cd057c20362724246d1a7407883854e065c86122bcfdc272/pyobjc_framework_executionpolicy-12.2.tar.gz", hash = "sha256:9b527b0deede8057a6482a6837ad8b3f6c3117232b8c9f97a3244991c9d0449f", size = 13040, upload-time = "2026-05-30T12:37:32.139Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9e/25/4b8994d6bc1b4647546a89225770e68121dad788e26fb2eba458e028d6fa/pyobjc_framework_executionpolicy-12.2-py2.py3-none-any.whl", hash = "sha256:a8b6177182c1cf316696db76de23dd40b47e41e8eebbe6fa204492055c8f1f3b", size = 3774, upload-time = "2026-05-30T12:06:39.998Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-extensionkit"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c2/37/d8578fa098ce7c4caf70bd02cc52ebae57dba3beeea260e27f10852ab738/pyobjc_framework_extensionkit-12.2.tar.gz", hash = "sha256:eb85b5ccea05f5bc41d5c134a2d199eae2a3bc4ee12cdddb94501272a45052e7", size = 19199, upload-time = "2026-05-30T12:37:34.066Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ea/2e/f5a6c1f22f4237085b047cc5a632a2bd1c637e716e68562ba89a899d2d1f/pyobjc_framework_extensionkit-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:8596735e5ea62af326a13fe61cd815027896e8960d32f7ed18f8c55e2911bf35", size = 7931, upload-time = "2026-05-30T12:06:44.916Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/7f/21d173aed300819ff9e7ed9918c8817f6279c0c85687208fc5466e92efce/pyobjc_framework_extensionkit-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:e81277815e9b7ad6adb8141be1ddc794cbb92acbcb8b582f0b929100c6528ffc", size = 7943, upload-time = "2026-05-30T12:06:46.384Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/cf/c75dc1b6a171743eb45ba4a28f51eeb3d348727d2b85c7af32609e18847c/pyobjc_framework_extensionkit-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:7f480965e4c3d06f352116f9362ecfaee20337f16a832c3f39ec185ebfc87553", size = 8084, upload-time = "2026-05-30T12:06:48.235Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/41/acaf60a6fba4235d3d5079a5ca8a9b60b50cdc20408f3c5c8d3719f6a73e/pyobjc_framework_extensionkit-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:e6b8b9ee143cba5ea27fb3afeb5beef58a33525f1d3374ea40b339079e853c2c", size = 8004, upload-time = "2026-05-30T12:06:49.713Z" },
+    { url = "https://files.pythonhosted.org/packages/53/34/cf0cb884f1d38f50da523e98aeffb5b5d09f81f129b5fbb7cf4d908d73aa/pyobjc_framework_extensionkit-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:bf4744cd6d3722a76dc61c8a7ff356457fb903ac5ac2fe20f49cc6f18dd95074", size = 8142, upload-time = "2026-05-30T12:06:51.395Z" },
+    { url = "https://files.pythonhosted.org/packages/73/9b/4dd5a8d62b8f8617f62f541befc4cc7ac5f8391add198641f723e64aa0a8/pyobjc_framework_extensionkit-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:0d29ad16d7abc03aec419a47a02cb7f1904345cfab2ea3831ba8f8ad58d494d7", size = 8003, upload-time = "2026-05-30T12:06:52.885Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/28/44c7d7c10ba9c395d5240652ef1dd82c02462d30f100a2876b46e5c83b77/pyobjc_framework_extensionkit-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:b355d0689196bb5b3a62c73fb1a9abf4b68e5582cce2b1057f2a6a02a7177f8d", size = 8139, upload-time = "2026-05-30T12:06:54.705Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-externalaccessory"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ea/fd/8eaf82d13c74834007c716a13a10e6c2dfc0edaf62248c4801ad951e924f/pyobjc_framework_externalaccessory-12.2.tar.gz", hash = "sha256:0df5c2db52220753e3c7673fa3051fdf5d2890b9972dc3e140edc3dc16c7cd4d", size = 21989, upload-time = "2026-05-30T12:37:36.303Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8a/89/e8fb9e30707a4535be8290788a950e02a28cc9c34de273833c3aae7207c1/pyobjc_framework_externalaccessory-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:01ee6ed84a307a8071de27cda8bc8abba748e818509d622728ad2c5f8d334f09", size = 8922, upload-time = "2026-05-30T12:06:59.557Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/0b/bf64b437eb48e86078cd2e9303ff4f45f1ea43b2f0febdf2bd03f44708c3/pyobjc_framework_externalaccessory-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:c04313f4b68982d9f9f23d208f234b44d80472000b9945392459eddc44a61121", size = 8942, upload-time = "2026-05-30T12:07:01.214Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/98/2588a2e1888d91f1059ad0c3d1939a213f23fb5bfe0130828808eed3393a/pyobjc_framework_externalaccessory-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:e546bb0db0e6832a40ac4978a24117eb1f93c2f419f6f26d908fd4315f04bd8e", size = 9105, upload-time = "2026-05-30T12:07:02.797Z" },
+    { url = "https://files.pythonhosted.org/packages/16/5d/fb59ccf789d1a68048163f83ee3250ff0990fec759846ecca9c57dfe332a/pyobjc_framework_externalaccessory-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:55c985489251fae171a743a2d86f7d3011e8c5283e22aea803708d4fd2cd1c23", size = 8995, upload-time = "2026-05-30T12:07:04.42Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/53/a5831ff85fe3c16c38c210dc605961a26dbdabd8e27e996ace0a59c13f56/pyobjc_framework_externalaccessory-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:1cc058e0a036d4c5c377272173029120f8950595688139d12f8e702e250dc479", size = 9179, upload-time = "2026-05-30T12:07:06.008Z" },
+    { url = "https://files.pythonhosted.org/packages/64/53/67748fab7d4e7e438db5d7fdce8e35f546654041868763cf26da99fb5ece/pyobjc_framework_externalaccessory-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:710b9da3f123a53c3b6618d920d07782462b68060c51f772caa490535db1880e", size = 8989, upload-time = "2026-05-30T12:07:07.662Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/a3/797b5d182fd3433996a87dd87097845062bbb738c4612ed0bd90c54473df/pyobjc_framework_externalaccessory-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:02e4c9fe185372906f4cbde8d16d5756e71c134e969618703e3449414774eac7", size = 9162, upload-time = "2026-05-30T12:07:09.217Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-fileprovider"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a3/a4/44d4f784ed0601800c80e06c53e892ccc39c2a5545bb1caa13b661fd6d83/pyobjc_framework_fileprovider-12.2.tar.gz", hash = "sha256:f9b146eab8a7f664f0e417310802bc2e31ad52b0f61951ce58e471a989ad4e71", size = 50565, upload-time = "2026-05-30T12:37:40.136Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/36/cd/ec8d50d5b56f4edbf2d9622f495c99aad8842c7cbe9729089d695f8d3eda/pyobjc_framework_fileprovider-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:659790edec0edd536732f79d16a44bd7b4c3112b410d463615514753717a26d4", size = 21067, upload-time = "2026-05-30T12:07:16.232Z" },
+    { url = "https://files.pythonhosted.org/packages/57/b6/27766ae4419f64f654c7c0b1f9892a0f82baec01a298fabd45d4fef10dfa/pyobjc_framework_fileprovider-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:5718203d129eaf32dbf454b2a7a5f312f2dba108a4b49fa0536702537f93c961", size = 21080, upload-time = "2026-05-30T12:07:18.475Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/48/bb7466f3a3d990868eccee96c6eb02155af2aabb08b705f90302789848c1/pyobjc_framework_fileprovider-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:78c6528c5d59881f88b2fe657fb48aa75b652b830ca18f58cabc1ece2f308ff6", size = 21360, upload-time = "2026-05-30T12:07:20.798Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/e9/60b8fb83afe07e69b0eddf382f2847bf642cb70ee5bc38ebd703b1a73f01/pyobjc_framework_fileprovider-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:746dcf3149920fe858d4b0bb725175f6df5cbd30fd35ff73a10cef30521c6398", size = 21117, upload-time = "2026-05-30T12:07:22.963Z" },
+    { url = "https://files.pythonhosted.org/packages/97/ae/e4eaf9f79210ee04eff41af0e890b6f2b5c5ce7780a5f54d8de038136397/pyobjc_framework_fileprovider-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:950b1d249475ae9d4f3c2b96058be4be2cda511eb5590c3f3f2243b7c6f75de1", size = 21397, upload-time = "2026-05-30T12:07:25.32Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/9c/4a514f54b03981f9cf3585b0052f8017005f876fb395e6e3986e9ea49f2c/pyobjc_framework_fileprovider-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:dca30fb647c7d22fa0de5d3c21ea6db01e2820ab9ffba4ae75cae53a6d4b750c", size = 21111, upload-time = "2026-05-30T12:07:27.832Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/00/de7f14ebb96afa2551384330b3e8f3a51cc4fc158b5fb49d7beefb24816d/pyobjc_framework_fileprovider-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:f9002875073d1e0c74d760518bca5101743392515478eed570d67f28bdb6ba07", size = 21396, upload-time = "2026-05-30T12:07:30.111Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-fileproviderui"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-fileprovider" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1b/53/ce4fc44c62f813e6572426c0f66475f5a5e4804693001185faa80aa95af7/pyobjc_framework_fileproviderui-12.2.tar.gz", hash = "sha256:520974c2966057cd47206f8792d8066531551b3222c8a5824851cc19e9bba7f0", size = 12852, upload-time = "2026-05-30T12:37:41.84Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d5/40/4514fc9cf9b9f20d2abe1dac66c4f94b8c20da9db7865ee9dec9dd6f3f65/pyobjc_framework_fileproviderui-12.2-py2.py3-none-any.whl", hash = "sha256:0874b16ea64d055f53d0c6ede6ba61b3dbe9d2b27a64db5c12b829391a510cb6", size = 3715, upload-time = "2026-05-30T12:07:31.596Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-findersync"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/54/8c/dc4e185d054d422f0b24417dd0a340923f7cd317e70879dcbb740bfdd01c/pyobjc_framework_findersync-12.2.tar.gz", hash = "sha256:e8c8dbfd0c1e9a055d5778c8f65a72bfaabfb8c30ff9ef635ea25ee2d607dd75", size = 14210, upload-time = "2026-05-30T12:37:43.536Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/98/3f/cd17c17bd1e3baa57388d80c5343bceb02df455047a3cfb91498b32849cd/pyobjc_framework_findersync-12.2-py2.py3-none-any.whl", hash = "sha256:6f7a461df88f4fe0cd64c0ad326c77bf1a8f72afb1bdf1f42c1d7e02b7340dd4", size = 4887, upload-time = "2026-05-30T12:07:33.154Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-fsevents"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/35/cb/f3fa1c24c2f7b3fc086b5cd0d7ec8bed1d5524e2b77d6e7b5c86d05284d5/pyobjc_framework_fsevents-12.2.tar.gz", hash = "sha256:c6599daed508605916fa31b23866c20ccc12565b568f61a43b5626d9b8bb8778", size = 27156, upload-time = "2026-05-30T12:37:45.922Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/69/cd/714e19b57f11c2f92e1b31787846f5ee806d84897f01e6d8d39ec51843a9/pyobjc_framework_fsevents-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:3a96802c25cbdce74b5d02bbb00cc85747f8f745102d3d22ec9bb540c2e17ac6", size = 13130, upload-time = "2026-05-30T12:07:38.808Z" },
+    { url = "https://files.pythonhosted.org/packages/67/61/e5376e0c3a95b93a6f1a77f68ca7a454ffe892ff6c5f301f4b83231a26a4/pyobjc_framework_fsevents-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:b4adc50338dc4f9f50f3525e2f070e2ab4b469976f9d4762e373505f82068831", size = 13131, upload-time = "2026-05-30T12:07:40.621Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/14/f0fc106e63187438c783f2b8480470d43fba311355343856bda91899248c/pyobjc_framework_fsevents-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:a00440f1e79f6639ffd601bf973d6c7064d82174da8433999825c33617d9c053", size = 13496, upload-time = "2026-05-30T12:07:42.429Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/6d/7cb724925e45553698e674ef48830052e1f7433d2ac715f90efc1c000ff6/pyobjc_framework_fsevents-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:caa86498ea298a542664222b33f6db2b09b7d315e1b1cb702c4652edb1fdca92", size = 13032, upload-time = "2026-05-30T12:07:44.421Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/c8/f049d4f2b39f254e91c79e8b9703a42ccf712ed1169d79ba0902fb4edd7d/pyobjc_framework_fsevents-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:b8e479864e232d76945219bcf3af12983a127a282f57af50ef089dc1b5116787", size = 13487, upload-time = "2026-05-30T12:07:46.371Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/46/176656c8bb720981e1806ec2f3c4396fa3f6ac9625bf69bb2a558b78b1fa/pyobjc_framework_fsevents-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:fe72e987dae3919e80e7c3641d74fee8fec2ca841268cdb855f903b0b9f6f681", size = 13034, upload-time = "2026-05-30T12:07:48.198Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/0c/c3a1ea89db895fdd0ce10a4d2c4686ad8e404482b4d9c407ad44ad9d3b13/pyobjc_framework_fsevents-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:7665f7e2944fa50727e818dfa45a2c6d1234bd64d352559c2d6f3946febcf707", size = 13516, upload-time = "2026-05-30T12:07:50.03Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-fskit"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/cc/46/9f5162cfde0340792043ab60d1a039f442a67b001f7bfc981b6837a9b07d/pyobjc_framework_fskit-12.2.tar.gz", hash = "sha256:a1a7f9678c55fa947783caa24325c91727cc3045b877c6770262790c00da3952", size = 49558, upload-time = "2026-05-30T12:37:49.685Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fe/8e/325d1664fb5aefa2d7c2b3c3efc047cb2ec0b59f5948d63079c00ec35016/pyobjc_framework_fskit-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:3098dd1bb05c1e59fac70695b93e42f068735d0111aabff844781918895eedf3", size = 20586, upload-time = "2026-05-30T12:07:56.916Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/ce/6bec42dade6873cf440f62d18be277b342b326bdb0ee7835b5f79b2748dc/pyobjc_framework_fskit-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:fcc8db6cf9e9b0e731e056411976c184bb3861288da4e97dae91a3e3e8063ade", size = 20597, upload-time = "2026-05-30T12:07:59.189Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/ce/385a29b02bc81bb70169cc2a5d85b78d3af131a113acb2615d87f12c5f16/pyobjc_framework_fskit-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:1f3935499d00678da05b97a7baa46bdbecaef3fd61768fa5dd34bd3dd484ad55", size = 20826, upload-time = "2026-05-30T12:08:01.384Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/61/b2900135b0cbc46edbafffd9b2bc13482d9ad417b7a09876464a2be09f14/pyobjc_framework_fskit-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:844a2b9f7377cbab03a578f0ef354450cff86d1520cd4f9a326590776df914fa", size = 20632, upload-time = "2026-05-30T12:08:03.59Z" },
+    { url = "https://files.pythonhosted.org/packages/58/95/b926293d92e47ad6a5f6e8dd86b0e3625e9e5e0c8b478d954ee6b4553d92/pyobjc_framework_fskit-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:7504760f3ef0337375ab6ec91688903981e71c4f65f5791778b34c7b27b54aca", size = 20890, upload-time = "2026-05-30T12:08:05.832Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/b7/968e71f283ec520c5d4d994b51849e2e409f0f1c8de1adf588a42354d0b0/pyobjc_framework_fskit-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:47fda8a47bc4711ff697601b4dce606ed75cd460f3a52fe1d3214fbb79acc6d8", size = 20634, upload-time = "2026-05-30T12:08:08.032Z" },
+    { url = "https://files.pythonhosted.org/packages/17/fd/b0cb952a57c1b133aac064f566c7e4bb38485fcde5c710d7f8c48e902102/pyobjc_framework_fskit-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:c8f247c6b3b77edea91f70e9c125f7faa493807c5e6b1922842c0046bc83bf52", size = 20895, upload-time = "2026-05-30T12:08:10.272Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-gamecenter"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/18/bf/71c09142969953637a524946c3609ddf472c0b4311d134223cc9c87dbf8f/pyobjc_framework_gamecenter-12.2.tar.gz", hash = "sha256:a1207696a547011094a4b8d2865a3a9018a622647a8a0371baf86a3e5959ef4f", size = 32153, upload-time = "2026-05-30T12:37:52.717Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e9/6e/fbf225a5826cfe68c447dbb1937d9c652617f5191772af95abca932cd252/pyobjc_framework_gamecenter-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:d777dd5f2a1e4849434cb56f82418b4ee781718710b36c68860a91d85dcd1f89", size = 18865, upload-time = "2026-05-30T12:08:16.687Z" },
+    { url = "https://files.pythonhosted.org/packages/41/77/2496866b618c96b3569da87385db6593688222f6fcaf733cc702abf0309f/pyobjc_framework_gamecenter-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:c5ff47f68b0f5f138fb91f03e5cc46dd12f00d95f795ed5b88f8b99c52e54e2f", size = 18868, upload-time = "2026-05-30T12:08:18.814Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/d0/6ec40754993e4f6f0366d7a13e5a19b6745b7c7d6395f2be0b3b60d5688e/pyobjc_framework_gamecenter-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:ee1890cc3e1266407d41475659b382067a08765bdbc62a0ae4eecec733491fec", size = 19153, upload-time = "2026-05-30T12:08:20.886Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/52/7b37cae6390244058278a9322166b1d65f2a723d081b3d57f9cb4e5e3aca/pyobjc_framework_gamecenter-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:bec386091dc9ebad94939acd26d2877d8f3a6dcaefab8a8336bb384b8f3c8f4e", size = 18916, upload-time = "2026-05-30T12:08:23.115Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/86/89f7a17d40f0cfcf546f3be1ec9a3c4aee77e7e875cee569aed6082c96af/pyobjc_framework_gamecenter-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:81e9e4680f13061a59b2814fbb316c17ea6fd41333b1dcc368c5210a26ef466b", size = 19209, upload-time = "2026-05-30T12:08:25.328Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/33/2ce5abb83cc70f3504ee46e660d1bc3ecb5db6ebee64409493b29d3c7afa/pyobjc_framework_gamecenter-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:96dade30ae38e54bf58aa4b727f66dd3b2c5918b5855502c099b0eed441448c8", size = 18906, upload-time = "2026-05-30T12:08:27.458Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/bf/f4f28be2dbddc09afafd1869e1b09b5b65b692c7a3f81d36dfdafcab7a8b/pyobjc_framework_gamecenter-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:834171b3059e778365190dfef1e075ca897cfb0a11e4af9f8a59d3a96285f16c", size = 19193, upload-time = "2026-05-30T12:08:29.562Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-gamecontroller"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d1/4c/440ac9652cae2fc386702a39973008fe0fd18928f70b359728c1926f5350/pyobjc_framework_gamecontroller-12.2.tar.gz", hash = "sha256:130418999cb5e202c0775fc1587666c6b9fa1d9285341eb6cbd589ecbe758a64", size = 65272, upload-time = "2026-05-30T12:37:57.45Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8a/cf/13e069a6c302c7f12e8a2fdd4da0ec2e4673936db28cf129af238d0cfb9f/pyobjc_framework_gamecontroller-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:76b488179bef3430eb91a5cd2961659af0d98893a577fe532e0c4af16b525a7d", size = 21503, upload-time = "2026-05-30T12:08:36.688Z" },
+    { url = "https://files.pythonhosted.org/packages/65/54/519b19e43bb3fcb8058c9cf780d324e7b3532a1b8a317ff1831615993206/pyobjc_framework_gamecontroller-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:8a448b31594c68993da348c3f2f24c02323853905e999f930d7c5d0fa6b4468d", size = 21517, upload-time = "2026-05-30T12:08:39.214Z" },
+    { url = "https://files.pythonhosted.org/packages/da/f3/11be9f022e2cc30f1ff2509bdb8405005b707beee2a01b70798054c52cdd/pyobjc_framework_gamecontroller-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:d5a5ea2c31f179c72dfbd1564aaca52fcce742c27f91e2c7af37ba1e4777c3fa", size = 21768, upload-time = "2026-05-30T12:08:41.309Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/33/73b0769f8d91ccc992c4fc53bdc7de7ea8e1e425769b5a09e2136bf14d30/pyobjc_framework_gamecontroller-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:77f7e1155f7789ff5d86b202a37eb731db7d37796d4870ec9830bc94850ea806", size = 21537, upload-time = "2026-05-30T12:08:43.615Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/01/7786c685582915f804f137509c0e0e6b40fe3c3de4419eac7c7e6969b3bb/pyobjc_framework_gamecontroller-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:9e79ab9d3133d0e104da33bda7207f293cf0b981230969b8d865fed831631681", size = 21836, upload-time = "2026-05-30T12:08:46.036Z" },
+    { url = "https://files.pythonhosted.org/packages/49/02/6d1347c85ddc14238683e0e76ed588d31463e447b2f754a66f8d168e9b2f/pyobjc_framework_gamecontroller-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:221c88cf75b91abb75e3bbdbd40eb962c467b9568bffea9decc09b3da26ee2c0", size = 21539, upload-time = "2026-05-30T12:08:48.536Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/c1/91d0459b9811309b817b96a48ba0a1a233146a19946344797d3b83f5f593/pyobjc_framework_gamecontroller-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:821098a524459089c77b19c4d11a378378fb010732babbb9dab1ab11118b5149", size = 21827, upload-time = "2026-05-30T12:08:51.002Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-gamekit"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+    { name = "pyobjc-framework-quartz" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c6/e3/dfc67af937bdf98b92fc0f6518bd1ee17cf84025ded15bd64acb91f0db8f/pyobjc_framework_gamekit-12.2.tar.gz", hash = "sha256:d4f4f98539db6125d5fb249b845398a0534f8962e6db390822da808b91ece009", size = 82428, upload-time = "2026-05-30T12:38:03.157Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c7/90/6c3f9d8892d1c1490a76625d05817ae98cad664a56fe67c260a4a13662e7/pyobjc_framework_gamekit-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:5bffec60177b0e2e20c239dd70035903a1937b0f9a8174029aa87a858ff8eabc", size = 22563, upload-time = "2026-05-30T12:08:58.282Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/26/f1af94c102570afb8ed0e1461fcc752098d8ea12e88959cbc3cd25709005/pyobjc_framework_gamekit-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:06ac26311a602aa0674c21d6dbc3fb0a19e0d8cc385e2e80b689518c3737df8c", size = 22571, upload-time = "2026-05-30T12:09:00.597Z" },
+    { url = "https://files.pythonhosted.org/packages/74/da/4020429066e04b02c1e40662dd546bba30adfbbbb19a3b87a4007bfe0244/pyobjc_framework_gamekit-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:d915b5a8e8073769f0c371aedbbce31152859ab6352f7488f815bd572e1a12da", size = 22864, upload-time = "2026-05-30T12:09:03.066Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/fc/bd02d01198a4119f55b078a34ad90e6627be258d6eb9c26b570a39ca5407/pyobjc_framework_gamekit-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:c891baea8d3f6530dfc0f1e824228ffd05f7e65f0053dc39c4dd6e3e56307b9f", size = 22608, upload-time = "2026-05-30T12:09:05.559Z" },
+    { url = "https://files.pythonhosted.org/packages/69/95/aca261e802409b745c2a0bf57a1dda51a67c51ee19bdabde40d63978c23d/pyobjc_framework_gamekit-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:e4c0ca676cf6979d0ad503362c4f90bc46e22ef886528778ca086906080c53ca", size = 22922, upload-time = "2026-05-30T12:09:08.061Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/38/3deae98b764d3379e3a3841fa4bfdf090934b396472ebbaee5e91a1230f0/pyobjc_framework_gamekit-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:af4251f67756f5ebb54c2e16aa3a6ca6242202f52bea0b5b04ddf2ad35aa5648", size = 22595, upload-time = "2026-05-30T12:09:10.243Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/25/8c3a7d542728294effb68e07b0494ae1773aa5984d248808d369e0bf8563/pyobjc_framework_gamekit-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:97ebf06d2140661ab01701a91534b7ff9387625ee61e372370894e3debb004ca", size = 22913, upload-time = "2026-05-30T12:09:12.757Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-gameplaykit"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+    { name = "pyobjc-framework-spritekit" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a8/72/df0abe840ebc9e62f8a04afefeb38997b7774ab2b68ceebe89a9dfb81b2d/pyobjc_framework_gameplaykit-12.2.tar.gz", hash = "sha256:27da2b7c4cdef038215246fc6c98e45e076f969ebb83d827095432a8213b57df", size = 50735, upload-time = "2026-05-30T12:38:06.977Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/09/58/935593360dadbf4d266bb350bb950e024b800057bf25bc880b017f5ceadf/pyobjc_framework_gameplaykit-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:792b527bda8e5784db552f4366de4e01f747a1b40a2c5445ed95cc75a687784f", size = 13612, upload-time = "2026-05-30T12:09:18.299Z" },
+    { url = "https://files.pythonhosted.org/packages/68/47/58dbd455f2d3cd18598408a45b05580387e788104148993aa79b8f4749de/pyobjc_framework_gameplaykit-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:89a695937dff8a4a43ac9d389b5f3eb64ced06410e8fbeb6e04f1976ed7c8be5", size = 13624, upload-time = "2026-05-30T12:09:20.136Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/73/87d2d0f4b97942f1401fd8985e8d7b2191502ed210c945472da1e37a4d2a/pyobjc_framework_gameplaykit-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:db270f78befada566106e3557bdc7281fe2f2759cf81e664e9a45ff2ce709c72", size = 13839, upload-time = "2026-05-30T12:09:22.044Z" },
+    { url = "https://files.pythonhosted.org/packages/12/90/a87ffcf7b241918b09cbfdfefe2ca2a990c8645594953e121933530b62ef/pyobjc_framework_gameplaykit-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:68482906120a563ec2830cc02e8548b98d6203893ff1e8164e2612bcc5837ffe", size = 13627, upload-time = "2026-05-30T12:09:23.891Z" },
+    { url = "https://files.pythonhosted.org/packages/18/a8/8b031c9768c6f0c01d338b5adc3e5491be558865307af9a395c942053fc6/pyobjc_framework_gameplaykit-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:92856cd1752fa4e50fb9522790969d57ceb8fd5ae45c9f766bf3d6256d5ddd86", size = 13821, upload-time = "2026-05-30T12:09:25.689Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/f1/5d137c44e4e4c8b130bf225f67a3fb36ca0fed410a120f0fa226977628cb/pyobjc_framework_gameplaykit-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:c9e60138e7d2328085db96e1b4ae6100912c42fb8f8871d753f4b4ea4fe6d56c", size = 13621, upload-time = "2026-05-30T12:09:27.506Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/8b/8fab0ee194b93f8bbac39e0eca9b6e32562a1aab994d886a839bf4d75f7f/pyobjc_framework_gameplaykit-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:14cb763e39a8705cdb39a28ada1c9ef2c5bdd47440155d1fb16a49641810920e", size = 13819, upload-time = "2026-05-30T12:09:29.466Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-gamesave"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/49/fb/aed9853de0ac26c768c1bfefd7c32443367e489d16f5b5563043019aecf7/pyobjc_framework_gamesave-12.2.tar.gz", hash = "sha256:e272a1ec2fc84f680226abc6a4e034534509cbd545cb937fbc76b3a95d7b9e44", size = 13245, upload-time = "2026-05-30T12:38:08.719Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e1/da/570c14f8c63cda0a128084cfc53f729e9183987b4a5582cc5ce4b3dbc6b7/pyobjc_framework_gamesave-12.2-py2.py3-none-any.whl", hash = "sha256:766d6eede6e7f9ef1c43333127ce42fdfa9438e62ab94c9533d32d41eb79233a", size = 3729, upload-time = "2026-05-30T12:09:30.757Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-healthkit"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7c/c8/fa1a309cabfa0d7190a6dc1f6194d349cdde0105b86683780190aa4e46ac/pyobjc_framework_healthkit-12.2.tar.gz", hash = "sha256:48bda5f86fff2da976c49d27c746cd190d62eebdfa6197305c3656c64a6fbf09", size = 116197, upload-time = "2026-05-30T12:38:16.268Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/33/07/e2738cd62bd458a903112c6b3aec3bdc56c5fd54a734da49e19c5ae808fe/pyobjc_framework_healthkit-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:b08b6a12a85c50bcd24286e3477070a60a9e602a34e14f1d1952fdd58e3e51c6", size = 22044, upload-time = "2026-05-30T12:09:38.055Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/44/db40ed76d01e0a99820f56dd0792448dbc34d508d2235d9185ec0fbb3db8/pyobjc_framework_healthkit-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:489858fd2cf97747390d14bd5343448a9cf612383e96958fd70968d1d7e75d02", size = 22058, upload-time = "2026-05-30T12:09:40.434Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/88/839c556d8e8e75b65961e65b78f683113cca6637e1917c9c4c0e2f050249/pyobjc_framework_healthkit-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:c8d43159c2c40641f9306407ef909b338325028846d04feaf2b26673d6b1bb4d", size = 22228, upload-time = "2026-05-30T12:09:42.738Z" },
+    { url = "https://files.pythonhosted.org/packages/38/39/82d7c9e65344b6d223ea15132471e3091e85a6f0fb6e4672a27f2290360e/pyobjc_framework_healthkit-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:94a42750ac0fc7f0e624f5541798dc9dba4e557569016333c058552f29f237ef", size = 22117, upload-time = "2026-05-30T12:09:44.846Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/2d/ef8d426d61ce4b41bdaa288b39246e7015264d96023318955e30f135e4ad/pyobjc_framework_healthkit-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:61b255e761c606a11f5a889cd3f7e251ae730bffbdd492e742030cd381ed69dc", size = 22290, upload-time = "2026-05-30T12:09:47.123Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/bf/c74fdf554df43bd0a52c97737e902aafa54aa5c38850749549c7b7a35054/pyobjc_framework_healthkit-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:328ff39f3ca9a4153c57b4a0ca38f7a5c8f289021f204c7347b04021100c277a", size = 22108, upload-time = "2026-05-30T12:09:49.443Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/e2/aad8f382f66cf5bbeb5ae87b162771ba3015215ec26b3d13d72a8f7ca064/pyobjc_framework_healthkit-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:6bc2c41c2e4c42485bcb07a583dfa575678b1f220ec8b8186504495941d81793", size = 22274, upload-time = "2026-05-30T12:09:51.803Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-imagecapturecore"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d0/7b/fada6744e9409643f7ec948a9b8fd5632a8f935d2c1d53e8a9f443a613bb/pyobjc_framework_imagecapturecore-12.2.tar.gz", hash = "sha256:c2931ca0d40d6ffe159149e140d4d158d3f844f19b99dae35f57c34551434eea", size = 53438, upload-time = "2026-05-30T12:38:20.318Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/26/ae619b47f178d4fbf3b3abe277e1e17000b2c396f02f8b09e9206473a6a7/pyobjc_framework_imagecapturecore-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:ed4af478ae05a0c6890bb9b89fdd02e44ce5e6602145d5796299df1b729db43a", size = 16039, upload-time = "2026-05-30T12:09:58.219Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/39/23ab07b2cef5e26b017723f061d5941416a107679f19f5327b6576cf5df0/pyobjc_framework_imagecapturecore-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:12514630d46621acaeae0b921ee7c9c9e4a2bf81a936690b767a6b745e899812", size = 16055, upload-time = "2026-05-30T12:10:00.367Z" },
+    { url = "https://files.pythonhosted.org/packages/13/d3/fed9ab9b40538711e3aba6c7b92a38c5439427510dd318923237f2280dc4/pyobjc_framework_imagecapturecore-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:56dbdee10d3d735fadfa15b3e7b9a11d3574493a4114fe9bf0eae86f55b43d2e", size = 16240, upload-time = "2026-05-30T12:10:02.684Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/4c/c35456724c11023080016a693bfd045263d57b493532bac08ca953c6d886/pyobjc_framework_imagecapturecore-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:daa65200664f6098ddf8f7525a83bcf77766fbbff98eba54226318cc624c0d2b", size = 16052, upload-time = "2026-05-30T12:10:04.856Z" },
+    { url = "https://files.pythonhosted.org/packages/86/94/fa7ab262c873fa598e97b3a514b65237fa7b179a70b537eec83dac18d4a7/pyobjc_framework_imagecapturecore-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:8e072e4ec1f67608e932bcf08a37972c10e91f1dd1dc92a7ade7210553aaaae5", size = 16234, upload-time = "2026-05-30T12:10:06.758Z" },
+    { url = "https://files.pythonhosted.org/packages/59/b5/126e7612bb1113dfcba7469c6a7a5440d41004f0c1a1fab688d5ad8a16ed/pyobjc_framework_imagecapturecore-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:bbefe336223ec5b3b18a211a6b65212da0cd5caa03124a9bef75e175ae913493", size = 16043, upload-time = "2026-05-30T12:10:08.913Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/5f/8cacbb42d183d47367a5aff499eb7c7f262bfc508ae10dd581d8a54a8568/pyobjc_framework_imagecapturecore-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:40488cbbb0ac35545a5f55c1e06327d43927db2cbd1e339cebbef10e4e12aba2", size = 16233, upload-time = "2026-05-30T12:10:10.913Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-inputmethodkit"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f4/8d/b9ba4cf37ef153584df3098cbc19ba668aef8469f18af53ff464eed1bd96/pyobjc_framework_inputmethodkit-12.2.tar.gz", hash = "sha256:63ab93867f25a3f54fc55e98b6b0540d0d23bf6f91a0a475ff742e4221a75917", size = 26270, upload-time = "2026-05-30T12:38:22.832Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d6/ea/e1f7e0d5984a6396e02930864e4260346f63506bf202a5e39a2052bf3f1d/pyobjc_framework_inputmethodkit-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:877c3fff5142434a8c7a5c357b5d44b731ecb1572c8f3ae275d54868fa9d46ce", size = 9509, upload-time = "2026-05-30T12:10:16.115Z" },
+    { url = "https://files.pythonhosted.org/packages/49/88/e5fc011ab34970cc1c1cc56b866e2edac6d160d25aafad7e86b033826cbf/pyobjc_framework_inputmethodkit-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:160ba62082a30d76b9e4aec1a4d54c95152fe39217940fea597756ad49910dde", size = 9527, upload-time = "2026-05-30T12:10:17.693Z" },
+    { url = "https://files.pythonhosted.org/packages/43/68/3c2fc27aab9cf228ede204ad7c8d1fe5f4e714aa4e478fe943dde6417258/pyobjc_framework_inputmethodkit-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:0b81fba64e92953ffc1788ec13c630a9d19447deacde34a7309c0eae6412d628", size = 9694, upload-time = "2026-05-30T12:10:19.292Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/4f/b8b96ca3392c7157e3abcd67f804ff1bc653b8a1c8c054a7717454e7d5b8/pyobjc_framework_inputmethodkit-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:ec6fe7374c080676b0a3d54906f542fdf49d685c45b7988e03a58530f54b4522", size = 9572, upload-time = "2026-05-30T12:10:21.366Z" },
+    { url = "https://files.pythonhosted.org/packages/02/f4/b4a07352bb14549d58edaed5eca2b97653960891d85dcb499425110e1260/pyobjc_framework_inputmethodkit-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:1ee16198c4ac8e9327ce3d98f91cfe085d05eddae958a4e7fb3fe24e63d8506c", size = 9748, upload-time = "2026-05-30T12:10:23.069Z" },
+    { url = "https://files.pythonhosted.org/packages/28/de/5a54161025361652ba6ec476b55f4b9e6d89bf576ed3592b4f176c6790ea/pyobjc_framework_inputmethodkit-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:a32436b7a498fa54e7a1a75d812dc7e61391cd7ce27d5ead0dd23ff0f3fbf74b", size = 9577, upload-time = "2026-05-30T12:10:24.674Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/7f/8bd67197094b11037ea5512eac034b9ed1cfd509f2db2d5d2063089bd947/pyobjc_framework_inputmethodkit-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:155a5d6a770403a99dc9a359aed08f542a309f6e3b20e96115196e7e61585b32", size = 9740, upload-time = "2026-05-30T12:10:26.275Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-installerplugins"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/bf/31/4284cba4b8904d2b93738249bb888762115d06876b92d30b721dea91e014/pyobjc_framework_installerplugins-12.2.tar.gz", hash = "sha256:6de54ab966f5bb304f9f5036c41937675cfdf49c44f70a1078a87dee2520261a", size = 26005, upload-time = "2026-05-30T12:38:25.291Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/08/9b8bb5f74df7d23d83ec5ab954301c91b8239091767df064aaff5b54c7a9/pyobjc_framework_installerplugins-12.2-py2.py3-none-any.whl", hash = "sha256:358ef2faefe1b9938c0563e95551ad685c4c2097a7b8bc46dbf394765eb00674", size = 4814, upload-time = "2026-05-30T12:10:27.678Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-instantmessage"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+    { name = "pyobjc-framework-quartz" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/02/20/2beaee41e71fcfe9bd3149277977aaef9510fae7d4ea3d70baecf2a978f3/pyobjc_framework_instantmessage-12.2.tar.gz", hash = "sha256:95a972697cc1c8c773d2e211815c7b4f3f11ad0aa114e46ec386d92f873d5533", size = 34017, upload-time = "2026-05-30T12:38:28.609Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a4/63/68356d5150c203b6b027dc93048b7e81d53c58d5d437b60dce914f861496/pyobjc_framework_instantmessage-12.2-py2.py3-none-any.whl", hash = "sha256:2fe9367f736b68557bf0c57a7da2c6a854cbf46ace9f6c5b161131309dc6b262", size = 5436, upload-time = "2026-05-30T12:10:29.334Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-intents"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/70/a1/2544e2b1e4fc794bc09b16651e967cbe11a17bf75f6d13c34a261e49a13f/pyobjc_framework_intents-12.2.tar.gz", hash = "sha256:441acf32738c8a4fa21458467ce451ce6880d0bac71b6e63e2e6634775f603b6", size = 187703, upload-time = "2026-05-30T12:38:40.353Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5b/40/01d85f90d9654083afd8588969b9d29daa8173463695e27df73103a74a16/pyobjc_framework_intents-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:0813154a7d37ead88ef741e971b0e053560dfeec524b989f3b60b119df2b5976", size = 35255, upload-time = "2026-05-30T12:10:39.031Z" },
+    { url = "https://files.pythonhosted.org/packages/22/4b/74dc067c2475881c4c93a2f4d6f460733a963a3f687de9f413b1280e40d0/pyobjc_framework_intents-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:1786dd54d1c570ca6be16383e653b897ad4c1b0c3df9be60ac5f8e0096d4a181", size = 35268, upload-time = "2026-05-30T12:10:42.054Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/8d/d6cb87fdc7df4bc81b61cb184d5fed3f55cc2cd30eed90033f434a32716e/pyobjc_framework_intents-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:9d697dca29ce2c282dafc4db9c0a0f165802e8d056a68f809bee0521ca47ff24", size = 35512, upload-time = "2026-05-30T12:10:45.295Z" },
+    { url = "https://files.pythonhosted.org/packages/95/78/30348e2ec790164ae11df2f07de9464ba767d3a73a55875b3e904e847e20/pyobjc_framework_intents-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:ed30e7c0b26622621046ce20c318084288d144ccc513736dbca856b91c5227e8", size = 35283, upload-time = "2026-05-30T12:10:48.573Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/f3/028fe6f22c6556c9f5faf391e3ea058339fd4ed2106fb34a6ba5c160af77/pyobjc_framework_intents-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:d6ae3f19f711a256b370435df0bad11c805ba5513208b5abdc61c30e7c75fd44", size = 35578, upload-time = "2026-05-30T12:10:51.729Z" },
+    { url = "https://files.pythonhosted.org/packages/60/ae/f0a94a60a788a25716f854018e415112b20b1b3db1a54897e0b3290cf761/pyobjc_framework_intents-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:f07dbd2383f859ed18a390d5e02b28e7fbc89679246fc1c330ec56190e72db1b", size = 35293, upload-time = "2026-05-30T12:10:54.895Z" },
+    { url = "https://files.pythonhosted.org/packages/45/4b/149a16762f0b496e1b025d6d56ed0a6447b1229ad1195297e06220931328/pyobjc_framework_intents-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:e5a9548175ff5d4630a6f2d800bbfe82e26bc4205358a7fb28429c5d40727bf5", size = 35580, upload-time = "2026-05-30T12:10:57.953Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-intentsui"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-intents" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4b/10/cdd1d80716e9970f5190517daa613a2d16bfec532b3fc9bd8f987c00a178/pyobjc_framework_intentsui-12.2.tar.gz", hash = "sha256:46292de2f2e915ddff88a060639adb175e0b3b2452a45f00e440dc04acbe0e70", size = 20742, upload-time = "2026-05-30T12:38:42.667Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/60/6b/06859a077829bcb895ac373cd1d3b268bb77bdfdd90d976c741c68bc0054/pyobjc_framework_intentsui-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:a92c40a66a27e70c4ee70838f43ae2c6f8ca6263699ed5e38ba25ebfef35f6c3", size = 9023, upload-time = "2026-05-30T12:11:04.153Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/f9/10f8bafdd58f136cd373fa2b0b5bd869dd6f7576abee9135fbc51c10e549/pyobjc_framework_intentsui-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:da18833b15f8f31ecc5d4769250de6883e1e117392840175ff33d002a8196f46", size = 9047, upload-time = "2026-05-30T12:11:05.908Z" },
+    { url = "https://files.pythonhosted.org/packages/15/e9/6f1eb774981b665e87c08f21b3a4695d0d97dce1c2a9e7eb2ab1956605e4/pyobjc_framework_intentsui-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:96b0b96147554a0e848a6804ad725abbb183b3d045481abf54d31d6a334a1a25", size = 9222, upload-time = "2026-05-30T12:11:07.572Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/66/c65ce9b1e5241caec467ac8d983787cdfe8fb500ad4342d95cbcd9011674/pyobjc_framework_intentsui-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:6c369461ac245b084cfa4803e90a91f43838637a4cce4cb0d25e71cf02e8444b", size = 9095, upload-time = "2026-05-30T12:11:09.161Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/6a/4d1eb10ba9cb2eeb30b22b2b10c274f76f25d0e2ea6b0d2a129d704e0645/pyobjc_framework_intentsui-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:1c78cd4e536590c15926d3ec2d2e0eb7ddaee9430424b30d5478ae12d3a53897", size = 9290, upload-time = "2026-05-30T12:11:10.799Z" },
+    { url = "https://files.pythonhosted.org/packages/12/8e/819ab1305d33e6c0d1342d5ebbd216f13fc5f682392d85162ad8fd9d283e/pyobjc_framework_intentsui-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:6a60e5f5277690479cad06df8a8e008f8f02e625bce2a24869770807576a78d5", size = 9089, upload-time = "2026-05-30T12:11:12.412Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/22/a674939ee5fdab2238452a9389d36e543ffef04432319057f357ed060a78/pyobjc_framework_intentsui-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:cad7677ef0ebe7e9fe83f07dea7e999f9fe067b3ff8e02520ddd3272ba19eabd", size = 9278, upload-time = "2026-05-30T12:11:14.014Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-iobluetooth"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ae/d0/ea3057fb6977ab87c85db9e676d8ec77ce77d096680bacade1964ced17e5/pyobjc_framework_iobluetooth-12.2.tar.gz", hash = "sha256:7fd7265db0f467a471a015f5a32ee79fd8f42440888d16b4206bbb985ed7331d", size = 174868, upload-time = "2026-05-30T12:38:53.498Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/16/6e/cf25292e7c6336b189f9bf9cd99df59aab8e20de9028abb4d2d7bc3d4559/pyobjc_framework_iobluetooth-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:b895e3c7665ac7d59f3356fc0c4471cf7c47146da65ee0b5cce327d3cafbdf70", size = 40541, upload-time = "2026-05-30T12:11:24.486Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/7c/6252a3f61bd674c770d37517433485653aeb5e24ff2f5df2a71b79cf9197/pyobjc_framework_iobluetooth-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:8bea83069a68476036c260e3c1f3f2a6cc919aa965ecd89c8821165daaf9886f", size = 40552, upload-time = "2026-05-30T12:11:28.065Z" },
+    { url = "https://files.pythonhosted.org/packages/df/88/4e49653cc0bf64a90b1aa10b89540cd8d6929a4e4ed79d5546b3bf6cc0f8/pyobjc_framework_iobluetooth-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:2d058ea04a6924233701cb0c9312aea71174d38a37430494e725d17eb7933ae8", size = 40763, upload-time = "2026-05-30T12:11:31.474Z" },
+    { url = "https://files.pythonhosted.org/packages/20/cc/9b09bc4022a05b00a187577caba8d46850c5a1d29112d3cf3826993080fb/pyobjc_framework_iobluetooth-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:63e089fb47feee2dd1f7de136ecf4a4985597b175cd210252fad7789dff5c537", size = 40542, upload-time = "2026-05-30T12:11:34.89Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/59/a0ff3b21a108a8fe1bdbb2bfd831a07d4be77d133500a3ba2a9aa2a2d186/pyobjc_framework_iobluetooth-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:98685dae5876da9d01dd531ef8f2f40c87d076dca2b79edf12dc5413492127e5", size = 40743, upload-time = "2026-05-30T12:11:38.293Z" },
+    { url = "https://files.pythonhosted.org/packages/48/c3/9dd84d41a883329e6cf2912f945ad2c22e9d6bb5802895e57e9fac4123ae/pyobjc_framework_iobluetooth-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:f0f848fdc184ab910ab00e395fb1fe3de9b89625e0dc19967560b796da73bfdc", size = 40531, upload-time = "2026-05-30T12:11:41.71Z" },
+    { url = "https://files.pythonhosted.org/packages/54/bc/bc8c028fbcb51a4b4a91224b3f0e40ef1385cc444764efdc4ba8f411cb16/pyobjc_framework_iobluetooth-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:6715d29e3f1fb465144abf77a7372795aa18e61b77abf44e9605ac657895cb9b", size = 40741, upload-time = "2026-05-30T12:11:45.07Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-iobluetoothui"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-iobluetooth" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/27/cd/0c14569b91e29bd0f64e2496c21b15e34e789f0ca07f5cf0149dec37ec72/pyobjc_framework_iobluetoothui-12.2.tar.gz", hash = "sha256:7902974cbc2ec50adc38dd961b03eae6a84f082812ed60a440db6f690b30b2d2", size = 17987, upload-time = "2026-05-30T12:38:55.655Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dd/a8/2ab7199c81c9f1541e20caa78cf44df5f05162665fcfd29f16e3a85fe822/pyobjc_framework_iobluetoothui-12.2-py2.py3-none-any.whl", hash = "sha256:60622518d2f70e82398c62edf5e4e72403ef9210312945d82f3151cb5e888ccb", size = 4043, upload-time = "2026-05-30T12:11:46.476Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-iosurface"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ca/3d/744c44cdd66f273e1ca731343e7845a281cb14a25c40d20a307334a36e21/pyobjc_framework_iosurface-12.2.tar.gz", hash = "sha256:d0315c6ad3b5ee72d3a5c946d9e92a4cace1a96bd0526f0b9f6b8009c26b9716", size = 18607, upload-time = "2026-05-30T12:38:57.666Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a6/f8/35fcd4d2504d0b470dd746138f47f6a8d8077fbde6aa85914c999ff9f7d5/pyobjc_framework_iosurface-12.2-py2.py3-none-any.whl", hash = "sha256:3ccd3abe40e21028419a39dbea36f60cb7e34335ab1b81aebb7a1a2f644443c5", size = 4903, upload-time = "2026-05-30T12:11:48.133Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-ituneslibrary"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/dd/37/308813d2e80ce9c8c4e5710e0f1e1dc479be03bb06e2f28dc9058862a756/pyobjc_framework_ituneslibrary-12.2.tar.gz", hash = "sha256:780f7e5f354dc2b0a27df4abb6538f730e8a29371a8703bc05edd6ce50466f8e", size = 26172, upload-time = "2026-05-30T12:39:00.202Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3b/c3/6c8fa4798c8f3d5194dc7f1d4ca061840705b7a908b6ba05b3c9449a0b22/pyobjc_framework_ituneslibrary-12.2-py2.py3-none-any.whl", hash = "sha256:9876e99dac601dc523b2f0e528fb21b027693b2b6f7d697fdf460cb819339980", size = 5212, upload-time = "2026-05-30T12:11:49.77Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-kernelmanagement"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/00/b7/f367cc6c20fc0e9b80706284a1978fa0ee90ba61c2421d7bab867a3ce4d2/pyobjc_framework_kernelmanagement-12.2.tar.gz", hash = "sha256:01abc525c1edbacf88425a36a055e52d1b4a024299097d9a2b25c34f2df4bafc", size = 11935, upload-time = "2026-05-30T12:39:02.13Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2b/5e/f98eb2645e1899579eb0b30695866611db6c25cef135dfdd323a164a5d8c/pyobjc_framework_kernelmanagement-12.2-py2.py3-none-any.whl", hash = "sha256:14e789ed81eaaf3ca50557015416fdc232400b682b3756efaefe4afd061552e0", size = 3672, upload-time = "2026-05-30T12:11:51.232Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-latentsemanticmapping"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/87/bb/2824a4eae4fad404603e5ab859654f4f5c5efb9687b27f97c58915726a44/pyobjc_framework_latentsemanticmapping-12.2.tar.gz", hash = "sha256:20dfeeb005880053dcccc03dc6a58d796dd72d7f282caa625906bebc3631ecd4", size = 15932, upload-time = "2026-05-30T12:39:04.01Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0d/16/85b8b7dbc58a0cd0baba9854604be687620433fe354347c0e93e05025551/pyobjc_framework_latentsemanticmapping-12.2-py2.py3-none-any.whl", hash = "sha256:1c87b1dd06626eca6188c2939f0dc1f58104ac9f8979c1dd8fc5f8c7d4d901e7", size = 5472, upload-time = "2026-05-30T12:11:52.82Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-launchservices"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-coreservices" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/25/fd/3ecceb569730898ffe9146f3e544415b4e4ea7d3343e424a3cd17500bf5d/pyobjc_framework_launchservices-12.2.tar.gz", hash = "sha256:02c3f25311673fc26eebb256cd0e873c9883575804c98b97a5d2096c8cebcecd", size = 20826, upload-time = "2026-05-30T12:39:06.23Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9e/8d/04c6bb237127a6c109437af6bae244b3695deca6dae67a20d408db736a1b/pyobjc_framework_launchservices-12.2-py2.py3-none-any.whl", hash = "sha256:4a0a478dfee2c53b7f3e2168f3c0e4183621050d324e7225251706500f8f5f0e", size = 3902, upload-time = "2026-05-30T12:11:54.2Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-libdispatch"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1b/fe/e23be301e46c30450955cdb096f16f6a86e7609787a4b8225ec24d6fdc9d/pyobjc_framework_libdispatch-12.2.tar.gz", hash = "sha256:4a41879ef7716b73d70f2e40ff39353d686cbc59d48c93217ed362d2b2baf1ba", size = 40345, upload-time = "2026-05-30T12:39:09.474Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e3/9e/94b587d8c5b243cb6026489752093a45d75fff08c85ed5b8b5548ad3596a/pyobjc_framework_libdispatch-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:9fb0028b400661b6b2279e2b611d396a4217bc36aa9dadd3ae21419551f5e091", size = 15634, upload-time = "2026-05-30T12:12:01.08Z" },
+    { url = "https://files.pythonhosted.org/packages/83/ac/f5e01c960287e3484f71a737e7ffd75ca1c192200de70fa342a22181895f/pyobjc_framework_libdispatch-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:265fe4edfd60de111c870932ab8397f845c314332a935aa7a27100fd8562cebc", size = 15651, upload-time = "2026-05-30T12:12:03.156Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/d9/8bcb4e234aee09396d06515ed80fb1f79cee3aeb67a311aa8e81a085584b/pyobjc_framework_libdispatch-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:117ed20ca54e334f657e60b9b9a3de3741d91875fd50ee51ac6a09224912cc68", size = 15918, upload-time = "2026-05-30T12:12:05.257Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/0e/caee3281628ba4913206167062274334a62ba5dedb8dada5fd884a53584f/pyobjc_framework_libdispatch-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:fef3158dd4a068a9db8108a5cbf7da385788136e1d8af2e6fb7f82215016ecb2", size = 15679, upload-time = "2026-05-30T12:12:07.217Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/e0/ecf5fb9f11d12271818c5244c57d36ee654abfa2d15799bd594d4f58d931/pyobjc_framework_libdispatch-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:02dc66f1c11e25eceecf3c1b2b397f1727659dcac3e0c7b97784d5af3cfab491", size = 15960, upload-time = "2026-05-30T12:12:09.199Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/74/c1d1d1fc45434dcbab16887273d368d9ad89e65939babcffd502ed308ef9/pyobjc_framework_libdispatch-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:a81d9329fdf5094c9bc09b916e1d2fb86ab27138161d3e7ddb76ec2e780a1aba", size = 15699, upload-time = "2026-05-30T12:12:11.103Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/46/6ba13e10cbac853af00ee37444f37826a0688e32d1d22ce2fde4e2add9d3/pyobjc_framework_libdispatch-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:8daaf8844b5b328cf8adb6e8c085bf2aad22237956f7c5dc6fbb7a46c5015af0", size = 15990, upload-time = "2026-05-30T12:12:13.077Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-libxpc"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e6/a2/443c0cad2a13ec038318d391f7ebfec2189ea6d97910c0ded4c863631603/pyobjc_framework_libxpc-12.2.tar.gz", hash = "sha256:6dcae3da5ab706762d68625a391c75a3969609e5676d4091947f5c1185d4f800", size = 37263, upload-time = "2026-05-30T12:39:12.446Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d0/35/04ee5a0c94c0e59536cd5d20e5afad73704240ed1f5d770a6eebd4fcf992/pyobjc_framework_libxpc-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:b1e5826137f5fe3c20a1f7f6d3bb55d7f692bbb85a16be209103f32761df3e0c", size = 19753, upload-time = "2026-05-30T12:12:19.57Z" },
+    { url = "https://files.pythonhosted.org/packages/82/f3/9e971bd977c63575359c1e4d95a0c7ac8acba1d0094b190bd738bf64dedd/pyobjc_framework_libxpc-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:7caa888b1046a7921121cb44087746803a458002a1182105b3e64734b0ca9f40", size = 19753, upload-time = "2026-05-30T12:12:21.682Z" },
+    { url = "https://files.pythonhosted.org/packages/70/e7/143c999a6dde74bff96697b36270ee6d8b105ce01d11b1a066d573a5d722/pyobjc_framework_libxpc-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:56bf8fbc45e722af533bed03889d02c1dd7f81338946575bbad3efb049e8177a", size = 20308, upload-time = "2026-05-30T12:12:23.88Z" },
+    { url = "https://files.pythonhosted.org/packages/08/40/996207b9c0fff0ec877ca9ed88a3e546bdf0f82ac5052a9d3cc84be8e170/pyobjc_framework_libxpc-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:2ef1feb41c7f52b771c9dd490d60b267d25983b19e7f6a896a0534bb97fcb728", size = 19486, upload-time = "2026-05-30T12:12:26.018Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/b5/59eca99d7dde55d8af5b7639faa0bda9239ddd23f64424ca4ca6fcb22512/pyobjc_framework_libxpc-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:2ba3e82597fcb828b60b5a95f6a189ae3374257a99058109ddd4844926579c0b", size = 20012, upload-time = "2026-05-30T12:12:28.244Z" },
+    { url = "https://files.pythonhosted.org/packages/08/d3/a023ec78325f3c5db3a58c17c5eb3323def22ea99c170cdf5361d47c572a/pyobjc_framework_libxpc-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:91d66e792bcdff0680698d8a4f4ca67962afb2810c3edfb652e34ebe6b4a942e", size = 19492, upload-time = "2026-05-30T12:12:30.308Z" },
+    { url = "https://files.pythonhosted.org/packages/25/a9/368f38fa17b507001555ad7e4b6ee243920d6111358656334c038c85bc79/pyobjc_framework_libxpc-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:c38d61a2ba5e26ba12bf0566dfa0687f396239c72f9d940d06b1e70af19cddf7", size = 20039, upload-time = "2026-05-30T12:12:32.574Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-linkpresentation"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+    { name = "pyobjc-framework-quartz" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b9/20/a55fa5ca6fbeb0a0b00515f4aa37cdb946e36fbaba8c8bef6c47774c10b4/pyobjc_framework_linkpresentation-12.2.tar.gz", hash = "sha256:bb910f692f3166d6c5fce44f501a4d64a6067bac9bc26ec9488995fae56bfe6d", size = 13988, upload-time = "2026-05-30T12:39:14.136Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8e/42/264d202bd16bb6d8b2820c4a0d3eb1267add1c94aef68aeb749927dfff52/pyobjc_framework_linkpresentation-12.2-py2.py3-none-any.whl", hash = "sha256:68f854b4b72fef3477f1fb6604b258207a5950164e8e278330cd4848281eafee", size = 3864, upload-time = "2026-05-30T12:12:33.935Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-localauthentication"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+    { name = "pyobjc-framework-security" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3b/bb/68ff2b154ed783d39a1752cbbb7dc9d0ce55c17097dc00fe56d9080c6349/pyobjc_framework_localauthentication-12.2.tar.gz", hash = "sha256:e1d734db5ddf35093307e213115bd122ef8712463be048eabfa4062022373e21", size = 33074, upload-time = "2026-05-30T12:39:16.945Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/14/4c/2893b8b70189597a84d5804e97df123f7596d83e5fa545894f2a0d6e3267/pyobjc_framework_localauthentication-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:0e1287a84708dd01e959fe3099fb89cff72bba292e0bafdc2e0385e12f0729cc", size = 10876, upload-time = "2026-05-30T12:12:39.478Z" },
+    { url = "https://files.pythonhosted.org/packages/09/28/23c4a20e97d06854248625f53b30543340c17e478e9d6850cbee9ea50736/pyobjc_framework_localauthentication-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:38eab810ace8b5cd5aac593b8f0db99a9851a47e7310e0a010eb33d37043da30", size = 10895, upload-time = "2026-05-30T12:12:41.218Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/05/4b988f1e0f70b404b3e6ee0b0f63e9a368efb2a17c8b900e57992c126b2c/pyobjc_framework_localauthentication-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:3b7ad8257cd372950463a4d6fe2f0b5ab14891ca756a8547c3fdb1b3236ec9ca", size = 11042, upload-time = "2026-05-30T12:12:42.808Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/38/a42123af0bc7ed7dba480b742fc97015bcf009dd81e2cf11b9eff79c6ed1/pyobjc_framework_localauthentication-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:8ac59a0aa0ea790743b680eec3050d6df5319d5b473c7c1deacb037e2509c9fc", size = 10942, upload-time = "2026-05-30T12:12:44.703Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/8e/915a63e42de556ed4da27c2537e0399213d22dbd1ed2bf6dbed43ad53b2f/pyobjc_framework_localauthentication-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:ff66f71e12f30c6ee2c4438fa933f9fcb34468e68e5721e8e640a37a90ada0a0", size = 11083, upload-time = "2026-05-30T12:12:46.39Z" },
+    { url = "https://files.pythonhosted.org/packages/41/e1/f8ea9d201f4118c13e8649e4fce9a21dbe196fc42424923fa13907514b17/pyobjc_framework_localauthentication-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:8b3bd2d3d9138cc091f977f8f69ebd71c9fa723086b5b1eca8f89f8c7a58410d", size = 10949, upload-time = "2026-05-30T12:12:48.083Z" },
+    { url = "https://files.pythonhosted.org/packages/13/fe/24d6a3a4e761772925dbd06588cd3085ed6800a4d7991bb3d7b1fd45000a/pyobjc_framework_localauthentication-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:1de45570296d7ab3aa0bc66dc6d9a31d6c6b33f950ea3d5bee8e5042c6fde92e", size = 11077, upload-time = "2026-05-30T12:12:49.835Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-localauthenticationembeddedui"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+    { name = "pyobjc-framework-localauthentication" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a3/93/a9d21a00896d016924d1912f2dd8918f8aa95ac0893c2b110cadc779a16a/pyobjc_framework_localauthenticationembeddedui-12.2.tar.gz", hash = "sha256:cff4e489375b3898f34d8ab378f8d84623ab19e89a35de958825c125aafceca6", size = 14134, upload-time = "2026-05-30T12:39:18.692Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5d/94/2e453acd660d9e1e059269c72a95b9f1f2de4a3b7a5dc0f6d6cdfd0eed5e/pyobjc_framework_localauthenticationembeddedui-12.2-py2.py3-none-any.whl", hash = "sha256:0b306917aa011deb364e85c118624d2d80c3eaf67016a345a6c4bc4960416b11", size = 3985, upload-time = "2026-05-30T12:12:51.194Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-mailkit"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0d/44/b8fc4dec34b6f29a98f64f38eb6f37e9729aeee4d2e90887a9ece06010eb/pyobjc_framework_mailkit-12.2.tar.gz", hash = "sha256:e29ea94210faefc46a4aefe0c1647bfb77b42cfc2a4962fb8316cb967b34c47f", size = 23870, upload-time = "2026-05-30T12:39:21.115Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b9/95/2b4b95d7e5e43750631596da4ee8de4800883475864ca9f169881fbefb3b/pyobjc_framework_mailkit-12.2-py2.py3-none-any.whl", hash = "sha256:25b9aa8c513c40d931a7c5cc44571fd090e3d565f2e1153a634f6980b08da733", size = 4994, upload-time = "2026-05-30T12:12:52.648Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-mapkit"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+    { name = "pyobjc-framework-corelocation" },
+    { name = "pyobjc-framework-quartz" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/74/6b/0f3d14cd1b6f3d30420e268fe6b97f6ab55f1717a4c436ac6e57576c480f/pyobjc_framework_mapkit-12.2.tar.gz", hash = "sha256:65fdf104bd8a1d3e8965c689446b7e42a44ea4bc2da5c871ff389ef7a14ee030", size = 79554, upload-time = "2026-05-30T12:39:26.639Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/74/8b/1f32a9a01f55fcdc86b4044a3c3b100901425c4a901b789586a1458ca44e/pyobjc_framework_mapkit-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:3190f21e6bd9efda626da12e1f2d86bf26c56948dc6863358b0f62875fa5e288", size = 22830, upload-time = "2026-05-30T12:13:00.385Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/23/649ecd0f1b7092390d5012bfccf0d653840a002c215fe5c7b1d0e1ffb069/pyobjc_framework_mapkit-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:4dc30cdae3b30869488ffa936d1bba327b6454809dc1d584083a8033637ab7f3", size = 22867, upload-time = "2026-05-30T12:13:02.802Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/ee/d9a3b6a982a3e7fd04d06d1da9627c76b08c7107e46fff217f35a60f0350/pyobjc_framework_mapkit-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:4245ce0af24948471eca1da30dac432712fb11ce0f65100420bfd74d176359bc", size = 23038, upload-time = "2026-05-30T12:13:05.233Z" },
+    { url = "https://files.pythonhosted.org/packages/22/50/679cd8f873fb077ef88cb7d36b485a5235f158dc70bea7a8357c9738cb36/pyobjc_framework_mapkit-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:45834cdf0845470504077fd352799a32dcee75ea66da20a3874ba1dbc52f95b8", size = 22883, upload-time = "2026-05-30T12:13:07.667Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/7c/ffb6b7abbb4a1f86d789b31da2516294465532c896f81665263ae8483f65/pyobjc_framework_mapkit-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:5a7e425f626f796da48d3cf8895ccf2835c5b40432675630300bc2fcaae08129", size = 23095, upload-time = "2026-05-30T12:13:10.209Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/a9/91f7aed638669796a13b08d7682e0681070f444d9e68c7abbfa60f3dc400/pyobjc_framework_mapkit-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:35fd5c1fbb0197ea7d44e739c1943270ec2c1e77f3dc6b363884943556b770e5", size = 22897, upload-time = "2026-05-30T12:13:12.601Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/6a/c5198e668724d04acb97fa44a31e2b11f664fa3aa8fc1438f479e928bb9d/pyobjc_framework_mapkit-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:71095b1129411dcf78aa2ff61f9a00679e5eeb6826ff3ef665a6f23156f4c393", size = 23100, upload-time = "2026-05-30T12:13:14.976Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-mediaaccessibility"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/02/63/34d6f7af511b116dca7761385b7462eda9f39641a9ead9eb1404d621e571/pyobjc_framework_mediaaccessibility-12.2.tar.gz", hash = "sha256:9036a6412bce491b8ca477d4673b6e441cbf2cb2463d617f82bed818c5bde9d7", size = 17239, upload-time = "2026-05-30T12:39:28.7Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3d/b9/fb53b336b9d6233ca96e53aec4ea142d49b225f846bbd9e13353477f118b/pyobjc_framework_mediaaccessibility-12.2-py2.py3-none-any.whl", hash = "sha256:2e1d023c738ef09ed57635ae277b3644a09d7313e6bb979ee1c6d68bae57e4a8", size = 4822, upload-time = "2026-05-30T12:13:16.428Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-mediaextension"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-avfoundation" },
+    { name = "pyobjc-framework-cocoa" },
+    { name = "pyobjc-framework-coremedia" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/60/db/c3c4a933685423d16f69daf8a0dbe026fd45a05e0988ed4842dc2a286097/pyobjc_framework_mediaextension-12.2.tar.gz", hash = "sha256:9affa99bd94774ed91f3fc9f314468b4dc3bc6fc110ee8a81884d3947a9ced12", size = 44550, upload-time = "2026-05-30T12:39:32.301Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ce/74/bad12d87ee91c01dc2af72e3e0fe3c4196764eb735759845f1ca1532d817/pyobjc_framework_mediaextension-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:b1745f140a683cb1a310ff4c1206ad0d2e644cf1cfd1da3fd3be5de224890a4c", size = 38998, upload-time = "2026-05-30T12:13:26.744Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/8b/1576473cd8154bc5e2b36cf2f82bac60ad1223bc09145248639446bcfd18/pyobjc_framework_mediaextension-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:37e8a452f17db3bce2b50dec8a20b6851eed88906809d2361385c3b096751ff9", size = 39014, upload-time = "2026-05-30T12:13:30.015Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/31/473101b145d98dc738c021d66496149d38d2b57d746cf69a3665e5403dfc/pyobjc_framework_mediaextension-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:5326b3ca9f8ba0f2b51525829bc833f9c441980e3cf6628137e51a50d9e45cbf", size = 39221, upload-time = "2026-05-30T12:13:33.332Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/b4/9218de5d1a1018fa9bc52a342a128d1ff547613b8523b2fa48e215fbf281/pyobjc_framework_mediaextension-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:9c315b0f9ec9a1a2239213d9b72f4653bc8ae8ff7a915e5c2b8b522e01b01c91", size = 39004, upload-time = "2026-05-30T12:13:36.818Z" },
+    { url = "https://files.pythonhosted.org/packages/69/a0/92f1046924df8ea54bafff6ca836254954f63232fee363cbd82d7084e955/pyobjc_framework_mediaextension-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:048a04da339030f15ec932de42428ed85a90faa6c80f982c710513ce43e54a07", size = 39211, upload-time = "2026-05-30T12:13:40.143Z" },
+    { url = "https://files.pythonhosted.org/packages/99/fa/80b00c06d4326039ae152393f4568ac7881d1080a98e436397b57ef18dc3/pyobjc_framework_mediaextension-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:b34f4f1a89810925313ba97064e01b63b597e424749f0b78985c48dd5bf4cba0", size = 38998, upload-time = "2026-05-30T12:13:43.667Z" },
+    { url = "https://files.pythonhosted.org/packages/85/f8/69b14a84ce316af7aac12ce3f7262fae225ead1ae9df1b8f9037762c0cb3/pyobjc_framework_mediaextension-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:bf567e1768b696f554b93c1f850eba474014d079abe70e65bbe816ed69e833bc", size = 39204, upload-time = "2026-05-30T12:13:46.995Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-medialibrary"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+    { name = "pyobjc-framework-quartz" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/50/44/ec97fab19e92f5d41c4e0f333bcd54f1f76a255406eadd93a95d753da711/pyobjc_framework_medialibrary-12.2.tar.gz", hash = "sha256:9b65eb789cf10b20f2c5bc4d5f4e61e5feb02a43bc213ac3c03b647e30b96634", size = 19019, upload-time = "2026-05-30T12:39:34.305Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1d/ee/8583d8c8a738e13f3e70bfb84ad70aab17f2995af55ece36780c1acbfdd1/pyobjc_framework_medialibrary-12.2-py2.py3-none-any.whl", hash = "sha256:3bc97cb03e633a3f6f0a4e9d351210000100ebd1a4b19624c49c4e9bc7b5e574", size = 4357, upload-time = "2026-05-30T12:13:48.479Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-mediaplayer"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-avfoundation" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c0/c0/aec081f84830e483e23a1763339c9c6ef9bd868d44d9aa39a83080b0ac29/pyobjc_framework_mediaplayer-12.2.tar.gz", hash = "sha256:ee4f818a85e89a4c691e368b2709709d11658b81713fe367342af24dba2c5e62", size = 42669, upload-time = "2026-05-30T12:39:37.577Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1f/89/a12bf5f69920b8909cf92b3e7722082600db4262293d5b878b58eaae8f7a/pyobjc_framework_mediaplayer-12.2-py2.py3-none-any.whl", hash = "sha256:436d3b410b84c7fa6577c4774faa4acc4bd3ca79f582b183e281ca63429a1574", size = 7176, upload-time = "2026-05-30T12:13:50.134Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-mediatoolbox"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3f/6e/5181efc8c1a077599ab5ac1cb2263ebb43b1603ed994e486f8a983d2e694/pyobjc_framework_mediatoolbox-12.2.tar.gz", hash = "sha256:35fbaa7df491df5b756da1ad2035f0f04f72e556a560cdd9a6ef74ce315c555a", size = 22818, upload-time = "2026-05-30T12:39:39.837Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cf/5a/4b31f1751570b12f44ab4472786f48fe2e7540f96e52263ad384f5e2fe16/pyobjc_framework_mediatoolbox-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:c722d9b86227fa0d5f091a151b19f80e2811323e6318a577b648412842e6c877", size = 12821, upload-time = "2026-05-30T12:13:55.852Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/5c/3bdcef52f234ce16c9b06aabfac43caeeea68a5068425bdd510e6277c256/pyobjc_framework_mediatoolbox-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:13cca0632cbb91f5c207ec6a9001aebb4bdd1077d3753a5bc7fef7f82c3e9a57", size = 12832, upload-time = "2026-05-30T12:13:57.732Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/6b/8ca72d9579f84560f5a648973032757e5b0c61bf1eb74e763bdca6913ef7/pyobjc_framework_mediatoolbox-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:5b876927d92fb35f6ca6a5c8e030cb853a8b5c68add7d59ebec4ae4358a1f5af", size = 13419, upload-time = "2026-05-30T12:13:59.497Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/23/5388bd9a31639e02c9b626c6b4694f807a836b3f6ecd76477a64c9208736/pyobjc_framework_mediatoolbox-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:193f021a90cda4e18523538f99348080147f0e35bb5ed45e44b0f8a964a58851", size = 12805, upload-time = "2026-05-30T12:14:01.315Z" },
+    { url = "https://files.pythonhosted.org/packages/af/aa/e287f682182f1953b2b36d35781c91cced01d0f0ad7fa97836d9498a4bba/pyobjc_framework_mediatoolbox-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:58745d0f400c3de07e07b021574f38d73a3f69a886432470fc6e32824785855a", size = 13413, upload-time = "2026-05-30T12:14:03.214Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/99/6685f94cae3b4ee734bdd06fcb29c9c729d44b1cdaaf501cb1836902e0c1/pyobjc_framework_mediatoolbox-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:9f028de65634bf4fe2d9addd4c85704778b91abb9f9bafe42f15268b775496e2", size = 12819, upload-time = "2026-05-30T12:14:04.964Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/77/10df782a4107d150672264914259c48fb98f235908716cf915530c26ce4a/pyobjc_framework_mediatoolbox-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:f3d541185086c7fc4df76da60c577be8fed06f8507ef35b44082167880476cdd", size = 13438, upload-time = "2026-05-30T12:14:06.665Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-metal"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/71/a9/ff281c31ce7d0cb819af1989b77258b2d8cffc0b9fad47fcdd39043f4d81/pyobjc_framework_metal-12.2.tar.gz", hash = "sha256:4fb2cfd42cc8e808f08f1f2fe57de713734dd2f495c666296b2c8a5fba9be6dc", size = 238106, upload-time = "2026-05-30T12:39:54.526Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7f/dd/948cdfbac4f20decd054b9cf134e8a69e71bf9dc5cbcc91d518bc4fb4f37/pyobjc_framework_metal-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:2ce5cd713869eaaaa8298c9e21ce750957d063cabde396e8d158c10809b452f4", size = 75906, upload-time = "2026-05-30T12:14:23.044Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/90/f3832396e967ae149b480ebf31da0ab7b033c145b15274b2bd5357d8faf5/pyobjc_framework_metal-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:538826eb6020e2d49e481f7ad390319dfa1016aeeac623f8b76bfe8aaec8a66f", size = 75935, upload-time = "2026-05-30T12:14:28.505Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/95/f36313fab765e90c8400c9423cc0f6af6fec96a919ad894b09681d0b4a88/pyobjc_framework_metal-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:b9a9ba61ab834ada0e23fe7d560cf01e6948a88a4aef3342c032683b795bc908", size = 76491, upload-time = "2026-05-30T12:14:33.968Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/92/3c9a3f13a968f8935d3ea46e0ca5d3662b5d5fcaa4faa7b19e68e33956f5/pyobjc_framework_metal-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:06775870d7f40496d647f9ac37793e4a037ffaad43612aea7313460a52ee9e7f", size = 75937, upload-time = "2026-05-30T12:14:39.603Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/34/9244ee1aef137fb8603daa7fcbe3919d4a27c894b120aaa22ba9c1481d5d/pyobjc_framework_metal-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:86296b6bf1b19f0e0c0d4bc1e99954eb666c48a386e61ed805cbaa961cc0cd6e", size = 76541, upload-time = "2026-05-30T12:14:45.26Z" },
+    { url = "https://files.pythonhosted.org/packages/65/c6/a5f5169c2799e67fbc7a159154ff9369dae2c1b0a76a87c1ab3206be9470/pyobjc_framework_metal-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:67619f9778593deb2596f7c7c20c230b93a1ebfd500b5cfd29c2e4d3db1e4a64", size = 76051, upload-time = "2026-05-30T12:14:50.76Z" },
+    { url = "https://files.pythonhosted.org/packages/39/f6/01b2bf593c60b325d4ad9568bb8b7861ddc15196d69bdf0e82871e417d8e/pyobjc_framework_metal-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:3d044801562c2a411ac65ff8f2f5d4004b3d1bd41082e8bb52b1f7a87ac53813", size = 76675, upload-time = "2026-05-30T12:14:56.186Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-metalfx"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-metal" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/87/06/e29f5153fce867015298a9b0b0365777004ff5f4e5276728135afc496269/pyobjc_framework_metalfx-12.2.tar.gz", hash = "sha256:46774b9c938f2af40510a787be291dbc0c7e3778494704489e728fc349183244", size = 33397, upload-time = "2026-05-30T12:39:57.533Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/30/94/490d8a4339e8e7c02a9e5105307fa40ed4d5e251f4af824238158b7a798a/pyobjc_framework_metalfx-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:f26bcdd3bd0ded637abaaedf6e1e42300de4694ea4b50a36322599fc126c43e8", size = 15059, upload-time = "2026-05-30T12:15:02.435Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/10/40bd25526328be5bb7aa14b481146fee3dbb1271662b5b69112f47f2833e/pyobjc_framework_metalfx-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:8f079710065e4f4628c34a2528b0dd868c9d16e3af58230d5f18f6bd22d2ee74", size = 15072, upload-time = "2026-05-30T12:15:04.464Z" },
+    { url = "https://files.pythonhosted.org/packages/46/d7/5189782d95c4790b704f70dff50951c183e0567aa53fd4892ccbc91b6f8b/pyobjc_framework_metalfx-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:40c7e259991c04f5520c4c40eea02810c50812f2bac2c5ff845828a35d99ccbe", size = 15286, upload-time = "2026-05-30T12:15:06.581Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/9f/400860454b42234d9a3e8b22b9a39281556fd71b8a47a13f1f20e24437a5/pyobjc_framework_metalfx-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:d2852041cfd3ab3a316412b3721074778d0ec8164e2f0e89daa3ce00b55d6b54", size = 16341, upload-time = "2026-05-30T12:15:08.529Z" },
+    { url = "https://files.pythonhosted.org/packages/62/73/3f7904cf7048af042f040e563222d9c143d15b3d7572501d0487b5c149b8/pyobjc_framework_metalfx-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:0c58b878e2994fdb37a74ad1ac93e3d624e8212c6658d64d1d8f62b18f7aa7a9", size = 16591, upload-time = "2026-05-30T12:15:10.601Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/35/41cd0392d0c501611c32f0ee0e980cdc29b84bc445f4ea705a605f0ce893/pyobjc_framework_metalfx-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:bf2f970bf2718d10a87e8fe5dfe5cf7ec9ca6152f9b31e05de54ed97ab799786", size = 16349, upload-time = "2026-05-30T12:15:12.728Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/bd/bfc5faf66e708a4ad384ec54670b4d2d3ff505dfd269d721f1661be31472/pyobjc_framework_metalfx-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:8a7ab8fbfd7d54c0b362c7c568ba22e648a4981631001fb29cc93777e33330b9", size = 16582, upload-time = "2026-05-30T12:15:14.82Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-metalkit"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+    { name = "pyobjc-framework-metal" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/14/48/3bbf8a296054633a8a297549c919b3ff6f53c469bdcb0046d31fd7c92ee4/pyobjc_framework_metalkit-12.2.tar.gz", hash = "sha256:0f6379b74d64ce9cb864476caa277ab5010da3b0779b7fdc94af7da25f013a1a", size = 28168, upload-time = "2026-05-30T12:39:59.991Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cc/3e/1bba6a52949a80a33c00650a1951e9f96ed27bf238e47694e35e4a8f087e/pyobjc_framework_metalkit-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:7de453aef880ba546e87b0d433d203388e579d09f7cee1b6c67f09c7074c79f9", size = 8780, upload-time = "2026-05-30T12:15:20.024Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/3d/982672d8b3b97e59214b85e694482f8d4b373d540f3d4eb1ad27c7763b0b/pyobjc_framework_metalkit-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:d1f1e352621d5e89a2066f992a2b03091d180fd4ee3b6c7b58b432e22d76641b", size = 8795, upload-time = "2026-05-30T12:15:21.571Z" },
+    { url = "https://files.pythonhosted.org/packages/87/24/163bbd1c430a7c6adfec59ad92c3f1ec7f3de0ab6739e2f5839edf90f8c5/pyobjc_framework_metalkit-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:a855935379ededd36ab55507af01b796b845a0acad7dddcff9d9f305fd903b82", size = 8939, upload-time = "2026-05-30T12:15:23.113Z" },
+    { url = "https://files.pythonhosted.org/packages/82/7a/d7015d0501c741c470abea665ccea2832e762469b9ef37ccee9575130cc8/pyobjc_framework_metalkit-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:bbcd660af609451ad40bbbfb9ae44fd838a91a5754c19a6496819704bc72dea0", size = 8848, upload-time = "2026-05-30T12:15:24.664Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/94/bacbfdc43870f06d31935cf5efade46d3c9356e6cb52df2c171cc23b81c5/pyobjc_framework_metalkit-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:5aa264c48301952fb6bc549e3e9e8862c41d0666d46ca356cc9606564f3bb59e", size = 8997, upload-time = "2026-05-30T12:15:26.375Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/6a/a79e6f27b96d85efdc896fcf2c7e7a090f2a355716f8c789de2a60e942e9/pyobjc_framework_metalkit-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:57b499d34ce41bf55b32a56fd1ce53d781d02d7c21d4fc92fd3ffa005e038939", size = 8843, upload-time = "2026-05-30T12:15:28.072Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/1b/f45b8b9423d66dbb463e19df3562e3841841fdf8e03e242926e30f49848b/pyobjc_framework_metalkit-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:5c0fe3df589ccc0bb07086f894457bab37fdc682bf7107bcb5bbeb2c93b0a8f6", size = 8989, upload-time = "2026-05-30T12:15:29.806Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-metalperformanceshaders"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-metal" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ad/77/9675e6e2ea06d693a75586c4194630c4346e6661bcf9c9299353dde1edf3/pyobjc_framework_metalperformanceshaders-12.2.tar.gz", hash = "sha256:f428f762bcf552f1a8f5533508ae4c73057a7f4f4a93bc997a921edec63b51e6", size = 190423, upload-time = "2026-05-30T12:40:11.806Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c3/09/a0906ac85670c10d7ba2ad597a66515f9d68cf1d16f69e76f9bb90dcc0ef/pyobjc_framework_metalperformanceshaders-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:4b4129480193b524fa5b1407922539e2f52e2cb77bc20e16936711d70c4c61e1", size = 34165, upload-time = "2026-05-30T12:15:39.086Z" },
+    { url = "https://files.pythonhosted.org/packages/50/f6/2eaf4c358eb9684b13a08f73239c654029805da1be0ae5052ac0e15fafc5/pyobjc_framework_metalperformanceshaders-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:ac154ee0c5bd0c715d2b837689a070b811994a772b209784907730793b725012", size = 34176, upload-time = "2026-05-30T12:15:42.108Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/f4/f134c898df89217ae3d07d364c75ac67048dd9106a164d7dcda52f83e5c6/pyobjc_framework_metalperformanceshaders-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:18cda4e2ed06da0caebb11fa54596e273e8d50cdbf243aa1d34fa347da71db77", size = 34374, upload-time = "2026-05-30T12:15:45.258Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/d8/fbeb68c5c03d6d4ce8030c2b55b910ce987bec58cfc327971da7936c5f04/pyobjc_framework_metalperformanceshaders-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:c6fda7dbcf6b64a9be973248568ec893abd4db96efd89c28a354605fae8dec43", size = 34240, upload-time = "2026-05-30T12:15:48.266Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/16/95c14b3e7a54da1a5cfefeb664cc553286706494825abc4864454a438e06/pyobjc_framework_metalperformanceshaders-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:bb9e81a36604523de1a82d28b8b25c32f9fedf58f17dc1ddd01a2676a39b67a3", size = 34462, upload-time = "2026-05-30T12:15:51.325Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/d9/bbd6439aeeca621bfd27b9c6dd6d5d43e637a69355878802f0ba49e995b9/pyobjc_framework_metalperformanceshaders-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:40a6743b3352cfbac9209aa29f6404f12939cbff232104b6165eaa8c0723a1b8", size = 34261, upload-time = "2026-05-30T12:15:54.564Z" },
+    { url = "https://files.pythonhosted.org/packages/85/5f/084ffa1fdd63a0007924068a1877ca5e69c0fb475ab312cd053b6e082982/pyobjc_framework_metalperformanceshaders-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:df0768e6ff1e27b6963dbdd851fb771a72539f0357ac667dc9b91898ee77f0e2", size = 34478, upload-time = "2026-05-30T12:15:57.574Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-metalperformanceshadersgraph"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-metalperformanceshaders" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e3/95/c274ffa29063e6f331a2d7d6942610ea2dc1e1984c647e68aff0f93e35b3/pyobjc_framework_metalperformanceshadersgraph-12.2.tar.gz", hash = "sha256:16249c5cd8d8403b5d81b871b618fdc0a8af0d7c81b461e733c0b5c1f9a9ef80", size = 60209, upload-time = "2026-05-30T12:40:16.281Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0b/ca/173cf282b48c454dac9ef40f96b0e5338077803f3fbf0f07c09333d3a9aa/pyobjc_framework_metalperformanceshadersgraph-12.2-py2.py3-none-any.whl", hash = "sha256:e465d7717df4b000e3a529054cdf547e50e175f321b53c9520bcd6c69c08c837", size = 7110, upload-time = "2026-05-30T12:15:59.125Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-metrickit"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/00/7e/b880dd8c641abbc0807d75396132df80d7d9cb0d64006b078c7f2e169fb8/pyobjc_framework_metrickit-12.2.tar.gz", hash = "sha256:c76cae82489813ca121de0ad6013555aa826f8742adf975028b3e4268ac51e6c", size = 30585, upload-time = "2026-05-30T12:40:19.065Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/09/48/3e08c40cb1f5f905a8c24f1969e8b51fd3d00428f554d48d69a36de808bd/pyobjc_framework_metrickit-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:a0c8f72b143fbdbfcf9f0316da44a6253071c493e07ec46ba7f7b5b91bafb132", size = 8118, upload-time = "2026-05-30T12:16:04.149Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/7a/224f8a506539197efb51df3aa84b269262ee14a6a4ecf9ac08d7267dbb54/pyobjc_framework_metrickit-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:db64bd8d99011d67edb16bdb0f923191d95649ee7bc4a276d4f2516e975ec780", size = 8128, upload-time = "2026-05-30T12:16:05.825Z" },
+    { url = "https://files.pythonhosted.org/packages/71/c8/a112d3aa27eb2749d1308122b40fb1b45947199034e37ee5d86759eaeff7/pyobjc_framework_metrickit-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:eb146093ab8ec597e74307ece22c572b3654a4247d6e0d0fd3f4635f0166286e", size = 8267, upload-time = "2026-05-30T12:16:07.3Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/81/b37fc0c8c58af7537f224da4f1d16e161756c09df62255b2273c245b8def/pyobjc_framework_metrickit-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:881f4e1af1f3e8bd5f9b58f9c1f3c2a51e2a119742ab98476a32c1cb03d09e33", size = 8182, upload-time = "2026-05-30T12:16:08.937Z" },
+    { url = "https://files.pythonhosted.org/packages/78/78/ff89dd771d30ae760a2549fc9384eb388b6771af59e8ae07e420d41dbb79/pyobjc_framework_metrickit-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:4e22d5026f99a4b355b7f0090f64ab857aabab672bc288d01078510b645d48ae", size = 8325, upload-time = "2026-05-30T12:16:10.362Z" },
+    { url = "https://files.pythonhosted.org/packages/17/d5/d8fb9b2eb03c6833468541961db44812f6b19f03467577740a68a0aed66c/pyobjc_framework_metrickit-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:d8ee9eba35773440c26d572b673d80c2fa3c804b595451a01d3ec0ecae23f780", size = 8173, upload-time = "2026-05-30T12:16:12.098Z" },
+    { url = "https://files.pythonhosted.org/packages/30/5e/e2fac8fb3341737891a31cab6a07a0ead428ef2910f8c6ae3ad77af24f89/pyobjc_framework_metrickit-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:b788a3cf866474dc4569fc253a6c0f62eb02a3b0104e9b2e757da8629d550462", size = 8319, upload-time = "2026-05-30T12:16:13.552Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-mlcompute"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/98/32/72a3733b6f3b1c60a18acfa517d28f9bcfff9822a1e21298c50c30c1a944/pyobjc_framework_mlcompute-12.2.tar.gz", hash = "sha256:7a2108c89ccae06e0fa03b1ef08c37bd9fae0ea0727d8b5890254bf44347eeac", size = 55014, upload-time = "2026-05-30T12:40:23.347Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/7f/44c69bb026a7ffc00686a51514b43d7fe1a09682997cabe7a39a016aad0b/pyobjc_framework_mlcompute-12.2-py2.py3-none-any.whl", hash = "sha256:18066ab867e02f5eb2cc66145b4274e6a7105e69165550356ec4a75937db1aae", size = 9622, upload-time = "2026-05-30T12:16:15.333Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-modelio"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+    { name = "pyobjc-framework-quartz" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c0/42/ff2d205133a753bd95c937b4591559bd10417d88da7debcdb7ef22e00dcc/pyobjc_framework_modelio-12.2.tar.gz", hash = "sha256:3f492868aa12c7107e456238fc718cac0316e8d95f7680b7465e41918d72db2f", size = 83763, upload-time = "2026-05-30T12:40:29.309Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e6/a2/84d79cae91284b7fd9c148fc6fbd84e54b5a30c189e0561dc605567d9149/pyobjc_framework_modelio-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:8d6c6fa5d5024495f7ee163acf872757824c4c2115909fb0f6e9ab045d1a6094", size = 20492, upload-time = "2026-05-30T12:16:22.228Z" },
+    { url = "https://files.pythonhosted.org/packages/57/92/6dc491a2ffe4c852c266d2a3430114fa0a4cee057930556adb5f27e4948c/pyobjc_framework_modelio-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:a2bcdc8079e4886dbee3c2351da5dfc53fe46d1d8e73a9a751085adce97a74ff", size = 20497, upload-time = "2026-05-30T12:16:24.585Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/f6/c4253cdf4ce3d2b55465805499deeecaff9230425366bdb9266c0e811736/pyobjc_framework_modelio-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:c7999915fad52b6578688d32ab4c761460237cb28b06dd663f81993fa6c4580e", size = 20738, upload-time = "2026-05-30T12:16:26.954Z" },
+    { url = "https://files.pythonhosted.org/packages/79/80/8f106d2a3c5236c05e58cf2652d0f346b723580b158543d33226bf0cdce3/pyobjc_framework_modelio-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:d8d6e411bf94a589372d2025ad854e1d9d96fa0c49af70898fd92c0265389dfb", size = 20473, upload-time = "2026-05-30T12:16:29.145Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/68/be1d3a840e1aad3d4deb9fe69338af2ea37767b6d90128f89aa04b3e00b1/pyobjc_framework_modelio-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:aa3e1aa0452c75a2a33b465a69f2203c3dbc93d556761814f68546dae6e8d6dc", size = 20716, upload-time = "2026-05-30T12:16:31.418Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/18/d5319d61d40e9409cfe11d26db0cb107d838e9a39c16bf488528f2499b41/pyobjc_framework_modelio-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:2204e3078e1e10ee43068ec198e2b24a8064901abb4fb040f3f9b06066bcd933", size = 20459, upload-time = "2026-05-30T12:16:33.653Z" },
+    { url = "https://files.pythonhosted.org/packages/02/60/7a9bf4028cd412840acb04110ace00b04399b549298b93fd63a2045122d3/pyobjc_framework_modelio-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:4e251c993b7dc123a436cc39802d272893a4c374796b3793d8f6cfd4f1c90f31", size = 20732, upload-time = "2026-05-30T12:16:36.008Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-multipeerconnectivity"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a7/a5/3112f721c54e1a09d12d8dc48b165ff51a1147783d8d63a53e1da5b603ca/pyobjc_framework_multipeerconnectivity-12.2.tar.gz", hash = "sha256:7a5879cb83e9a7ea8c8d9e7e11ed3de4c9d67046e6c330b8a5f6332339f631a6", size = 26444, upload-time = "2026-05-30T12:40:31.848Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dd/87/873cc3512150455b387492dcac327e9ad68187b708b06ac4665e750d2bca/pyobjc_framework_multipeerconnectivity-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:548618e01d4df6aa80f3f855af06bbca9e7148c06f174d1b091f54adf5aa63cf", size = 12000, upload-time = "2026-05-30T12:16:41.693Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/50/4080a78aaa2fe925dd2473fde41f650e3433cbc658c062d09b3658e181a0/pyobjc_framework_multipeerconnectivity-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:ff0c6305c3b573d97f217a69b8b82b9075d788a82768377a07a456114bec248d", size = 12018, upload-time = "2026-05-30T12:16:43.467Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/75/50488445848adbac42d752d99d126913dadf5e7026aaf28d83c836b6f788/pyobjc_framework_multipeerconnectivity-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:5f5de878761b5e1cec4566df0aef13143845a83e4d12c80faeaefd308fd919c4", size = 12198, upload-time = "2026-05-30T12:16:45.195Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/6c/ff2eb6e93c855d62b8fa7b07b76d549e381d2cbe37ffe6988ebdf6148a93/pyobjc_framework_multipeerconnectivity-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:4168de44baf26e779a115dba20d4c4415199874316135932f0c1647b638d1571", size = 11995, upload-time = "2026-05-30T12:16:46.938Z" },
+    { url = "https://files.pythonhosted.org/packages/44/6d/ddae986c4c54a47273baa6f068fe7b78b277d1bc4823c6f520d08c434225/pyobjc_framework_multipeerconnectivity-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:e97c1fd9656afd8287c111341e44e1cd87ea5dfaabb56a899f589d63bcb1b014", size = 12209, upload-time = "2026-05-30T12:16:48.791Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/54/77a9cecd9ddf1b76711c0a90faa1177101f52057931e83c174e180e9b7d8/pyobjc_framework_multipeerconnectivity-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:8863bbe1774901dcca970e2113f95832fdfd2f3473de8df033411611224d65a8", size = 11988, upload-time = "2026-05-30T12:16:50.651Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/0f/0949e62302bbfdfa453e795ae88351b18d213b4308dfb03d4fcbf5b4f443/pyobjc_framework_multipeerconnectivity-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:c83025bca07a25bf416e960906375f66ff7fff2ea4411d1be13fd51dce32737f", size = 12203, upload-time = "2026-05-30T12:16:52.288Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-naturallanguage"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/6a/1b/8fe870dd9ffed8943e72328fdd71df69363ea55037107882a3c11182edbe/pyobjc_framework_naturallanguage-12.2.tar.gz", hash = "sha256:f6980ba957bb24501bbe135ffcdd0ff149f33d30e965f033ad153df756b33cc7", size = 27251, upload-time = "2026-05-30T12:40:34.327Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f5/00/5923b25edd9d64ba7494cb8e28c1c073ec5cbb43a41eaa70bffa4b7a2862/pyobjc_framework_naturallanguage-12.2-py2.py3-none-any.whl", hash = "sha256:8c02a9ea25b888eefb0ac503211e17a9868a1781f5d5bf9c1655445abc14ffe2", size = 5436, upload-time = "2026-05-30T12:16:53.941Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-netfs"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/de/c8/e22988cf11df9b7c7da2ba04b7e9b9435fa7dc4ba3be7d6bb34d60f686eb/pyobjc_framework_netfs-12.2.tar.gz", hash = "sha256:fdb04ecc91864a4b79498a07f4d34f33b5dcae34958d555f5cbd69e20165991d", size = 15139, upload-time = "2026-05-30T12:40:36.186Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f8/c1/1584c42fc716ee13d085461913b59f5682fddd76b8094feb760477a8edab/pyobjc_framework_netfs-12.2-py2.py3-none-any.whl", hash = "sha256:864d09a7b671f4407ff577739949c98ae8ba9b013433cf938fb0c86319151248", size = 4161, upload-time = "2026-05-30T12:16:55.515Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-network"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fd/a8/12fcf0341ff377600a102f48266ef85e67af9dc7d894ca40fb18dd8702bb/pyobjc_framework_network-12.2.tar.gz", hash = "sha256:99d7a1900d8250d008eb285b20792d14076eedd665749cb0f48e1e102056207a", size = 62275, upload-time = "2026-05-30T12:40:40.695Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bc/7d/b519d186727fda8eb3d365312e2d4059e104f50525f0c0618083c43755fb/pyobjc_framework_network-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:0173665fde7fe004c49e9786a0073ed50f6b2b7f6b78198bda78a01c36ec9650", size = 19630, upload-time = "2026-05-30T12:17:01.972Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/b3/c99e31a29975fe58d81396105518d74cdd1b0de5f8d939e5a5892b7d95f7/pyobjc_framework_network-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:6677fac4bfe2d8ae320ffc069767c0e2ca7d50304ad3cf7a77d0a4d08d69465e", size = 19643, upload-time = "2026-05-30T12:17:04.223Z" },
+    { url = "https://files.pythonhosted.org/packages/85/94/233e77df7b4b53aa0316346540ee1345ed6c2d5b1893fd10fe268e1d9a1c/pyobjc_framework_network-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:c198226431964487f1213ba17de69eddcaf5ddd1bea406b31c6845cc956da536", size = 19714, upload-time = "2026-05-30T12:17:06.29Z" },
+    { url = "https://files.pythonhosted.org/packages/95/48/9d19d4dacbe35ad331c952501776965686eb93e385fddb8aac9feb02cc14/pyobjc_framework_network-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:842fcdb53fcf86af1f5a2287107955e05f124be1e461a407b77b944628f7a57b", size = 19374, upload-time = "2026-05-30T12:17:08.391Z" },
+    { url = "https://files.pythonhosted.org/packages/93/53/b20568f13df1dde9b8520e84200581a3be120a7a9f57b98086e169a892c8/pyobjc_framework_network-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:7f3748fe2d12061b6b4035d2a9575b81ea6911dfd3f2652d23bd913e9aa4b559", size = 19432, upload-time = "2026-05-30T12:17:10.638Z" },
+    { url = "https://files.pythonhosted.org/packages/32/29/3bbde722d3c54a8356c7a942cfa75f54a8589bc22899e95f27ad62967b63/pyobjc_framework_network-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:c88b1b8666e007cf3388c17998147d12a9e80b103d21a625df170382990a974b", size = 19385, upload-time = "2026-05-30T12:17:12.667Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/5b/99538f4541949b561788eb2971b1b0f1a60353000f780266508a7cf1a2fd/pyobjc_framework_network-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:2157c11fe921fb76af55364b7ca1e9f9679156b2cf2b7b18f1a1e2d25bc4502f", size = 19438, upload-time = "2026-05-30T12:17:14.731Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-networkextension"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/11/f0/bf65ac7714c81159f295d9386d718c9a876fc212f8af54b6da22c2d2873a/pyobjc_framework_networkextension-12.2.tar.gz", hash = "sha256:45bc3e7966cb9fce997832960d8aaf324a187f84019e65fc4432c27046715f70", size = 81296, upload-time = "2026-05-30T12:40:46.374Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2d/d8/ad0b3dadd27ddffecc697f3155fc387b278d74972ae36e790c3bd69c92da/pyobjc_framework_networkextension-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:1b9d588739185994e945fcebf23d1f25bfd0d2893bfc2cddc366a2f421943245", size = 14451, upload-time = "2026-05-30T12:17:20.853Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/86/91d135890a83c021e2b031c467001802314a5b2c6aa1580669b1bf524060/pyobjc_framework_networkextension-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:631ca462cedf277531800e3cbdf6d4f98aac2dd2ce8512fc855076fa373d6725", size = 14467, upload-time = "2026-05-30T12:17:22.768Z" },
+    { url = "https://files.pythonhosted.org/packages/85/d5/47debfb91e4f0c1bdbb1d4f433662cdc97e0467bf84379764be7dc26dfe3/pyobjc_framework_networkextension-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:1f9c7e7aa156d604a2c0764f65ef95131ff0c7724dd9ff35347d96b27836814c", size = 14611, upload-time = "2026-05-30T12:17:25.109Z" },
+    { url = "https://files.pythonhosted.org/packages/30/94/c894b717aafc6c93dfa02424e64025d2f15fe90c283b2166a9131e0c9306/pyobjc_framework_networkextension-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:e2bd61562844e400f8b8c5b434be44e42164af3e64ea4f51cdee335f92e9cc8c", size = 14530, upload-time = "2026-05-30T12:17:27.228Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/d1/8073286f4bf3d38edcd506826101d4f421bfb140ab402a4e627ec9f5235a/pyobjc_framework_networkextension-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:4a105e5cfe795914f728684e0b5b08647b7d7c106b9602ab782bb0af93f44bd9", size = 14668, upload-time = "2026-05-30T12:17:29.176Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/71/2ee8580786367e4376a2bb76e45c17b81d7b85436382bb40f8236f7f8700/pyobjc_framework_networkextension-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:fdd6a5807b30077ce1545b0a9583a8f878f220f6b5f246daa470d77ad0b1a692", size = 14526, upload-time = "2026-05-30T12:17:31.141Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/d0/053e00fb31b9b1cd0ecb207ac61f59befc9ccf3f257af7d05445b3a83e8f/pyobjc_framework_networkextension-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:faf4482e957bc76a78d3784ee5b010f9f562eb606118a6a3a30edd59f89f430a", size = 14659, upload-time = "2026-05-30T12:17:33.068Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-notificationcenter"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e2/d4/62b27947aa2ff2228b49083245e622eb4840f68c58d6d3e89041f597b5dc/pyobjc_framework_notificationcenter-12.2.tar.gz", hash = "sha256:d7a20fd67851d91db142765aa823a5c60c03c37957cea310a4eaad37640c085e", size = 22134, upload-time = "2026-05-30T12:40:48.715Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cf/37/7ba6f07424412b99f3eb9c4ef34e16d156f257b2670cd625d2ec0c7e2c6b/pyobjc_framework_notificationcenter-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:1141c58ff04085ef388c7fc4e588d5be9facbfc6d63f405ea6940f990293c493", size = 9872, upload-time = "2026-05-30T12:17:38.161Z" },
+    { url = "https://files.pythonhosted.org/packages/46/ac/2b2465db73f0340538df30728e5cc4a1c3014066651b091406cf2fe96e0e/pyobjc_framework_notificationcenter-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:d869a7689086ccb6f5c82a29684f38cbd2293e63a50fb8b06cec6151b497a73e", size = 9896, upload-time = "2026-05-30T12:17:39.78Z" },
+    { url = "https://files.pythonhosted.org/packages/11/0d/bff8fbabbad5f0328852f0d9b7d87551b206c3c76ff9c5ecd863d7613643/pyobjc_framework_notificationcenter-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:db911fd4de68f52abda8e812799e87721092f78ac575ec50bff82018e1efb06a", size = 10088, upload-time = "2026-05-30T12:17:41.723Z" },
+    { url = "https://files.pythonhosted.org/packages/18/bb/06fbcdcd37586878ce75cd61218594d0f3c4559262487b870dd4061f8394/pyobjc_framework_notificationcenter-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:3425e37a3eaa63dc63b8ca9556472e57d020bb6681885f1e36ef875e67ea07e6", size = 9955, upload-time = "2026-05-30T12:17:43.467Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/f1/3d1e94e67bcbc4dbdad682d421d2545e80bc08d0f742f71311e99c17bd2d/pyobjc_framework_notificationcenter-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:27dc6e162ff3fe446b50e276c97d7e811b71cacef460dc857b0cebc08e6a6286", size = 10165, upload-time = "2026-05-30T12:17:45.078Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/4d/800507135e5018b87343a4ab8cda11ee4d9b3018b3469d2f68f32a1607a7/pyobjc_framework_notificationcenter-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:e0b2b48ee6012b8019211d7e8910f5cdfcdfe846b54c79e7ed58deacff5d73fa", size = 9950, upload-time = "2026-05-30T12:17:46.653Z" },
+    { url = "https://files.pythonhosted.org/packages/32/22/09ff226c62948056d15f8b9f7dfdbba873f876f1496ac4193e1b4f26cc7e/pyobjc_framework_notificationcenter-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:7287b66979a21d94f132a4bdd2914f6e6d96823d7454c46841722b6d494ecd78", size = 10153, upload-time = "2026-05-30T12:17:48.179Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-opendirectory"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/12/43/1c4b9f4e3739c3ab763f42b6e51ea74afebafefa5662b2740a6fb812697a/pyobjc_framework_opendirectory-12.2.tar.gz", hash = "sha256:e9edbe26c4d9aa533f343264d34af96fbef958d0c3a833acd2d64cf0fdb138e7", size = 69875, upload-time = "2026-05-30T12:40:53.704Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/09/0d/6926ea3ba0f58e52e7a2260b416abd44c4680dc6c5c8e2212ccdd8d649cc/pyobjc_framework_opendirectory-12.2-py2.py3-none-any.whl", hash = "sha256:71d17cc1be29dd2ac50ae76fd654d233bed3b117854bf0ace021d8242a5a5566", size = 11910, upload-time = "2026-05-30T12:17:49.849Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-osakit"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9d/bf/f6ea6b2e15151c79a22feda80d9e2c120d457cf16750c7751408f3dffc7c/pyobjc_framework_osakit-12.2.tar.gz", hash = "sha256:219efdbe36fa6bea1c780b28ad8a1b23ec4ca0ee9ad3cf040da192f883514b81", size = 18910, upload-time = "2026-05-30T12:40:55.732Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/ad/e79528da31d07f4d227c0f674b94a8a5b0aeac062d6a2df8363dbf0d99c9/pyobjc_framework_osakit-12.2-py2.py3-none-any.whl", hash = "sha256:604f428b00a0b1da1f40fc8a78db96e08b23abc7d666545a0909cc6e7b5ca2fd", size = 4143, upload-time = "2026-05-30T12:17:51.431Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-oslog"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+    { name = "pyobjc-framework-coremedia" },
+    { name = "pyobjc-framework-quartz" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/64/ba/dc92bab4a4be642226c3f6b71e0a100f70c27027728df00eeaaa588d04f8/pyobjc_framework_oslog-12.2.tar.gz", hash = "sha256:c2213dbb3edff318c731b300509c69bd922ad102311042dddcd9de8287e50a83", size = 22307, upload-time = "2026-05-30T12:40:57.943Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6a/62/e7ee1eceb1645615eebf7549e89cc9a5ee815d0a8d1058790faa68a780a7/pyobjc_framework_oslog-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:3f88f4921707ed38da239d03f423929b126f0d8361c0500a382c76144b674f55", size = 7882, upload-time = "2026-05-30T12:17:56.321Z" },
+    { url = "https://files.pythonhosted.org/packages/be/13/df0e2bae8e19998101ba238a2cd27c147906c63cd42d1814293bc08f729b/pyobjc_framework_oslog-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:ce52bdc6803bf980369d3f265339063fb71391fcf980acadf9f73c4b7af7413d", size = 7902, upload-time = "2026-05-30T12:17:57.82Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/cb/b73921c1ce8a78620c14f00f2907de7430a5dd78cd858b3b72cf43758ee1/pyobjc_framework_oslog-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:102c32f34f772befc22d37bbf3a6a70a88b3389ea6d25111217e84c5bfde40cf", size = 8081, upload-time = "2026-05-30T12:17:59.592Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/d6/8945a6f9ff6f31f90a41e190d944bacd3d3115d73004eb778c95212fe9c6/pyobjc_framework_oslog-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:595f392d7966a28765dc35b7139243ee6cd1467a6edbb1f1ebe20af38e058542", size = 7943, upload-time = "2026-05-30T12:18:01.072Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/ce/d0620e285ec8a2257dd7079d1fb3c44d6b853ce049abcfdefc5fa73d0155/pyobjc_framework_oslog-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:7b4048471200aa35b7100dc58afc9c1c36b6b7a969070cec608b6b260a892259", size = 8143, upload-time = "2026-05-30T12:18:02.765Z" },
+    { url = "https://files.pythonhosted.org/packages/83/6d/e7e9ea2ba0e4c4af69651f7aef78ddb2f35232f782526089c9dd727feeee/pyobjc_framework_oslog-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:041b952ad6bfc80637f827ed0007f34ac68352b1d51f83279ab6db66b89d1dc2", size = 7944, upload-time = "2026-05-30T12:18:04.209Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/50/b76c39a5cfed0476ab89926b1c324673f99571336d56d8a099dfcf6dcdc5/pyobjc_framework_oslog-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:1bb0922c211b07f50022583ea54ea58cf651963982e325873c6813474c4f0ff0", size = 8145, upload-time = "2026-05-30T12:18:05.925Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-passkit"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/03/ed/68c8657d080f53706ea7e6cd77a4babb2b8f95a0c73471db5a56c5742988/pyobjc_framework_passkit-12.2.tar.gz", hash = "sha256:14a9b37b290942e86633ac59f923195d0038ff0f746443d914dfd5858cba9eff", size = 68267, upload-time = "2026-05-30T12:41:02.865Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/33/31/97632296672a105db7e30f005f036216f341a20d6b0c651f25a458eb970b/pyobjc_framework_passkit-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:1e24dcfe31e1635b6d858c5386b8fde4bade3eefc869aa683b0bf681bf1d72ab", size = 14451, upload-time = "2026-05-30T12:18:11.899Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/b0/dc2ca2ccf1377eb980220ea1b392803c0d7f42b2164960ed5a04361ec592/pyobjc_framework_passkit-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:3ca56bc17cd5ac7fea74caec55f3329a2b21c9462f70f1799a1896cb2fc9c06d", size = 14465, upload-time = "2026-05-30T12:18:13.945Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/24/1355ea6c97237c844e689e1f6b92481c3382693590af67a637a7c5205df7/pyobjc_framework_passkit-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:f58e668a4e827e2bfb7ddc41aae68025c980b5ec25d218ea8a49740159268f8e", size = 14627, upload-time = "2026-05-30T12:18:15.871Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/40/a96eae0e665cec73c5d9e0a5760dae1b623483349e618985772f09be400e/pyobjc_framework_passkit-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:737215ab0ae39960e4b94d70380b873e06002a8905589cafc92b01bb9e54af77", size = 14469, upload-time = "2026-05-30T12:18:17.816Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/fa/a0e28ff2e0fc0ba620a603df0b642a83a8b5c1468377e5b6a6c6100b4db6/pyobjc_framework_passkit-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:6c47fead9168df3cb8985f572ae1bcbd200b5edfb8c50e8387df70c915e8e734", size = 14625, upload-time = "2026-05-30T12:18:19.796Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/b5/8c9f7b433b4d4a773ec29b788254c700e5b269f28f8348c80e1a634cee5b/pyobjc_framework_passkit-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:9e77169e91a10b33eaf650b9af160c8c4797a90f409577ccebf45cd5279dcd27", size = 14458, upload-time = "2026-05-30T12:18:21.763Z" },
+    { url = "https://files.pythonhosted.org/packages/16/28/5ce999f434a082e21c1a85f65232ada04eb5967244b18cf370645cdf8cd2/pyobjc_framework_passkit-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:8bf020af75bc581438700af5d5cf170d18bac9be8cc953dab057846dbf95bd4d", size = 14621, upload-time = "2026-05-30T12:18:23.636Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-pencilkit"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ea/f0/39d09038bea6f2130ed6ad9de9034a2ebf3babd9eb5ad75a70f60160cfd6/pyobjc_framework_pencilkit-12.2.tar.gz", hash = "sha256:a224250d5bd8490e619792570bf2b03849b875757c076412ef83bddf58a3d2c5", size = 20122, upload-time = "2026-05-30T12:41:04.877Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ee/d6/45dc7133e4d561b725718a2d8cd016605a6fe7bcf3f12a002c34a309ee4c/pyobjc_framework_pencilkit-12.2-py2.py3-none-any.whl", hash = "sha256:aec57e9ebe2a875d4fc17c46ef16ffcee74ba7551dcd6d83207efb05c3377187", size = 4245, upload-time = "2026-05-30T12:18:25.228Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-phase"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-avfoundation" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/40/4e/3102eb1fa234c851e23213701d3cda26eb3516c61598dcc7e3f26eb17724/pyobjc_framework_phase-12.2.tar.gz", hash = "sha256:fc1ec192bf7aac2627425c5f1fdabc3df614d100d18a6273b25ec4593f257eca", size = 40747, upload-time = "2026-05-30T12:41:08.372Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a8/80/9d526e002b9be65dd80abc2cc5c62afe8a85f353282f33d212c6b44b52db/pyobjc_framework_phase-12.2-py2.py3-none-any.whl", hash = "sha256:e8b85d7b2743b61f8920ad044f7e8370de80e5a4ca4f85ff42b6047b04e5f821", size = 7187, upload-time = "2026-05-30T12:18:26.949Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-photos"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7e/a9/3845e4976742f15baf7decd63202b16326196596ee95271eb1eacbb388ed/pyobjc_framework_photos-12.2.tar.gz", hash = "sha256:126d2d2aa78ea0e704db807ee2c7f7b418d8a859a0cb8df6ee31e66fd371c2ab", size = 58662, upload-time = "2026-05-30T12:41:12.67Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/25/e4/71d6ff0833727d3958bf7dd0239d25a05a5d4d52475e443c5e25f6ffedbf/pyobjc_framework_photos-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:0c9e2311970d031ee7fd5cb6531ac9236ed70902910cf448a2adad61c516be68", size = 12522, upload-time = "2026-05-30T12:18:32.426Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/39/2195f0457e021692c80db6b31334d26fa08db64ced2751040384de8b5fca/pyobjc_framework_photos-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:2f3caf43105e0d142abc6b10bb851dc107158682d9dbb612d053cee80385f0f7", size = 12537, upload-time = "2026-05-30T12:18:34.198Z" },
+    { url = "https://files.pythonhosted.org/packages/67/ca/3c305cec64c242f2f66533650ec955c93af89772a910c64c4eb4c6748ec2/pyobjc_framework_photos-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:59a9ac81947dc6140093ec2f4131842c8820f6ad9a51226c56e15b43ebacf011", size = 12715, upload-time = "2026-05-30T12:18:36.022Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/87/809159a91d74d25b098bf1b1551029329c348144caf726dc1aefd67892c6/pyobjc_framework_photos-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:facf2989cdf8cac7a34d6e5b6d410aa873b78edcd90da1e5d4812e30f5ad6b5b", size = 12586, upload-time = "2026-05-30T12:18:37.817Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/8e/4adf7cd8b7ce70ee16f28ab92258959f10e4de60ff8839f0230eddef60ca/pyobjc_framework_photos-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:1931ea06e6bbb6025c3d24b0311415c3676c61157b1ccfe4f41eda12240adeaf", size = 12774, upload-time = "2026-05-30T12:18:39.731Z" },
+    { url = "https://files.pythonhosted.org/packages/02/28/00586042f82ecafd48e82d15ea6aebb2300b0f524a613b3f6cab1214621a/pyobjc_framework_photos-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:0ff24a985f6fb0a876346f320afe77f3cbc8617b8cacdb3cc010218187cb1d15", size = 12584, upload-time = "2026-05-30T12:18:41.51Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/5c/0863492ca4780a11ac86e5c6a309e9acc00271581e77dabc1544eeaa05b7/pyobjc_framework_photos-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:b82f8aaed4f43dd344b45c81f2a661b607443b5bd221fe612f948a7f9a71acfe", size = 12767, upload-time = "2026-05-30T12:18:43.347Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-photosui"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ff/62/9b4322779ac45e8971d613c23f19284d7c6ac2492b2384c8eaa4582e6dfd/pyobjc_framework_photosui-12.2.tar.gz", hash = "sha256:c85ebf27f523dca57fadf767a4d72739c760d7c7236f5e5c8fbe4f80e696c9fd", size = 33856, upload-time = "2026-05-30T12:41:15.824Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f1/81/5233f2e0c255d73e0fe20cfdb5914bdd50c1df8c911ad5eba6759d870476/pyobjc_framework_photosui-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:1bc96dba3085d5ae6d5f311ec4c82cdafb04b5519a6014e3ae7915086408346a", size = 11784, upload-time = "2026-05-30T12:18:48.825Z" },
+    { url = "https://files.pythonhosted.org/packages/99/c4/c2f9cc556bde2e1e85cc20103ef34705da6e695b542330d5fff7eff17cdd/pyobjc_framework_photosui-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:2630d9f61df8f786b1a42a30872e856be2ae7a2fd21c995c5d7d88705cc784ed", size = 11793, upload-time = "2026-05-30T12:18:50.524Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/68/f9696cd18c479e67b9b911c5a8d7243034fe36c6bf6482add22ae1076dc0/pyobjc_framework_photosui-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:9c3e0cdbca02ee749b3d56ff332a4a69b8d378550131df4e4003733c6331728d", size = 11994, upload-time = "2026-05-30T12:18:52.323Z" },
+    { url = "https://files.pythonhosted.org/packages/af/c7/5dbd150e31f3ba6a972f7006bad934836e2063c1c81c4a245cb4eb6e190a/pyobjc_framework_photosui-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:75ac87647349f556c91cca0d584720fefaa303fb472f20e31c4eefc4a7d7ffc2", size = 11791, upload-time = "2026-05-30T12:18:54.055Z" },
+    { url = "https://files.pythonhosted.org/packages/22/a1/709f881022cff00e7b6f08fb53b68161be16b0979861adb465403de5b696/pyobjc_framework_photosui-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:70e9ab782e9ae83d79da7718e9db4c491ce7fdd58d18bc00a27e4b1e9ea113e8", size = 11976, upload-time = "2026-05-30T12:18:55.753Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/90/8ecf14ae1227be6b049c237a25f4c5986aa1a77661dd62d0e9550c4cbe61/pyobjc_framework_photosui-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:18cddf0afffb005cb06ef6c10c3ea61dc7387162264e469c2aaaf261970a1022", size = 11784, upload-time = "2026-05-30T12:18:57.48Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/e7/de8dbad22bc3ceeb7ed61de59762a409a1773a066369df3cb9ff7016d0d4/pyobjc_framework_photosui-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:52f74cc40c1dc129e073331910b627bb53f457645ac1bd1802176cca23c49a1f", size = 11977, upload-time = "2026-05-30T12:18:59.182Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-preferencepanes"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0b/86/73de5b65736cea66bb0159d9a37c007abceee8ecd3a059211241aa2d77cb/pyobjc_framework_preferencepanes-12.2.tar.gz", hash = "sha256:4928aa6fb30b24af3aa7379125ceca91687e97b08715909689d549a0a73266d3", size = 25151, upload-time = "2026-05-30T12:41:18.455Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d9/5d/b75418c408c5e969352307b5fd4d739e55b3618cf94e729ba9768e453f2a/pyobjc_framework_preferencepanes-12.2-py2.py3-none-any.whl", hash = "sha256:ccd142fb1d26f20e660651008fce1440f0abc1897bd5ffb5546cd77e89bb31a6", size = 4803, upload-time = "2026-05-30T12:19:00.619Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-pushkit"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e1/40/23d8b7065434179984df6f4bb18c6ead5400ed2f85b7080282c600106022/pyobjc_framework_pushkit-12.2.tar.gz", hash = "sha256:8f6b6879920bf9650f2288adb0dc8f809a807825c29136b6492561712234b0b3", size = 20471, upload-time = "2026-05-30T12:41:22.736Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/50/e6/c787ca0efe193b7f8eb907ef13eefb47efedf513d42214f5ec7411867a51/pyobjc_framework_pushkit-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:955d18de1963fa09f41fa797470f943d0f85f3d2ea5db3d618798e92e54b4575", size = 8282, upload-time = "2026-05-30T12:19:07.379Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/73/d315aac0efb5466a0235ea69aefac9883add2f5fb90ee363372abeaab299/pyobjc_framework_pushkit-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:358e5e381d37fc1199d0e18eae0ec9bc88145545c985a75ffae37918c0634a3c", size = 8299, upload-time = "2026-05-30T12:19:09.129Z" },
+    { url = "https://files.pythonhosted.org/packages/89/6f/8ee291088ec4b6469b9b51674d0f160929395164483136cccf2569bb85c2/pyobjc_framework_pushkit-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:11a5efd1e08cce341b0882cf4b47ba120f288c04594d714c0149c2a357518b05", size = 8438, upload-time = "2026-05-30T12:19:10.855Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/40/1b139236ac991f39723b9fbed278f655be4d6837f90d10214203e442064e/pyobjc_framework_pushkit-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:19dc136cfe89f43b3ff3e0643106aa4e527ac03936e50cc9d3bc2d91dd2a3226", size = 8356, upload-time = "2026-05-30T12:19:12.318Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/73/18dd6ab8aa631a616c88ff7451bd7d57c8f49d44c7a4aec0a7ad13ba3c6a/pyobjc_framework_pushkit-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:4e8099d9db9c9a66b2b098dd36fa03116bbe82387bca27c34969eca207b74b6f", size = 8489, upload-time = "2026-05-30T12:19:14.024Z" },
+    { url = "https://files.pythonhosted.org/packages/26/d1/a80f3bed47908c156d83ef9b6d80c3a0a949ce4fad0f45e5bcf982d1240e/pyobjc_framework_pushkit-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:23654c78ddb89412ab0f57ab36734789566525de0d357e22edc22f30a63d7971", size = 8349, upload-time = "2026-05-30T12:19:15.479Z" },
+    { url = "https://files.pythonhosted.org/packages/96/e4/c0fc4a461ba75e64bfe0681a1ea469932e8df8c5ae7536b438de6ee2dde1/pyobjc_framework_pushkit-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:3d943e4c56d5e2ac5652c8b4d62187235d401d00fddce28e06a2db857772460c", size = 8495, upload-time = "2026-05-30T12:19:17.23Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-quartz"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/91/a3/5ae4c90c13999b46315f549694f25c374c48a9f7ab18f98ace6e74f4a5c1/pyobjc_framework_quartz-12.2.tar.gz", hash = "sha256:b343395d4790323b0376fe20c83ac468510ba19f65429323ca211708c939d107", size = 3215525, upload-time = "2026-05-30T12:44:27.759Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/96/98/3b1fa78ddb1cd10d0edd4d49a3d00301d941f535694ac444fbed53ec7504/pyobjc_framework_quartz-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:8b238979d62b6e0b90d466477eee968d8f2f6720e850af2472e01cef349293b4", size = 218969, upload-time = "2026-05-30T12:19:58.528Z" },
+    { url = "https://files.pythonhosted.org/packages/96/56/670a847a3a8ee2799f405b876a2f20914f22b4865f1d8157169095c21d94/pyobjc_framework_quartz-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:214c19aadfd100d9202994a22fbced804f7d60f8473de6f292111cc1668f9373", size = 219383, upload-time = "2026-05-30T12:20:12.444Z" },
+    { url = "https://files.pythonhosted.org/packages/35/ef/598bd4d1fb796305648c03667938f08bb59ed4e0bcdc1591fd2c6238abf2/pyobjc_framework_quartz-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:4e0634ee9782e480587a074d1d08867fa7ef0d845c2f6cbaef6a48b7d2c3899f", size = 224436, upload-time = "2026-05-30T12:20:26.608Z" },
+    { url = "https://files.pythonhosted.org/packages/11/b4/7ec90f6480b554173df109b570915c26d286c414d9444d2066fc93567781/pyobjc_framework_quartz-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:08f7c7b42de70875cee15f4d0e217471e382ffac44d0a5bcfd30f583b9b41adb", size = 219749, upload-time = "2026-05-30T12:20:40.674Z" },
+    { url = "https://files.pythonhosted.org/packages/72/f7/9a6cc42345d7a89c7344763e931476c9bf00d3b16ef1e862b1f720709afe/pyobjc_framework_quartz-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:57553e7085191f9421ec78fe57a8a0c8462e39d675014ac1e4b389381f04535a", size = 224703, upload-time = "2026-05-30T12:20:54.835Z" },
+    { url = "https://files.pythonhosted.org/packages/41/76/a831a11a67fe36898b4b887bfe7694a291e08a96266416a832a9de97bec8/pyobjc_framework_quartz-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:6fbd127d864108103d4980292ffca32bd9c1e5f643e0abd5773fdde2918afaca", size = 219804, upload-time = "2026-05-30T12:21:08.79Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/77/3223cef0bf8cc97f1d586ad1b6c79e04bfbe2a47a1fe5bd1ad3abd862325/pyobjc_framework_quartz-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:359738c88b12427a30d73a3d202002ab910e31eebf6bee4550495ec8aa64a004", size = 224750, upload-time = "2026-05-30T12:21:22.826Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-quicklookthumbnailing"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+    { name = "pyobjc-framework-quartz" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/75/c7/e19792f6473714f4144ff2c579f2a231eeb81e405388140471f9f6ffaa4c/pyobjc_framework_quicklookthumbnailing-12.2.tar.gz", hash = "sha256:b0104142f0eb950e849ea25f40c01715069e1bdb3de69949c1b4732c8f5c693f", size = 15771, upload-time = "2026-05-30T12:44:30.263Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/48/5d/012d04a9fe4117f727e0436b7b6c9a30f780e04ee51f1d6e28bb6d1a8700/pyobjc_framework_quicklookthumbnailing-12.2-py2.py3-none-any.whl", hash = "sha256:a60bdc283a44a70ad7a12840010b76d42ffd580c4bffb630da3874b229d30a74", size = 4306, upload-time = "2026-05-30T12:21:24.611Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-replaykit"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ad/28/9562e12a0f13ba9c03ec59694af026500265cba2bc71468bf5985230ff3e/pyobjc_framework_replaykit-12.2.tar.gz", hash = "sha256:f971842973fad039642a67e3432b864e8bed815228d67d07b52174fceadca86f", size = 27206, upload-time = "2026-05-30T12:44:32.807Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/94/f4/2377e7bcf93257ada33941e8ea7993357bde6e679fccfe44f9f36c9b9988/pyobjc_framework_replaykit-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:3b60c6b287dd8b991bd432acb4fe061f8939df56aa65741dc777565aa0615f68", size = 10149, upload-time = "2026-05-30T12:21:29.974Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/e3/bf9e3cc9fb4f3629b42e510f40539e323af43597601bf1ae5275a8468572/pyobjc_framework_replaykit-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:ae67c235356b4442dd0765ba3b911acf6f597894ad27b6b6c322b55ea501be6e", size = 10165, upload-time = "2026-05-30T12:21:31.556Z" },
+    { url = "https://files.pythonhosted.org/packages/03/ad/a34116524dd3d7cae22cef8125a897c4533b9dff9236cf4e00f06ca01012/pyobjc_framework_replaykit-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:2040fe7d3da7ac485c32f620bc0a2ffb8c5c1052ca67e2d36db78533bbd84e9c", size = 10348, upload-time = "2026-05-30T12:21:33.309Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/2f/c6f524971e6f61e763ce6c36ea9ecca4d61d423e79c26fc715e06ebd879b/pyobjc_framework_replaykit-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:4479558bbaa1d0292e77d1d01b56eb6593a47310c9c49d213061b35094f0a948", size = 10220, upload-time = "2026-05-30T12:21:34.924Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/57/06b54386c5d2079172682193030fa39bae31872b9ab85c208145b7569a6b/pyobjc_framework_replaykit-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:aa7785a906efcac0d5cd6c68c61bf0e0800c041c2a56ec179298a2df4af3f798", size = 10414, upload-time = "2026-05-30T12:21:36.53Z" },
+    { url = "https://files.pythonhosted.org/packages/34/37/cab6961855ff727e6ccc2e7766dd2429d042721f2929d38b3e2ecd174d07/pyobjc_framework_replaykit-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:9d429b4bc0f0ed7b07242e103f8652b79eca93e81d0730071377eb54b3c47152", size = 10219, upload-time = "2026-05-30T12:21:38.087Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/7a/9f755469b7ca6f962c0c3afa503ff6a67e5bc8f654728a1f2bea33a5bab2/pyobjc_framework_replaykit-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:95be424c8b99c0beaa068fe999c2cf31a449095b9f89fb56bff2a5961d1995e3", size = 10410, upload-time = "2026-05-30T12:21:39.659Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-safariservices"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9f/e5/8caad7cc12d7452f9f78f931bec253f04577c6a876a9884834572223462c/pyobjc_framework_safariservices-12.2.tar.gz", hash = "sha256:35f76589201c9857f36fcae027c79ae2719d4463e1bb35996f78de9f570a0a58", size = 27300, upload-time = "2026-05-30T12:44:35.242Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c9/2b/731f8bc8601aebb0e23032d5a0e6cd9af7abfb55192f95ec999c913443f0/pyobjc_framework_safariservices-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:4e9657d68f73454f1f147ff4c6526fff28a5bafb769d628091cc8cca5d89882e", size = 7314, upload-time = "2026-05-30T12:21:44.344Z" },
+    { url = "https://files.pythonhosted.org/packages/83/56/c3bf80c5abf766078fc6815a91c287a72772eb675eb538fa8e3aad426dd5/pyobjc_framework_safariservices-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:d7883793626c82eb645c99b719cffa856f8fa6d2bc19ce9fabedf5611888b7e9", size = 7339, upload-time = "2026-05-30T12:21:46.007Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/19/bbd38d764573a907e9287aec7fd065904b136042a6f4d8d9b488cdb67640/pyobjc_framework_safariservices-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:f97571814b69ca81baa3570a4338e9c7679a7505c5f05b28938890ed71d95ff6", size = 7344, upload-time = "2026-05-30T12:21:47.611Z" },
+    { url = "https://files.pythonhosted.org/packages/84/6c/10d2e963d630ba86a0dd72d83ce9e6a8d59bea309d76a71868ec4bdfff3e/pyobjc_framework_safariservices-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:6d5df844c6e10ef54a87ff9d847037978cd1cbf4ef87e31333a56726767ab5ff", size = 7371, upload-time = "2026-05-30T12:21:49.238Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/0f/fa12873da4842d5b0c253c3412a7e00251e7f5392007e5fd9f71a92c2d4d/pyobjc_framework_safariservices-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:79a9960e0d04487ac0554d25668efda8ba0bfeffc68936d841fdb1be9b44b93c", size = 7380, upload-time = "2026-05-30T12:21:50.689Z" },
+    { url = "https://files.pythonhosted.org/packages/58/9b/eec655a20a7732b2159ea8dda119b59fbaea7ae6864648e36fde50f314c9/pyobjc_framework_safariservices-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:de57e964f0dc86e40d9dd4b1a240fa889c80218970a1e716c45950d5da38ec34", size = 7390, upload-time = "2026-05-30T12:21:52.28Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/82/75e9d7f2662b252e073fb8ce771ca689cd733ede5bd9ee07e8198e1436d1/pyobjc_framework_safariservices-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:fad17d1e4f9a0a680cb9778c3aec4f31ebcf86ffbaa7f1850a368dd21b2075eb", size = 7394, upload-time = "2026-05-30T12:21:53.768Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-safetykit"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+    { name = "pyobjc-framework-quartz" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/28/c2/7a6c1c356ba3d9164357c353142e6d9354f999b45f204c57c5f2162a47dd/pyobjc_framework_safetykit-12.2.tar.gz", hash = "sha256:3161c4cd35261615ea38e64bd1db9de19c66d18d4d350bbe7d4eb4f69207e256", size = 20867, upload-time = "2026-05-30T12:44:37.319Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/65/b9/57f5f140685596bce0587b8348c996ae03b5f3f399bd8513d63780b691fb/pyobjc_framework_safetykit-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:13c471d8122a52bc0ae26263b22291475465fa00b5da488e096967c305d65bed", size = 8577, upload-time = "2026-05-30T12:21:58.553Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/c9/f33171cb2129b39fc8ce4a2dfd5ccb9d5fd7fcff795b90efa85462490609/pyobjc_framework_safetykit-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:93020a92a64dba726e8e1fb03079b4697d49e67f0338b33a63eab76a1a797033", size = 8594, upload-time = "2026-05-30T12:22:00.181Z" },
+    { url = "https://files.pythonhosted.org/packages/54/1d/2abc135c5b8674511bf72a194e2ee7d9fd23cc37ad6a9a8884451aa2a6b1/pyobjc_framework_safetykit-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:6dee8522c45cca1017ebc52198a89d81cf12b4e1fc751e8fab87059326b9c9d2", size = 8748, upload-time = "2026-05-30T12:22:01.766Z" },
+    { url = "https://files.pythonhosted.org/packages/34/87/351f935618c953e54258ba6d83a72343afe4296417ea5479f90233c6d1a9/pyobjc_framework_safetykit-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:650eeb355a74e39781dffe9ec364f9a7628f30f4bb4fd8080fdb850d90dad83f", size = 8644, upload-time = "2026-05-30T12:22:03.312Z" },
+    { url = "https://files.pythonhosted.org/packages/55/8e/5960031b9c56da88e4fc96f4fe8eb19bd1c41acbfcb84ab0d9f0ed554032/pyobjc_framework_safetykit-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:b2994d2c0d49a18b41a627c504fafff167eb54511111c0bce132c20269a784d3", size = 8807, upload-time = "2026-05-30T12:22:05.281Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/3a/cdb5155f81decd0aee51a730129dc2826b5d84b4690585c8140093a2075a/pyobjc_framework_safetykit-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:a0ab5169593c99b96fbe09506fa89eed88e799c274cf70d99817699c253d3b11", size = 8646, upload-time = "2026-05-30T12:22:06.994Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/a2/c5eee93c915e26b38c1f324aaeac223145d099572d6e7f0096999b3c8de4/pyobjc_framework_safetykit-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:e65386962f80aa4f85d11ee4f0470c05348b8282493336ca3adf9bb8feade375", size = 8804, upload-time = "2026-05-30T12:22:08.721Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-scenekit"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+    { name = "pyobjc-framework-quartz" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f8/c8/963293a476d7c80f60d93e3da2b1f6016913e827fdde63d3b9b7ec96164b/pyobjc_framework_scenekit-12.2.tar.gz", hash = "sha256:de58706317e567d0a5f257f9a4a66fafa037c5c8ef79051c19066b42477e301f", size = 131982, upload-time = "2026-05-30T12:44:45.83Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f2/b0/613f52cdd4b4fbe0735564ee8883d168d39b832c9146700fc9263a55ee4d/pyobjc_framework_scenekit-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:e623bd497088caec95e666b8f99bfcf89096d943b90038bb243b582e8707e6ca", size = 34800, upload-time = "2026-05-30T12:22:18.024Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/e1/c117e5db66ceb6c13f0bb44c40210749e2d9c61eb5d77d50e731dceb8865/pyobjc_framework_scenekit-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:0b1795cf860b19fb04116236b6de3a46ffac9f8b03c46863128d36207cc53a40", size = 34827, upload-time = "2026-05-30T12:22:21.167Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/44/645de9525dbd6258954b8001336df1f3ae85559acae9a119049089975270/pyobjc_framework_scenekit-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:0d0bcea0b7a4a13046a666a5b316c1b3ebfdd90a63226fcd5b7943fd9ee9d615", size = 35142, upload-time = "2026-05-30T12:22:24.247Z" },
+    { url = "https://files.pythonhosted.org/packages/49/56/8f9b1e188357488d143016852b1b203690a5d070d76e2266244daebca92a/pyobjc_framework_scenekit-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:7a28a88d7643c12c17a2bcc90899eb1c4d6750d48bc7fb71b8ea0bf9091c22df", size = 34933, upload-time = "2026-05-30T12:22:27.432Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/3b/51883f04be248965015f96045f449cda35c4dcc249c054d25244e552aa41/pyobjc_framework_scenekit-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:3ffccf8f84a60f671261c1fb997e4f8ed55d71603db0aaf1806032307dcb86ed", size = 35225, upload-time = "2026-05-30T12:22:30.464Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/8a/c1934d6cbd824ac2cd674f3adbb516f73fd55e9f8298e8c0bc785d3bd1cd/pyobjc_framework_scenekit-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:c881852ddf8fde16d1d124c6c664e2938d3f00839df1375bf54dacf260d1f6cd", size = 34965, upload-time = "2026-05-30T12:22:33.666Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/15/3a3c0d53150ec202ee8fa55fa5d374d046cc63d22db74a7804214b38a108/pyobjc_framework_scenekit-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:0b8b92b25f35889a7d05f350faf0986af2306430321e09a758469f043810cbf5", size = 35261, upload-time = "2026-05-30T12:22:36.7Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-screencapturekit"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+    { name = "pyobjc-framework-coremedia" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d2/e5/469c73f6ba9bf9ae6d4a93aa23838f288dabee88555402754dee000ec884/pyobjc_framework_screencapturekit-12.2.tar.gz", hash = "sha256:7f45f2e170b97dfde3e6c7d3b867ec3ec03caf3aac9259fde4ba0272d912b00e", size = 37813, upload-time = "2026-05-30T12:44:49.014Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/65/3a/461e7b200fb656c9581ae7e4bdbad58a81fc1b95b594a448b92b8858c5e7/pyobjc_framework_screencapturekit-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:ea666ebfd9da6a3db9eb9a36b22834ab381842d2ce0fafe19e782a03ed592aee", size = 11576, upload-time = "2026-05-30T12:22:42.324Z" },
+    { url = "https://files.pythonhosted.org/packages/73/5e/e64b2a94e8f950dc2418a274049c01ad3f8f3f54fbabe6912c72a72dff5b/pyobjc_framework_screencapturekit-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:ca8378bf217d3ac48db0bb62218b8bcf6b69bd35e1ba66608bec8c31e0f0fbf5", size = 11590, upload-time = "2026-05-30T12:22:44.063Z" },
+    { url = "https://files.pythonhosted.org/packages/21/25/892fe4f54b8ccecbcce6f05c98e377021ec4ada9b226b18523ac97c04025/pyobjc_framework_screencapturekit-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:c1be8a80eaa2a929cde641526f81e7452ff156234372d27c5084df472a74843a", size = 11766, upload-time = "2026-05-30T12:22:45.744Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/ed/94d8e98d2d035604e80ea72449b0e5a3fc63072a6f1aac7c76e3e5dff688/pyobjc_framework_screencapturekit-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:d2b4d13114bcea42f4643ff263e4c5ac1d006289b2ed04ad0390180a4525bef6", size = 11646, upload-time = "2026-05-30T12:22:47.448Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/b1/eef4bc88c093a68c65553a263ebef50fc1f280682e6bded1d0d1394e6b15/pyobjc_framework_screencapturekit-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:8aa43d36d8840560c3521833b5c2abe45008bfd1c45c980a6fd85aa29430673c", size = 11850, upload-time = "2026-05-30T12:22:49.337Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/7c/21f8b109ff5fc2a5de9dfef5c7b2dd3a6678395636c9835419410bb29a8e/pyobjc_framework_screencapturekit-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:1784792b5809946eec69792429d332cd818614fb6899f7cce35f7c9d8c357355", size = 11641, upload-time = "2026-05-30T12:22:51.03Z" },
+    { url = "https://files.pythonhosted.org/packages/42/3c/94f3c62be42642759ea9fe3428e8e859b3ecb738b9955ce35ade5d645797/pyobjc_framework_screencapturekit-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:560e81da652b05b0d10b16a62eeefa5e10cb05fabcae455f1c75da55c952be32", size = 11846, upload-time = "2026-05-30T12:22:52.781Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-screensaver"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/45/47/475b9d9462fb72f264c600178905e0f149d0dc3ac549940477cc582aa24c/pyobjc_framework_screensaver-12.2.tar.gz", hash = "sha256:2aefc58e53b42c33d0d06b4c846147c7b15b065254c588bef0ce8871ccf6d9d7", size = 22793, upload-time = "2026-05-30T12:44:51.232Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d4/9f/e2c143ea0f0ccd29f8c7e199d2bc81d198ea0c6d3d63948b314f6a26afa4/pyobjc_framework_screensaver-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:4572cb659fdde2df5e6fe9a6e6972e87a4a04ef60c64fb8766bdb6d281782f4a", size = 8463, upload-time = "2026-05-30T12:22:57.818Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/cc/168c45769e522b7982702c2b2af9891036e7653d8bc50a3871f529c9fb8a/pyobjc_framework_screensaver-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:e4a2e2205effaa1dcbf5365e25011b057ae70deadeb29b0782c0af6dc2592f7c", size = 8481, upload-time = "2026-05-30T12:22:59.402Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/bd/f0ee37d17d48f64c1232cf89fcac33ba56454be63062ca50150ff0002799/pyobjc_framework_screensaver-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:921dc983e81b0aab7f102bcd115b4c5cbc347d251b00167ca58ccec7c6ba10cf", size = 8493, upload-time = "2026-05-30T12:23:01.134Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/2d/a91eaee7dff0443e0930d9572d172370dccc15a2aefe37e2a21e01d04e35/pyobjc_framework_screensaver-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:fa9e2b9527ecffa4cad752f50b02b521016641d07faf78717ce801a95f934598", size = 8526, upload-time = "2026-05-30T12:23:02.753Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/6c/1660f902c6d3e985fc5b864744e8c3929381e30f0491cd3145c22da13dc7/pyobjc_framework_screensaver-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:4b174df55aaad1040b17bb8856ba79ac3c76e2076163ff66b264b89b6e2ee2eb", size = 8543, upload-time = "2026-05-30T12:23:04.315Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/a3/45eb28982e10c6ddd124d6e31b07ec4de929242d4d92c661e3bf03d1e176/pyobjc_framework_screensaver-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:270331dc16e72e692e6b732d0536c289a3b46f60aa149a36b7c78518fbc8a0b9", size = 8560, upload-time = "2026-05-30T12:23:05.923Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/d5/4a810a651e854e90fc271bf4bb61d7f10d00530464062593b9b28c5081c3/pyobjc_framework_screensaver-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:d5a32f11b57ca5d3399a9bb39c1f7eb76a5f303a008e82e6f022013aa6c7f4ae", size = 8570, upload-time = "2026-05-30T12:23:07.642Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-screentime"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7b/e1/acd5b9635c905305cdd367d1e5e06f71db13c44ac3384f0241845b180272/pyobjc_framework_screentime-12.2.tar.gz", hash = "sha256:0f708bf1707f2db5c4d13397471bd13cb8c1516ea204d7c4cca8f448295caa4e", size = 14069, upload-time = "2026-05-30T12:44:52.98Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/74/a6/2bdf31496600ffcbbb958910e03726e238f6a0ac6a7f3862cdbc28cab9c1/pyobjc_framework_screentime-12.2-py2.py3-none-any.whl", hash = "sha256:ef463bf9cf66ab2679a6fdc3da0a51bca3050bee4ff7614ac714edaa13e36003", size = 3979, upload-time = "2026-05-30T12:23:09.049Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-scriptingbridge"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/2b/81/59528ce5c27667c0effcb6af24d039767df0faafe3ad006f154a82d270ef/pyobjc_framework_scriptingbridge-12.2.tar.gz", hash = "sha256:b1420622d923cfe6218904a6a997eae4984653d32554b16374690c347f8ab55d", size = 21239, upload-time = "2026-05-30T12:44:55.141Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/01/fb/e3ffa8a5812302b208d0063254c3f6b1560cb0cdc18862280df471c899e3/pyobjc_framework_scriptingbridge-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:8292259f1ef59c503e003d96e05e489b6834cb6ac0ae92712cefed7a957bd7f3", size = 8359, upload-time = "2026-05-30T12:23:14.267Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/5b/ed96c67b88ce1408f1778d1235a7c3c354980e4c925ce53bfbea0b424c78/pyobjc_framework_scriptingbridge-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:ea7944907fe696a8192f2a9861e148b9a0161ac3415ab6ce6e76230181a10264", size = 8376, upload-time = "2026-05-30T12:23:15.823Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/57/9658c1a8576038e571308c3f21a6f38050808a7e379b1149c9b55abed746/pyobjc_framework_scriptingbridge-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:8dfab9213a60840f15d0ebb2572237fea569ff69d2a593f524e8c7074b6cf657", size = 8525, upload-time = "2026-05-30T12:23:17.429Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/70/d4476462f9a922b4346a1aba5d43280102f718a95d33d42ade716deb6991/pyobjc_framework_scriptingbridge-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:be526303d2304e1cc88f00b673153f52e4af8324d1a58833442bec9164e4342b", size = 8413, upload-time = "2026-05-30T12:23:19.16Z" },
+    { url = "https://files.pythonhosted.org/packages/64/bc/e742f299d2a929b4e4c3a3e82e6a1db0dad05e69c6cd75c9c9f122eef559/pyobjc_framework_scriptingbridge-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:cfc8f1fb2ecd22cdf5bd3ad7c7d1b10329d7302b69761c07a32c2810d016aa6a", size = 8567, upload-time = "2026-05-30T12:23:20.691Z" },
+    { url = "https://files.pythonhosted.org/packages/73/76/335f77cd6ed5f8cc921998f10f8ecf588352c41402d46584d29855dab94e/pyobjc_framework_scriptingbridge-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:db40b1c7670f909198984ba1a57154ad6d896af425c9599ec8e6ba5921d0f9c4", size = 8414, upload-time = "2026-05-30T12:23:22.275Z" },
+    { url = "https://files.pythonhosted.org/packages/24/2f/31cad6ed0e2ba683ca8f7c5fd285fd266fc09ca105ba3ae1ce1934f606e3/pyobjc_framework_scriptingbridge-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:31cf0969d00e61a2f783ca5865d9d650a4be0ad1afded93cd575125187285693", size = 8567, upload-time = "2026-05-30T12:23:23.877Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-searchkit"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-coreservices" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/87/f1/2240da12e22d6e7273f60bc7fa7ec160ab67d8a3c7801010d480f661a16d/pyobjc_framework_searchkit-12.2.tar.gz", hash = "sha256:aec05c1fa302e11a8e1e737a67ed8ce2bf1e04e9e249796b3b923e90e7b07b9f", size = 31137, upload-time = "2026-05-30T12:44:57.732Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/47/ef/4e69b33a88e31e6d4e2ef9d266771b81bd20fce0eeffc1fa7c79ce9b3ec7/pyobjc_framework_searchkit-12.2-py2.py3-none-any.whl", hash = "sha256:eb004bbc4522e7e7a8ee3751539056e18c204fd591ac8a2ffa6a8146117ab3fe", size = 3732, upload-time = "2026-05-30T12:23:25.282Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-security"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e3/3c/7778dd8e196373feabc54841b87e495148da3fe20d305f39397546afaaee/pyobjc_framework_security-12.2.tar.gz", hash = "sha256:ef4d2d852a09360929e284c6f355964d84ac88b170207de1ac299fa1e1c33e40", size = 181056, upload-time = "2026-05-30T12:45:09.053Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b5/72/be521a3961089017555936422be5b8a27c3cbceba84445bb1bdf7d602727/pyobjc_framework_security-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:817986dfa66e5a323ada063f4af52e699e7ac58aeea054a54344f2ad5af9683b", size = 41278, upload-time = "2026-05-30T12:23:35.974Z" },
+    { url = "https://files.pythonhosted.org/packages/33/ea/20d93a62d2f3d54dccac9e3d9de617d27c229ccce42b8bd0d7f4bb4461aa/pyobjc_framework_security-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:703b8544d2623a854f438b13ef4561402e6228eacfb0f0b2cbf28d2704815f44", size = 41278, upload-time = "2026-05-30T12:23:39.428Z" },
+    { url = "https://files.pythonhosted.org/packages/17/a7/9725d152c8f23c6f2d3bb7fc2c2c9bbcbc7908a91de935c80fc5ed54c6c5/pyobjc_framework_security-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:10f03ed38e915f823640cbc19d5a921ee29ae266f0d76a2910c53fcd7cd61447", size = 42156, upload-time = "2026-05-30T12:23:42.945Z" },
+    { url = "https://files.pythonhosted.org/packages/75/39/6cf09f7d53a37dc9be7ff2215d067fead65229c54e7153885f1a2bdba57f/pyobjc_framework_security-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:a837738a85884518fa7d50de4b88c1df0fcc67241a05dec1b36272cb3aa37e22", size = 41350, upload-time = "2026-05-30T12:23:46.406Z" },
+    { url = "https://files.pythonhosted.org/packages/59/3a/a479f9aa83d7b2f763afeb33f06f23d23948cfb81ce55e6ff04c91b514c1/pyobjc_framework_security-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:448b9658b59bcf56f4bcdf9345592fb719db711cb0f490f75cdffc82121b7c8f", size = 42904, upload-time = "2026-05-30T12:23:49.901Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/8c/a6024c130e82cf471fc1ea479fe9f387712ba22ff9d9db7b9450bcec3dd5/pyobjc_framework_security-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:65845ed21358e07544b57adebcf0b18de80afcc51c9c1da705689e35aa33d9f9", size = 41354, upload-time = "2026-05-30T12:23:53.349Z" },
+    { url = "https://files.pythonhosted.org/packages/55/1e/1ec868d695d173c6d44d5ed9b1f86b1398839a1539589ae545422548fbba/pyobjc_framework_security-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:e1ffef0aff259884e728cdf4105610c462eeb7f9f624a670c24ca47cb4744eef", size = 42924, upload-time = "2026-05-30T12:23:56.846Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-securityfoundation"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+    { name = "pyobjc-framework-security" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f6/20/7fc0158fb92a894699ecf510c3be138c249817276c8346e70fd2a8868371/pyobjc_framework_securityfoundation-12.2.tar.gz", hash = "sha256:03d51d2945f4ceeb7f5fe60e28f9f18f9e96797152467d523d374f6f242eb89f", size = 13080, upload-time = "2026-05-30T12:45:11.227Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bb/86/f3fe3bea55f684182e65a4762204802c5fdd7f0b67db77f5dff2a2b3b2f6/pyobjc_framework_securityfoundation-12.2-py2.py3-none-any.whl", hash = "sha256:7e1c8307799cc819cf5891ed046b78eae4907e267592456688fe15f5892ec16f", size = 3801, upload-time = "2026-05-30T12:23:58.268Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-securityinterface"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+    { name = "pyobjc-framework-security" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f4/21/d164e409e47ae4460d9320d21de17c825017731a870dee1a2905fd187127/pyobjc_framework_securityinterface-12.2.tar.gz", hash = "sha256:096ea141b84f5128d367f4a7800073c801200bde86a451c735708137a4f23183", size = 27756, upload-time = "2026-05-30T12:45:13.639Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5a/75/9d541b257b320ad7f76237399e6bfeebe96a1dfb877b32ab5c08bf39c0c8/pyobjc_framework_securityinterface-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:1022c258f7caabf5cb5267da7c48766ee3329942d228782f9ce70080b34aed5b", size = 10786, upload-time = "2026-05-30T12:24:04.084Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/6a/39f94ce520d5661866ba15c69264eec1af67ed8e757d5ba9c25ddf0c5577/pyobjc_framework_securityinterface-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:8741dff8c98a9cf585e5dd582c3fc2df124a0b5b885e9c128a53afb960b6e4fb", size = 10795, upload-time = "2026-05-30T12:24:06.026Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/9d/a18302f5aac77c33b8f3e6e6b529d3cca2d934c893c880b756c8bd6434d5/pyobjc_framework_securityinterface-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:d1e56bce8179bb4b5e71986162491423173c6178663e5ca9f1f5c4ac0a493adb", size = 11136, upload-time = "2026-05-30T12:24:07.847Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/98/f738a5e68a4f19e650f9614d83fb043d4e18895f38aa4b1515c765e0c8cf/pyobjc_framework_securityinterface-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:a54d16c9e0a0810059bd8a64debe77854d357b974b387d0fa55879845e67e46e", size = 10835, upload-time = "2026-05-30T12:24:09.467Z" },
+    { url = "https://files.pythonhosted.org/packages/35/ce/5b0b179384f9b5cfdc7c5718a81011ec3d347d525a7da735e7189d1a9a6d/pyobjc_framework_securityinterface-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:ad5b7b6f33981ebf1857042708fa56f0bb3040656f9ff63e0bc4b76407ff96d6", size = 11180, upload-time = "2026-05-30T12:24:11.271Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/9f/9c72ef65d981f36d8e7d55974498a2a38c7b2a4f119afe23472d010f34c9/pyobjc_framework_securityinterface-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:94881d2f4267629385296f5814949e0ee03f051f86987ddf0286c66ca12996f8", size = 10833, upload-time = "2026-05-30T12:24:12.822Z" },
+    { url = "https://files.pythonhosted.org/packages/78/c2/1d4f371c224583ef7c850db3f1b20e7f7a5bd65532d561408789a1f19777/pyobjc_framework_securityinterface-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:b7cf4225eb732c473eccad19a14a0b11d3ad38e41bfd0bed0447bfbcc8fc339b", size = 11184, upload-time = "2026-05-30T12:24:14.686Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-securityui"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+    { name = "pyobjc-framework-security" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c6/f0/bd802a0bca727076fc117b57046a953bbf57cb41656fda917ebf066f287f/pyobjc_framework_securityui-12.2.tar.gz", hash = "sha256:9ce580490d7be95d7ef4b6cfdb9af80b62be486932a89aa402accc86596df934", size = 12587, upload-time = "2026-05-30T12:45:15.325Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/92/a5/db3bc24bd588cb704bb7db16f0f73177b0488c7577d676ced3932f1f41ee/pyobjc_framework_securityui-12.2-py2.py3-none-any.whl", hash = "sha256:d6cc86e9c039e8a1ac0227947277fb2b46ca2b9f9bb1fb7f7b081a3717ac045e", size = 3603, upload-time = "2026-05-30T12:24:16.206Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-sensitivecontentanalysis"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+    { name = "pyobjc-framework-quartz" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/03/f9/e18f459b2957f208718e7ff6a9f2715ad66509bb3bb1d4988d4c5820941b/pyobjc_framework_sensitivecontentanalysis-12.2.tar.gz", hash = "sha256:796d6cd3696daa7ac9116b35e7b2d520e86b687a8433443b755db8fd0cdd8315", size = 14411, upload-time = "2026-05-30T12:45:17.068Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e1/37/3c92718706b58f76eeacbafc5d6ba1b09a5ff684cd8f47ee7b53dc139d70/pyobjc_framework_sensitivecontentanalysis-12.2-py2.py3-none-any.whl", hash = "sha256:5beb7d718e6dea0b17c14560ebaa3474f7aa349e412f974573cfae84cd7121b7", size = 4246, upload-time = "2026-05-30T12:24:17.732Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-servicemanagement"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b5/d6/c31e62d53305b30110cae00013b0947b5cec17ee77afe3e1376d5fe1ea1c/pyobjc_framework_servicemanagement-12.2.tar.gz", hash = "sha256:9c7b698f4354a36ad0448dccba57e724ac682a1276eef3971b8d85d7ac7a6488", size = 15263, upload-time = "2026-05-30T12:45:18.771Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/09/67/d02639a189926546ddd2afd5015c0a5574e8310c2a59633bff0ad2b90b2a/pyobjc_framework_servicemanagement-12.2-py2.py3-none-any.whl", hash = "sha256:fa8b9d3bcfd0d2e6feb0884f3a95fda9cd681baf0b0ca457ec3f611de9439f7f", size = 5427, upload-time = "2026-05-30T12:24:19.271Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-sharedwithyou"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-sharedwithyoucore" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f6/bb/afb864c9b6835bae72d55208e52d79734a88d597edc89c437a717da34ef5/pyobjc_framework_sharedwithyou-12.2.tar.gz", hash = "sha256:215aefe1baee8d31dce55b38bd653cdecf0a74dddcf89277d64fcb8d6beafb9d", size = 27301, upload-time = "2026-05-30T12:45:21.174Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/93/26/421a8222319cc41cdcddc0fc7a0c8f096fe313971cb92e50f56f50098a27/pyobjc_framework_sharedwithyou-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:eaecd376e2a3e682d7e666703a2a03d22a1c39cf38762e36863b7a20a3c9da07", size = 8808, upload-time = "2026-05-30T12:24:24.426Z" },
+    { url = "https://files.pythonhosted.org/packages/22/2d/5df7613183733cb6d8bcb811d3b423cf97a24a12803cda0caaaa5018e5c1/pyobjc_framework_sharedwithyou-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:1e6d829807fb4edd2eaf5752319649b99a4574d359cd0742c71c7ec0037fec82", size = 8826, upload-time = "2026-05-30T12:24:25.996Z" },
+    { url = "https://files.pythonhosted.org/packages/16/cc/5b5bb308f516f9ad75089595f3bf06eb08e1641cf4b66747473cb45bdf12/pyobjc_framework_sharedwithyou-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:ee9b7aba9c09b8f7c75982cfc714f16d2c8db9dff54eaba689b4ee51f84c2124", size = 8962, upload-time = "2026-05-30T12:24:27.619Z" },
+    { url = "https://files.pythonhosted.org/packages/41/08/24a827de4d50388848aef2c162756b3bcf24545f2650dfe6602939df53b6/pyobjc_framework_sharedwithyou-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:9556e5da95153991712b9556f5c19804a98c578c6a3e41fe240d414c77319484", size = 8871, upload-time = "2026-05-30T12:24:29.228Z" },
+    { url = "https://files.pythonhosted.org/packages/72/33/91efbfb9e4b41aa40180e3e835f18988dfa6c79f4897afbcea5e043eb99a/pyobjc_framework_sharedwithyou-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:7cc06ff9b28cf3b30f599c96e076ae885d02511a02ee41d9e3127fd0230d2b9b", size = 9017, upload-time = "2026-05-30T12:24:31.043Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/d3/9350031f1e0bac76cb84a3cd34df609992980c1b69586b904cccb98110c3/pyobjc_framework_sharedwithyou-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:1557bd65b7eb6ddbad3bb152ea31b2f1cb7bffdb525de8ae400bbeb1cac8e1e0", size = 8866, upload-time = "2026-05-30T12:24:32.741Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/1b/75c970532fa1dc09d3fe297d4078d6e6d239989a821ddbd3e0427aa634e5/pyobjc_framework_sharedwithyou-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:53b4e3b844c9d9f8105350ce49028702f7c4e03da01e63cfe39d325d6c853cf2", size = 9014, upload-time = "2026-05-30T12:24:34.347Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-sharedwithyoucore"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b0/02/4b1809c63319c277d88542576f86b7d7abcffd57ccd876d47d4623d6d5fb/pyobjc_framework_sharedwithyoucore-12.2.tar.gz", hash = "sha256:212bd551676cf0ae791eb8d7b5f6a4b10090e2d407721124d691e3020f709e51", size = 24303, upload-time = "2026-05-30T12:45:23.444Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/32/eb/09c4906bcfa9d67629cc6e950018c0e070b2a3130eb66dc58502d423b9b4/pyobjc_framework_sharedwithyoucore-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:091e58f4e1d976c0e6cedb3955f05e7376b2f5c7b226510affe7107428b80cb6", size = 8577, upload-time = "2026-05-30T12:24:39.278Z" },
+    { url = "https://files.pythonhosted.org/packages/34/3e/913bc40fce99ee370c940261eb59d65bd4f9961354c5059bd4d5612e32b2/pyobjc_framework_sharedwithyoucore-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:3cc10c8a03892a3da8bff22235e31baa24a931f5bcd1994fc0124a197f14f70e", size = 8594, upload-time = "2026-05-30T12:24:40.949Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/94/67b218f72f4a6be6926691fc85266437edd7fcc837cec755a43bc0daa206/pyobjc_framework_sharedwithyoucore-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:0286e5dfb8bc9530de31b0e686d052019d91e17fff3ea35c0338ac62e23659b6", size = 8721, upload-time = "2026-05-30T12:24:42.525Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/b8/062c40dc958ad481a1936c334111c9630d3ad542b1a0e7ccac0c95bc7552/pyobjc_framework_sharedwithyoucore-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:24b9233ff69030a7e55615a80b8c1dc13049ec6d14ae673aec3b6a5ebaf0fc5f", size = 8643, upload-time = "2026-05-30T12:24:44.325Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/1e/35e59ed5475d2343f8d03ce568a94aaec9a82262983fe2ddef425e841a33/pyobjc_framework_sharedwithyoucore-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:49d0217ff0569e575a9cc1c432cc4147e4a2307d701fa2bc287471424f139aae", size = 8787, upload-time = "2026-05-30T12:24:46.042Z" },
+    { url = "https://files.pythonhosted.org/packages/44/56/92de20611af1f8cb82d23f50556ec1f3bd421664f3d38485eb0f3d5818b7/pyobjc_framework_sharedwithyoucore-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:c0c3d6f7b763ec13a4f12d43cfadb80b13490d802de47cb63a982ea84895ba08", size = 8641, upload-time = "2026-05-30T12:24:47.74Z" },
+    { url = "https://files.pythonhosted.org/packages/12/05/d7d4b49116e31e02eaab9acb583c5ab5febbedf041ecf49a80de8e4c81ab/pyobjc_framework_sharedwithyoucore-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:afe3582b4af25afa5bf94a6af3cd7cdfa3bc966f754502d3054c419754e67ca3", size = 8781, upload-time = "2026-05-30T12:24:49.333Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-shazamkit"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a1/c5/5cc4e2c0cb5e3fb3a3e3a4eb75aa85da70c5491125efef25e581516ec108/pyobjc_framework_shazamkit-12.2.tar.gz", hash = "sha256:9bfd2790b331b36ebdd9f80dab1fcc80b816ee19a1fb5ae981e5b4a8fb2e7084", size = 26080, upload-time = "2026-05-30T12:45:25.726Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/90/06/c4d7d2d455acdbe009e2cc91040260ca288b502b9ad76e4f05661470b7ea/pyobjc_framework_shazamkit-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:8033175f28a4f0bead5878a6e420bdd4e60d00281e50b7d711105ad9d4248748", size = 8637, upload-time = "2026-05-30T12:24:54.279Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/e4/837c888b09e330599601446b0da9ec3101ee1ad4250113c5f4a040ea76d1/pyobjc_framework_shazamkit-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:05b0f1efc47471a2962f947dcf764355086a37061307880ca4853df3d7d202df", size = 8648, upload-time = "2026-05-30T12:24:55.896Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/48/ca405138c3deae6a18b8750ab8b1e688add932e149ce234bb132b999e034/pyobjc_framework_shazamkit-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:ef389bb99ac4c74741fa1b08f4b08721cbeed3522f2d8e167a9105545d5d29f6", size = 8796, upload-time = "2026-05-30T12:24:57.441Z" },
+    { url = "https://files.pythonhosted.org/packages/47/25/b0cec78700270e3a99215b60566a28c6dee4e70dd2d6cd93f8d31399d24e/pyobjc_framework_shazamkit-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:d116b4e3e09c92ee33dbe4852570510ab7ca0f43a1f02d708ef10b7d6a681b19", size = 8707, upload-time = "2026-05-30T12:24:59.124Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/d7/1e07eda03786619d6c30c717cbc1163351098217068032d31170eff9b311/pyobjc_framework_shazamkit-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:dc79ae05fed89d1aab4762ce23e9bcbeda300990c88d1fcbadda87b6425c40cb", size = 8854, upload-time = "2026-05-30T12:25:00.71Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/2a/d3ca6f9ca9b0d5c22bdad0bc41621778af5d36e30134a6dea414031c7fcd/pyobjc_framework_shazamkit-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:f5a0f3410c2852c057f79bfcc00627cb6b429ebbb72803d72422258f005c7f1c", size = 8703, upload-time = "2026-05-30T12:25:02.295Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/e6/90918334be4850363b06b0d0773547d57969238f446fd37b6268b44117d6/pyobjc_framework_shazamkit-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:c20fb1da41721b3818f4f1253f11d29b0f0568ab5b2c96724c6eecc74ce26bd0", size = 8853, upload-time = "2026-05-30T12:25:03.89Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-social"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9e/8e/30527d2219e08e0d042c1190ffb64425aca051701f50823d5376a22bf573/pyobjc_framework_social-12.2.tar.gz", hash = "sha256:0f5e8c3e6bfd36f8c552b58b42d8d1ff4c8bf18c74776cdc3e830c272a904118", size = 13754, upload-time = "2026-05-30T12:45:27.614Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/24/93/e8f2405693ca24878b1fe1cf58d4aa58b293f4e774af64a56aeba904b33b/pyobjc_framework_social-12.2-py2.py3-none-any.whl", hash = "sha256:d012f52721d694000b37999b2fed213332bf89e8a682f4d29656db4d8c6c7087", size = 4464, upload-time = "2026-05-30T12:25:05.261Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-soundanalysis"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/97/0a/19357da779f1b8942f69acfaa3f4568c0b117d6c1b5820af2a50d25dde31/pyobjc_framework_soundanalysis-12.2.tar.gz", hash = "sha256:37dee57e3f75121b690550601fc136e0931f3be56a87357cdfae7696886850fc", size = 15773, upload-time = "2026-05-30T12:45:29.585Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/23/8b/fb4db5583f5be6a5537baa1ecc39ae56f2bc1bdd6fc8dc7912e7c48b36fa/pyobjc_framework_soundanalysis-12.2-py2.py3-none-any.whl", hash = "sha256:d669deee79636bc6858e40039d5c9b4cca47af7b4cf042c787c52f39b5b5ab40", size = 4221, upload-time = "2026-05-30T12:25:06.842Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-speech"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5a/d7/b4c297150b863946fc4064dd927445d0539140524629e4d0b12f704577c0/pyobjc_framework_speech-12.2.tar.gz", hash = "sha256:14058f3ab48e29a68de5925297754a8bc6157b60c17cb24b3e8560290769e9aa", size = 27785, upload-time = "2026-05-30T12:45:32.009Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fb/23/11012a4842dffdc15e30910f7cc6ae45c7b137859e3d1916c7c7558e4e74/pyobjc_framework_speech-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:8d940d444912b69f6ec02878a0fab554305bb9c196c87550033a212dec758a0e", size = 9263, upload-time = "2026-05-30T12:25:12.18Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/bb/4262b2565e6fd0137b07b661a828acc48d65c6280124755feeac8fd1964b/pyobjc_framework_speech-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:4647b2775c3bdd3016fb5cce155dd03ca7a8f04902211868a68099511e8ea9f7", size = 9285, upload-time = "2026-05-30T12:25:13.879Z" },
+    { url = "https://files.pythonhosted.org/packages/96/48/4071527182ef72ee5e31158cfbdf11d6f97265708e94a0a1ed138f2620e0/pyobjc_framework_speech-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:df58c5d6ec1ac5425565a1544659c8c45c78b0f7984ac50ff4590b5b6b872a5d", size = 9441, upload-time = "2026-05-30T12:25:15.502Z" },
+    { url = "https://files.pythonhosted.org/packages/37/97/0bb1b78cfcf5613a1e9e90043cda358791f275d366274efea11ae9c08b2d/pyobjc_framework_speech-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:74993681f0d7ef50a5c132346f74142729c477fb917a584f84c204ba6fd4332c", size = 9343, upload-time = "2026-05-30T12:25:17.081Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/e1/ce08ba2974fd740b8dd9ec79215807a5d178a91dfdf0b264361c51813f5c/pyobjc_framework_speech-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:3ad06446848adcc7b03f731e60147122ed599e523a54a325585f401c53c045e5", size = 9502, upload-time = "2026-05-30T12:25:18.724Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/31/51968e6e9633e0dba0d54558579fe7b3f2147cf99179b9aa9c6e80f9eb26/pyobjc_framework_speech-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:dd88f54107bf75bdce4445734453ad5ca3446e12cdc9ef270414ce5254fe011f", size = 9333, upload-time = "2026-05-30T12:25:20.492Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/ea/5a661d61a5ba35faf697bdd08a23fd81afa1683ae2d11b01f7df0446b54a/pyobjc_framework_speech-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:5dbd2321eb4a6d39e53143798b5b23388d975b4b7fb1cf0e91089a21c36286cb", size = 9493, upload-time = "2026-05-30T12:25:22.091Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-spritekit"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+    { name = "pyobjc-framework-quartz" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/de/1d/84896e2233d2f90444e3be44282ad6e8600b485ce96c37566ed5bd255204/pyobjc_framework_spritekit-12.2.tar.gz", hash = "sha256:75e8fd8040f77c7585247004b9c59971de84cbcb707070f391c8508888750565", size = 83896, upload-time = "2026-05-30T12:45:37.754Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/67/5a/0aca87af17d9000be6893349d3968c36d3f40c2c2e3ef1fadc4fa2e4bad2/pyobjc_framework_spritekit-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:a9f5a77acbd93f2280ae8a098b7fd1690c2b16f93fcee7dacca350dbff196deb", size = 18623, upload-time = "2026-05-30T12:25:28.551Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/39/abc521893bd60cf5b88ece0091e83fd30717c58a2dbce712d9d9da2e5b3b/pyobjc_framework_spritekit-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:d8ce3c810728a0a54f0af3063ed7ae45a8d0ae6c5a5ba405d02d08cf2c2bc6e5", size = 18645, upload-time = "2026-05-30T12:25:30.826Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/44/aaa0c92b8bf0b9b32c13fc62fdf506e3a868f3451670291441fe008bf9e9/pyobjc_framework_spritekit-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:a8a68b20f5377ee1530f752bb693388a3dcc085b1c2cdaf6930427d1cf5791a4", size = 18914, upload-time = "2026-05-30T12:25:32.947Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/ba/23397f87cd54bfcecd8be53e52b00882405ad27036eae8a5c835b7acc9c2/pyobjc_framework_spritekit-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:a7009d0693b72308500f9297cad80d8d95545d58637fcc43129a744c7c18d662", size = 18615, upload-time = "2026-05-30T12:25:35.01Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/cd/93164071434421d26d3c6b707494f2e5536b8eccdd779ba6aff4cd4a7569/pyobjc_framework_spritekit-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:5a1b4c138f57ae297c5842370bd13f188238da8430bd0f4687a420c3545192fc", size = 18892, upload-time = "2026-05-30T12:25:37.06Z" },
+    { url = "https://files.pythonhosted.org/packages/38/9b/731043fc52dd2f51b817b24d365a78a8c7f2be9a31136f13021bdd6fca85/pyobjc_framework_spritekit-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:2a5d2ab99193bfd9af9adbb78e2e6805f2714dfa2d8fb440830f79d21eca06b5", size = 18630, upload-time = "2026-05-30T12:25:39.323Z" },
+    { url = "https://files.pythonhosted.org/packages/74/e9/ed3a076908faecef04e17a57889c444f2d5339a3c439b18cfd5d618eee2a/pyobjc_framework_spritekit-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:0bc636ce5448dbcfbb0306cec2eca6170b68c11a3041a671a52a1a6f5e127aea", size = 18902, upload-time = "2026-05-30T12:25:41.406Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-storekit"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/29/ce/3c5e9ee38040e4770af6aafa0fd11080b34a20dc2c718d2524db5b048bce/pyobjc_framework_storekit-12.2.tar.gz", hash = "sha256:f50699484da541b9d028503441bcb745eeff0becadc75556783aaf76b8764975", size = 40947, upload-time = "2026-05-30T12:45:41.165Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/39/80/d8447ff5cdf292df364c12ca0d912a29247a2caba0e710f4f0a02461ab9d/pyobjc_framework_storekit-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:e0acf29d337a0b046bb4cc8d876823e56f83a9530933842eef270a12a2e9c9d5", size = 12880, upload-time = "2026-05-30T12:25:47.112Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/b7/16adfa4c5aedad949ea10a751c60e343745afe889706bb8d71491ff57732/pyobjc_framework_storekit-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:94d2daae9e5166cfa9d694acb2e51bf1d3856cf7ce6c74a84e13d80dbe6915ec", size = 12894, upload-time = "2026-05-30T12:25:48.888Z" },
+    { url = "https://files.pythonhosted.org/packages/39/c9/bcf7f4c1087b7f83d190335d2149e8ecd5591064419ea820dac09b47bf4b/pyobjc_framework_storekit-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:922da8a72885d79c3c30dd3d36e9a966dcdd642c08f258b4b099a3f0e3ded643", size = 13091, upload-time = "2026-05-30T12:25:50.719Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/8f/ca5b9b3688df3d30e564d6f48f9d63456a5bf76c98a5c0746f261766b7d0/pyobjc_framework_storekit-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:1e8b62a74c2174e8685471fcb302a0cf263b521b9e14ff65018eb2e3c13beacd", size = 12885, upload-time = "2026-05-30T12:25:52.619Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/8d/9f63e339267bc7f73f9fb901e0164c56309789ddaa70e68e0fd10dc6bfd7/pyobjc_framework_storekit-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:b0629d80932a2ee24c60b67ba2ee868071422d6b56a99fa1e14163d00a5213b7", size = 13074, upload-time = "2026-05-30T12:25:54.464Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/b0/61ec475dcfbd8ccfda19fc2030ff68981486951b91881dc7e69daba6b74a/pyobjc_framework_storekit-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:3f5b6030c8e1353eebbe98e3ea90e0d0f0353ee014d2a8b5746b580c7ccfdcf4", size = 12878, upload-time = "2026-05-30T12:25:56.295Z" },
+    { url = "https://files.pythonhosted.org/packages/19/39/32b266ce05533e3273926a380fdacdc6d1c83404bf8cfe1292c02b770537/pyobjc_framework_storekit-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:6204fbbf29f01875cc6683999fc6f627dc6edf4bded6bed68583422ed0d847f4", size = 13080, upload-time = "2026-05-30T12:25:58.095Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-symbols"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/50/06/042965972619d440c69037105764accd700053c658dbcbc2914ba4682ab5/pyobjc_framework_symbols-12.2.tar.gz", hash = "sha256:06c00d97047ee79fad95f95380d308c6dc1200d688cf4adf954382d65f138b10", size = 14785, upload-time = "2026-05-30T12:45:43.191Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6d/de/168b3925a76417978e5bc5921c8ac0a278e5a672302a20ca10f18d317695/pyobjc_framework_symbols-12.2-py2.py3-none-any.whl", hash = "sha256:abc83c18ef8733897667d0b4d79400e3c38828347985bcad4aaf40b0cd61c94a", size = 3526, upload-time = "2026-05-30T12:25:59.498Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-syncservices"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+    { name = "pyobjc-framework-coredata" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f3/e4/ac36cf4a79c52c865d92b148b024ee0fcda7e9efa45017cc64654558654b/pyobjc_framework_syncservices-12.2.tar.gz", hash = "sha256:354f7aab848d4f2ce055886a083d07be752ebedf5fe1dcb3cbedd489fd4bfa05", size = 34830, upload-time = "2026-05-30T12:45:46.067Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/a6/01f21cf774b952fcca49f23a67c9d2f4a52b7bf5e2436a4911bc69e4077a/pyobjc_framework_syncservices-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:87e95555da2ab0f87e8b3e48df7515e61cd5929f331a1c6cd9ba4f8b92310fe2", size = 13414, upload-time = "2026-05-30T12:26:05.587Z" },
+    { url = "https://files.pythonhosted.org/packages/60/1c/1ef02418ff43f53ac9ef49035b34fcdf664fcd5632d3d796cafddd01fd57/pyobjc_framework_syncservices-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:a9ff8eb0475033f24434b1dfd7f77a8c458f9ef7ed692e59b9e5a26c22692e0d", size = 13429, upload-time = "2026-05-30T12:26:07.387Z" },
+    { url = "https://files.pythonhosted.org/packages/21/ea/df2f2e636b8616ccb4c8d2b15ddd29275245ba60a7666dc9287b4fe977a5/pyobjc_framework_syncservices-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:10c1dff31d1499b618b3741956219577f2254b04df2fbf10a65a49ed3ff3dff2", size = 13599, upload-time = "2026-05-30T12:26:09.354Z" },
+    { url = "https://files.pythonhosted.org/packages/33/0a/6971856780f54f9f2ed94dd034fce70e02653dad10902badb10ad2c1442d/pyobjc_framework_syncservices-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:d7944f195da7488e89df0f18130a5ed6db29fcbd9404e76d108f9e4aeccf2576", size = 13404, upload-time = "2026-05-30T12:26:11.164Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/06/b8b39fb6130c49c9747ad52836bfd61308771a08f3ba4a6192fecc34005b/pyobjc_framework_syncservices-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:05ea5b32ed1ad19c958103ba9a2bee6696c0e217e2259c49908d710b2255f01c", size = 13586, upload-time = "2026-05-30T12:26:13.073Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/6f/505ddd49c8c5236a05d46bac82f00989d50c8f9cee425843971435b0ad35/pyobjc_framework_syncservices-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:35b96ea6b1e85124039dbb195ee46b6bc1986c4fe43cd44dc376f8f4cf01e382", size = 13398, upload-time = "2026-05-30T12:26:14.907Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/c6/6d70e0ee36a927e77c02336744103e1da4b99af9654634717100be525f79/pyobjc_framework_syncservices-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:f80b37b92d409b22b9a63d67f45f75c91b14986b6939bf69a11a55497953c651", size = 13581, upload-time = "2026-05-30T12:26:16.823Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-systemconfiguration"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a3/de/30ce4e5e41d2bc965b5598ba4f3595ac3eaa088e26cc99d519f68d62c7b9/pyobjc_framework_systemconfiguration-12.2.tar.gz", hash = "sha256:017bb958c436b6aa90e04a99fe3fdce3787e8c1db80d165ff0071273bdbf242f", size = 63332, upload-time = "2026-05-30T12:45:50.691Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8f/cc/c105a396dcabb8eb9c787c8447a379c6041db3971e89946e843ad07ae059/pyobjc_framework_systemconfiguration-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:1e2784dfd11381c5f420ca4c93966c6fbbe3f726899c49aef81a3a11fc55c38e", size = 21542, upload-time = "2026-05-30T12:26:24.137Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/e3/fb4e684f873347039ea5136c0a5f7a0ae18ce7b4caaee8508e013fd47f03/pyobjc_framework_systemconfiguration-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:d0b290b3cfd77fde1f4234590afa0be7785c02ff2cd5b591ef8d07e2cd0caecd", size = 21533, upload-time = "2026-05-30T12:26:26.467Z" },
+    { url = "https://files.pythonhosted.org/packages/26/0e/948a070637f7f0ffcf2dd3b5a323c77694a1ed0ae04e54dd4fddea9cfac2/pyobjc_framework_systemconfiguration-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:d4b81bb37f365891a14bb4a09d735784a0bbe2c594b89a1cb87e17f1db7abac8", size = 21946, upload-time = "2026-05-30T12:26:28.795Z" },
+    { url = "https://files.pythonhosted.org/packages/18/07/9b72143a735bd5d17e5e81e3862097438c8020acecb9e72511584e86718c/pyobjc_framework_systemconfiguration-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:8a384b7cc722a7a266707bf3f145cb4cca88facea5000ef2928327ad3de1ea51", size = 21563, upload-time = "2026-05-30T12:26:31.289Z" },
+    { url = "https://files.pythonhosted.org/packages/40/70/db8f3860f1fb56a80407b16ab3b2a33f4d3e71834556eeeeb6e16ebdfe0a/pyobjc_framework_systemconfiguration-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:ac6f7e2c54223d7aae5bc0b71880bede7e26b5ee754c11a23f4bd5cedd4dda45", size = 21956, upload-time = "2026-05-30T12:26:33.889Z" },
+    { url = "https://files.pythonhosted.org/packages/92/8a/2ac3a3c0599159944b940bc8a8882048490980f51ecc1ce8d579c09c484d/pyobjc_framework_systemconfiguration-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:a3971c02199f6b85830f5f29610478133ec9fdea8e3f82208fb58f2f4db822c7", size = 21571, upload-time = "2026-05-30T12:26:36.357Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/f4/38ec9b9994fcd6ec4dae5ed58650882e108fb6fb269f6edf21e25c052dd0/pyobjc_framework_systemconfiguration-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:6e54a0df0b04b09f0bd7665db7c4887750ac70d243acbc9b8bf146947796cc1e", size = 21962, upload-time = "2026-05-30T12:26:38.715Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-systemextensions"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9c/4a/49dd15416665943fe08999c3d5d8675c6dc153c720b9cc17e83215350a46/pyobjc_framework_systemextensions-12.2.tar.gz", hash = "sha256:2ec1edcd9d12451ef74969eae546b4661514381d7d60221240560ca9a743f506", size = 21675, upload-time = "2026-05-30T12:45:52.904Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/44/f1/24d65afb6a7e5cfaebe2d9f36eccb4e97ae18c0222fd36dcf44a592664e1/pyobjc_framework_systemextensions-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:e82bc31c3b847e293006e749ad17004b5e046e9cda2a8ab74310b9e6b431d4f0", size = 9201, upload-time = "2026-05-30T12:26:43.706Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/76/f9490cb2be6a6c06ba2132a50d33d368dd90a917284a712614eec818c08b/pyobjc_framework_systemextensions-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:dc3c41d413a867483511edbd3332d3a13fa0011119fadf0e4c642ea1b97b7bec", size = 9217, upload-time = "2026-05-30T12:26:45.252Z" },
+    { url = "https://files.pythonhosted.org/packages/db/4c/a9e07ceece91b207e2554166675f299f05b0fe9af93868b91eaeedfeb2d0/pyobjc_framework_systemextensions-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:8c131f836a61df9064020382b6b1b80965799ae44cdb197ef4696167e0796bf2", size = 9375, upload-time = "2026-05-30T12:26:46.809Z" },
+    { url = "https://files.pythonhosted.org/packages/18/5a/606fab2d2bd2d0ca4ab834b7a73547ae5f8faa095e64f20e210f976733ec/pyobjc_framework_systemextensions-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:8accafc90d9707cbbc35461b37d00ecac48e569440ad935d23ab6e28cf8ebb9d", size = 9289, upload-time = "2026-05-30T12:26:48.411Z" },
+    { url = "https://files.pythonhosted.org/packages/06/6b/34403dc90bf0f59f6bc2aee0d386c2d18f85885f90d672702292a69e4c90/pyobjc_framework_systemextensions-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:0a7b8a301e288a7d2f560f7028226393eb4fc8a34f32b23ad1693ecf851684dc", size = 9446, upload-time = "2026-05-30T12:26:49.95Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/85/6f85d38abf47a979fa658c18c1fe905de891177438b4a2ca293a787d1dbb/pyobjc_framework_systemextensions-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:fa8b186c217230aa74044df091e3bd2d3a0b962ba47a8465727d914767b9288d", size = 9279, upload-time = "2026-05-30T12:26:51.503Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/05/6959ac75f0c08862681fa1fa46527e1d0f51f9a846176515f1ca6ba8e4e6/pyobjc_framework_systemextensions-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:0cf56fa70539445d64c7582ad7ee7ea11f7f15d2f4ce24745d3123522bdae666", size = 9440, upload-time = "2026-05-30T12:26:53.046Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-threadnetwork"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ce/e6/8b1744871062c39cce64d43ab20b11344ef5f1b93993c1b737da2faa3acd/pyobjc_framework_threadnetwork-12.2.tar.gz", hash = "sha256:2d7df5938094e3aa93210a079ebf3e801a20c84a3b759573ddf05ec2c2cbf083", size = 13327, upload-time = "2026-05-30T12:45:54.674Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a4/7e/dfa9e914c1f192d6afdb504efc01f5aac777a73d43cfe103896bb5072ee2/pyobjc_framework_threadnetwork-12.2-py2.py3-none-any.whl", hash = "sha256:08c7a03e11c60dca7b3f219db744986b90b8797d61b6842e0c0bad192e723f48", size = 3805, upload-time = "2026-05-30T12:26:54.517Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-uniformtypeidentifiers"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/64/54/e270da2b0b4ab1fb0dc7f4e616d1a6e141583f88409c0742f6ebfcf7a064/pyobjc_framework_uniformtypeidentifiers-12.2.tar.gz", hash = "sha256:19cc82f1bbf3bc0999597779711422f6c9d7340634d699ae64d9bc7c0d79f984", size = 20704, upload-time = "2026-05-30T12:45:56.773Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/da/19/4f314697bc8f519fe6505afe51d83d7fdcae93239b7bab5941f4bebc1f9e/pyobjc_framework_uniformtypeidentifiers-12.2-py2.py3-none-any.whl", hash = "sha256:f140a378cfe6a8ca47ce3b04fd5a4c4bec1fcbedac8acc87e2c18985bb805203", size = 5019, upload-time = "2026-05-30T12:26:56.001Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-usernotifications"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5a/c3/f1d43ac73b5fce42a00bcb68ac53edd7180217df60a25985e2477c9c389b/pyobjc_framework_usernotifications-12.2.tar.gz", hash = "sha256:b7773e84fe40e746f706055267ba2b1dc9e0a34e6575719f1e515354f72583a0", size = 33908, upload-time = "2026-05-30T12:45:59.61Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8e/39/d9dbc214cd2516c6ad0ff28f97c50c0e8178b8b293f61974bf2efc5b4e2c/pyobjc_framework_usernotifications-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:b5533378b934430f73bb0092df19e54d67ab9f3e61ac8116a0480916c8c4c0b9", size = 10185, upload-time = "2026-05-30T12:27:00.986Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/e3/a962cbd3739cbb01b2b5697e336babb15307fb473500524bd7e730446b7e/pyobjc_framework_usernotifications-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:dbc51fc214446f622b4670bca7efb8969ad84cdee21672da3c872fa3aff5aff5", size = 10198, upload-time = "2026-05-30T12:27:02.504Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/8e/2a44292fc4e96682054f74a1aab1c303fa5caf5820e5cd67b0d23b52750f/pyobjc_framework_usernotifications-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:e329301b42181a95c2ac5f71491529ac1260afa9b26b16a104db275bbafdcb18", size = 10357, upload-time = "2026-05-30T12:27:04.132Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/00/659908e2a3654564727daddc494624531e9950274627130b74f918e9fa84/pyobjc_framework_usernotifications-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:c227579be5f40579b6345400578c0f0c56dc85811d56b912937ee2408dd00b83", size = 10265, upload-time = "2026-05-30T12:27:05.736Z" },
+    { url = "https://files.pythonhosted.org/packages/04/f5/0996481a6c3c99c42c5eff47c8d136b84a5a1108276dadf4f58830c73814/pyobjc_framework_usernotifications-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:969f60adca5420ea1c4a42b3d5eb0aa0654ddfca4ca3a10a9774933b8bac65fc", size = 10421, upload-time = "2026-05-30T12:27:07.286Z" },
+    { url = "https://files.pythonhosted.org/packages/22/2e/04150a39eeb077dd1a637744c5920f3f64590a022c38573a1c12987472ec/pyobjc_framework_usernotifications-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:3889af591a44859a11ed4c2ea4a7bdd90ed61d17bb3b27dd4aade24d80a0bda5", size = 10256, upload-time = "2026-05-30T12:27:09.278Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/2b/e1a7f0b6b19c4f73341a1ae1dd9d063998777fe092c5f8ca5e84906e7187/pyobjc_framework_usernotifications-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:1656cc4d2be411447196df1c8b63466000bfaccbf144ab97715ec42eecbd497f", size = 10423, upload-time = "2026-05-30T12:27:10.858Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-usernotificationsui"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+    { name = "pyobjc-framework-usernotifications" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4b/5f/d58600259b0b99ff3745eef91570d0ced05fa1b26083f2846082acc15249/pyobjc_framework_usernotificationsui-12.2.tar.gz", hash = "sha256:8c3298cddd27be794ad46a2783304b6fb1f0ad4d65933c34ba3e43e58ecdb406", size = 13462, upload-time = "2026-05-30T12:46:01.549Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c6/29/f4413e1941e153a770b2d85faee4d3a4f9be67b69f5823f63db8dd091356/pyobjc_framework_usernotificationsui-12.2-py2.py3-none-any.whl", hash = "sha256:a5d92117c2d18e2b6365f5e39daf45a68491a66ac9103b1bc94df43b8868c256", size = 3930, upload-time = "2026-05-30T12:27:12.318Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-videosubscriberaccount"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/42/3d/cace0ae1dd453f9da495311675d4fabe7adf89e94e7b99e26f45ba0fa713/pyobjc_framework_videosubscriberaccount-12.2.tar.gz", hash = "sha256:821f5485545238fd997dc26aff8ab2c838b43d664a7ec6a030ba67b09c2b799d", size = 21360, upload-time = "2026-05-30T12:46:03.619Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d3/03/f3b0c4ed85b4883d5fcd48ba2efd807507c3a5ce7c3aa7d4366dce81f503/pyobjc_framework_videosubscriberaccount-12.2-py2.py3-none-any.whl", hash = "sha256:b158b03e1432dc229fabc96451f5ac8db5ab228792354f0f26419a973777c700", size = 4866, upload-time = "2026-05-30T12:27:14.012Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-videotoolbox"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+    { name = "pyobjc-framework-coremedia" },
+    { name = "pyobjc-framework-quartz" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f3/2c/af5a91d12bb265697fb13ccdbac7068e04e8f40c36139b314ea477982aa3/pyobjc_framework_videotoolbox-12.2.tar.gz", hash = "sha256:33d0838f706c771667b0be5737036d303b677bb243ba64df9ea2fa6860ea9f76", size = 64923, upload-time = "2026-05-30T12:46:08.377Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2f/de/d4f998122a36cc7f7bd07c297a30f776455e00b27d24fd63b778c72421d8/pyobjc_framework_videotoolbox-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:36576a1cebd379efeff58f7e016fb2eef5bfe36c4649f7fb197157fe61842b5e", size = 18983, upload-time = "2026-05-30T12:27:20.923Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/08/48b4af0452930b1865dee4e847113d5b6d2530a19ad111b6f551d8b5bd8a/pyobjc_framework_videotoolbox-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:3393990f9f566dadada78b06c134bcefcabd50731b5322110759e0d26d9ca280", size = 18999, upload-time = "2026-05-30T12:27:22.983Z" },
+    { url = "https://files.pythonhosted.org/packages/48/11/d111f5d93f88f0d4d7150d318a6e089b0e08196cc29bdcae3c6af7c9891b/pyobjc_framework_videotoolbox-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:06dea99b364c3628037332c5fbffcb341f32a4cc7acd0ea4813a83b78fe1f70c", size = 19209, upload-time = "2026-05-30T12:27:25.22Z" },
+    { url = "https://files.pythonhosted.org/packages/33/45/f3bf7ebc231abb84a57fd5125850883380ea9a7cbb5f1c218cc7a8a3c386/pyobjc_framework_videotoolbox-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:49f12920f8a7ed85c110145dd628b38d387319a2b7cd399e70b5359aa8724614", size = 18996, upload-time = "2026-05-30T12:27:27.37Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/34/79754107f661cb958871f52b0c8b0a935f6b09a118ab4b56fa53780d0a67/pyobjc_framework_videotoolbox-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:58a547a45fb92c9335f52814cd234a80383cbadd0f5e8897d11b5ddaec6606f8", size = 19192, upload-time = "2026-05-30T12:27:29.434Z" },
+    { url = "https://files.pythonhosted.org/packages/10/40/5cb09ce331ca581b9cc9e50cfb22deede8862dc40386174785fe84ef3a58/pyobjc_framework_videotoolbox-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:ca98d2604f00273bac4977cba830ebe48a2b0a0b5d8068b551599780ac0045c2", size = 18999, upload-time = "2026-05-30T12:27:31.523Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/a3/852fd3029533d7a94c86f00383fab060dc77664bdc330b7734c87877fbaf/pyobjc_framework_videotoolbox-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:f3a916bbaa8826e91f8ef9cd53564fd3be33135d92acdadfc7e85b49d3245c8d", size = 19193, upload-time = "2026-05-30T12:27:33.643Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-virtualization"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1a/b4/16c8280c717f393e524e32de93bcb18952ca852ebbf5aaed38dac68d2e01/pyobjc_framework_virtualization-12.2.tar.gz", hash = "sha256:021249f0cd72e4756dfba096bda0e9ebd9294ba7738f1bdbb2742e461ac5671e", size = 49152, upload-time = "2026-05-30T12:46:12.317Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6e/39/c348fdc27fc68729faeaf8510596ee70a4d97d9fe51b68c365c47a1bd5cb/pyobjc_framework_virtualization-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:2b9fbd756c7fc8fb0a78b235612e643e9bebe04f6e047ecb7e80a832510c744b", size = 13600, upload-time = "2026-05-30T12:27:39.302Z" },
+    { url = "https://files.pythonhosted.org/packages/46/90/a2e2a3676286359dcf4d5898652e904925006dba0eca959759472be37651/pyobjc_framework_virtualization-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:48667f1318bdc3e3599123dafb1d9df3369a6d8d3a64fb36f9eaf86ef2ea4808", size = 13617, upload-time = "2026-05-30T12:27:41.616Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/22/3e04b58c4a1ecc27518a8c5b8ca13cea7b74106928b1bd130a0564cb54a6/pyobjc_framework_virtualization-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:68e8989bf2cfb294116cdfd583d6ac092f9209ccca2af5b79fb697adbdae4653", size = 13821, upload-time = "2026-05-30T12:27:43.448Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/c8/8fa0b9ca53e7ab283d65c0ecde625344e55c493f2b31f330944171c119ec/pyobjc_framework_virtualization-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:365f797477eec5cc79f076e7a986937ff54d2ca1a136b4e0bb0fcac4bfa888aa", size = 13606, upload-time = "2026-05-30T12:27:45.26Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/10/0455b8ebef3412e7247867dc760dac1c8c0c1a4eb30fb45830f088b0cf3b/pyobjc_framework_virtualization-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:6a1dbdba76fa72829662547deaedf9bc38829be245e88a0781fb83934a2caded", size = 13814, upload-time = "2026-05-30T12:27:47.066Z" },
+    { url = "https://files.pythonhosted.org/packages/72/48/5ea61a159ed12a9715233e1b90af5a8d384c9964f402f1f2e03dbf41197a/pyobjc_framework_virtualization-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:e4c38f21be12dc1199dd263cf5ab8e07290f98d9462c8873827e43d37332a9dc", size = 13596, upload-time = "2026-05-30T12:27:48.924Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/3e/ddb09e174928a927512643f531e69823ffda8487c258eaa0705b56bec4bf/pyobjc_framework_virtualization-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:b3531955330c0bb91daffd28f161c9c481a4683c2ff17b944bf216126d3580c5", size = 13807, upload-time = "2026-05-30T12:27:50.789Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-vision"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+    { name = "pyobjc-framework-coreml" },
+    { name = "pyobjc-framework-quartz" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/49/51/aed3761cfa2f0335a8fc4cdfa04c54b3fece5242745d5dd2370f38efcff5/pyobjc_framework_vision-12.2.tar.gz", hash = "sha256:0e90244f98ede5ec16ac129ed4bbd7cf0ec07247bac6f06e9cb612db23a68a3b", size = 72582, upload-time = "2026-05-30T12:46:17.468Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/da/e6/c8606a1a106f5361360762eb26a9736ad4ea9528202b85b6dfe2a9e8a82f/pyobjc_framework_vision-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:77628f8c12a2f8072e8a8ab780cd0fd716f279153dcd883ce058bf2d1843b16d", size = 16924, upload-time = "2026-05-30T12:27:57.619Z" },
+    { url = "https://files.pythonhosted.org/packages/79/34/9c92c1d70a98818edb4e113f771bb264c2e7f08ec6bba501e0196c500dc4/pyobjc_framework_vision-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:df4d7d3ccdd723334ab62e6e2051d04e3554724be90102db353874938f101e05", size = 16938, upload-time = "2026-05-30T12:27:59.678Z" },
+    { url = "https://files.pythonhosted.org/packages/16/a5/1cf2213da57b1941f788baf0505c3cc4c98fbbdcdf1ac3a19290331ca4d1/pyobjc_framework_vision-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:76737fa3440c504993995537643b6529d47c1affecba426f00c716cd93a07a9b", size = 17081, upload-time = "2026-05-30T12:28:01.972Z" },
+    { url = "https://files.pythonhosted.org/packages/20/f3/3f87679134adab71b2366c5349fe3a68eb2edcf5ff62fcb872855243e6e2/pyobjc_framework_vision-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:b6d12bcb96d711a4b5d1743aa7b1af7dec9e2f840b0e5ec200aed262da3fb587", size = 16917, upload-time = "2026-05-30T12:28:04.196Z" },
+    { url = "https://files.pythonhosted.org/packages/26/e2/4c1419e9429bed0c1bac0fa6ea705c32c8d9e098fa5ba3f8b49a4f916ff0/pyobjc_framework_vision-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:45c7d3fda44f740b4c0a9c1b86d9af137994172f2990e0650112f7eb8e77e48e", size = 17068, upload-time = "2026-05-30T12:28:06.264Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/8a/6da11857e32d588c16cd474dc768c45e31e0b6e9fc48d10b34a12850e6fb/pyobjc_framework_vision-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:c08a08dd979886e2435a53714ef95af6da4a0dc1b2e37236cdd292b5b8707060", size = 16906, upload-time = "2026-05-30T12:28:08.786Z" },
+    { url = "https://files.pythonhosted.org/packages/92/f4/01b8d88c29f46f3b7690d49e0a5ddf992a2ee214e83451820301607f3b95/pyobjc_framework_vision-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:3d9080e4882e292c2d3c0726127e516a5c7774e96faf199a2c74aafcc1b6aa60", size = 17073, upload-time = "2026-05-30T12:28:10.836Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-webkit"
+version = "12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/ba/0e17f151d80854285a84b3c96f48d55b0c61ae683060a52cd50084ef4c64/pyobjc_framework_webkit-12.2.tar.gz", hash = "sha256:498353fe812006f7fe2829a679018fcff3ed2684aa31c08d8a8af929ee9283b6", size = 332359, upload-time = "2026-05-30T12:46:37.677Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8c/ae/0cfe909116627905542390c7d6a33a3090b6e7f2174b9d75f9c8a661d431/pyobjc_framework_webkit-12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:bd1e0f6f340a5516c853aa59fde381e002f2c109ae64a05ad4e99a2b74375fcb", size = 50337, upload-time = "2026-05-30T12:28:24.926Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/32/bea045cf4e2c697ea9b68ed7d60b0e765a8b0e46d30a4eb26bf178be817c/pyobjc_framework_webkit-12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:9fafcbf5a071cf9ad3fbc28155a99287ff9dc9efcaa41fe3ed3d79b6e5576450", size = 50367, upload-time = "2026-05-30T12:28:28.846Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/3e/d29fc44f6d346a5a97883ae76bfa030a5b6ff3b019bafd58ad8ea14588d2/pyobjc_framework_webkit-12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:751f3138441c81fdddc555f0bd31f5f3ad3ec72ae2ed626af24925ce32054353", size = 50840, upload-time = "2026-05-30T12:28:32.75Z" },
+    { url = "https://files.pythonhosted.org/packages/00/e1/12288f728e2862d7932a1b21aa5a059ae67708900e4f0873c88053edb761/pyobjc_framework_webkit-12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:6cba6e76e33c62369d0fa8cb4b83959db4c53888173cb3546a15cd998c8e8aec", size = 50475, upload-time = "2026-05-30T12:28:36.862Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/98/6373d02bc5dd9653207f1f766e55c2659aa01b65bf94b9d00584e7142312/pyobjc_framework_webkit-12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:43a18df9a8d6b6f1f003a732eee0a0fcd01c2d31566be2b2ba8ee732c1a32cf9", size = 50938, upload-time = "2026-05-30T12:28:40.942Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/22/22d4b3d39d41fa94aa8bb904ec546199d940edcdbc9594c4ad3517d49692/pyobjc_framework_webkit-12.2-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:50dbd5210f80c7834b1af2b675712f6134217d713f2b2a8d9f96cf29be6ec8f0", size = 50469, upload-time = "2026-05-30T12:28:45.058Z" },
+    { url = "https://files.pythonhosted.org/packages/22/1b/09cb42c5ede2a5025c4695b2beb37216a4d200511aa3eb4b9faadf1a517d/pyobjc_framework_webkit-12.2-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:e8895b2cbc8b5d4c1475a3094771d3b8e6dbbd19ec3200922b1cd91d649e8043", size = 50936, upload-time = "2026-05-30T12:28:49.013Z" },
+]
+
+[[package]]
+name = "pyotp"
+version = "2.9.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f3/b2/1d5994ba2acde054a443bd5e2d384175449c7d2b6d1a0614dbca3a63abfc/pyotp-2.9.0.tar.gz", hash = "sha256:346b6642e0dbdde3b4ff5a930b664ca82abfa116356ed48cc42c7d6590d36f63", size = 17763, upload-time = "2023-07-27T23:41:03.295Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c3/c0/c33c8792c3e50193ef55adb95c1c3c2786fe281123291c2dbf0eaab95a6f/pyotp-2.9.0-py3-none-any.whl", hash = "sha256:81c2e5865b8ac55e825b0358e496e1d9387c811e85bb40e71a3b29b288963612", size = 13376, upload-time = "2023-07-27T23:41:01.685Z" },
+]
+
+[[package]]
+name = "pyparsing"
+version = "3.3.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f3/91/9c6ee907786a473bf81c5f53cf703ba0957b23ab84c264080fb5a450416f/pyparsing-3.3.2.tar.gz", hash = "sha256:c777f4d763f140633dcb6d8a3eda953bf7a214dc4eff598413c070bcdc117cbc", size = 6851574, upload-time = "2026-01-21T03:57:59.36Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/10/bd/c038d7cc38edc1aa5bf91ab8068b63d4308c66c4c8bb3cbba7dfbc049f9c/pyparsing-3.3.2-py3-none-any.whl", hash = "sha256:850ba148bd908d7e2411587e247a1e4f0327839c40e2e5e6d05a007ecc69911d", size = 122781, upload-time = "2026-01-21T03:57:55.912Z" },
+]
+
+[[package]]
+name = "pypdf"
+version = "6.13.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/99/0a/48fe05c6bb3aa4bb4d2a4079a383d33c0dfec1edf613a642f07d8b8b5c2e/pypdf-6.13.2.tar.gz", hash = "sha256:5a96a17dbdfbf9c2ab24c0a13fa0aba182be22ba6f283098712c16fc242f509f", size = 6479250, upload-time = "2026-06-10T16:42:34.5Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/17/378943705992f74e451a06de3401ce68e3213763c81e44d0614559c45599/pypdf-6.13.2-py3-none-any.whl", hash = "sha256:6eeb9e57693f29d41bd01255d02660cbbb41fd7fc818a982677389a35e4f2083", size = 346555, upload-time = "2026-06-10T16:42:32.37Z" },
+]
+
+[[package]]
+name = "pyperclip"
+version = "1.11.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e8/52/d87eba7cb129b81563019d1679026e7a112ef76855d6159d24754dbd2a51/pyperclip-1.11.0.tar.gz", hash = "sha256:244035963e4428530d9e3a6101a1ef97209c6825edab1567beac148ccc1db1b6", size = 12185, upload-time = "2025-09-26T14:40:37.245Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/80/fc9d01d5ed37ba4c42ca2b55b4339ae6e200b456be3a1aaddf4a9fa99b8c/pyperclip-1.11.0-py3-none-any.whl", hash = "sha256:299403e9ff44581cb9ba2ffeed69c7aa96a008622ad0c46cb575ca75b5b84273", size = 11063, upload-time = "2025-09-26T14:40:36.069Z" },
+]
+
+[[package]]
 name = "pytest"
 version = "9.0.3"
 source = { registry = "https://pypi.org/simple" }
@@ -1084,12 +5980,46 @@ wheels = [
 ]
 
 [[package]]
+name = "python-docx"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "lxml" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a9/f7/eddfe33871520adab45aaa1a71f0402a2252050c14c7e3009446c8f4701c/python_docx-1.2.0.tar.gz", hash = "sha256:7bc9d7b7d8a69c9c02ca09216118c86552704edc23bac179283f2e38f86220ce", size = 5723256, upload-time = "2025-06-16T20:46:27.921Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d0/00/1e03a4989fa5795da308cd774f05b704ace555a70f9bf9d3be057b680bcf/python_docx-1.2.0-py3-none-any.whl", hash = "sha256:3fd478f3250fbbbfd3b94fe1e985955737c145627498896a8a6bf81f4baf66c7", size = 252987, upload-time = "2025-06-16T20:46:22.506Z" },
+]
+
+[[package]]
 name = "python-dotenv"
 version = "1.2.2"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/82/ed/0301aeeac3e5353ef3d94b6ec08bbcabd04a72018415dcb29e588514bba8/python_dotenv-1.2.2.tar.gz", hash = "sha256:2c371a91fbd7ba082c2c1dc1f8bf89ca22564a087c2c287cd9b662adde799cf3", size = 50135, upload-time = "2026-03-01T16:00:26.196Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0b/d7/1959b9648791274998a9c3526f6d0ec8fd2233e4d4acce81bbae76b44b2a/python_dotenv-1.2.2-py3-none-any.whl", hash = "sha256:1d8214789a24de455a8b8bd8ae6fe3c6b69a5e3d64aa8a8e5d68e694bbcb285a", size = 22101, upload-time = "2026-03-01T16:00:25.09Z" },
+]
+
+[[package]]
+name = "python-frontmatter"
+version = "1.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyyaml" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9d/e8/79cbe69864d44f3b48e70ebee0a872a7d5a4e7150c9f8577ed7a5beefff0/python_frontmatter-1.3.0.tar.gz", hash = "sha256:acc73e477a568dc2a25c9e130c6c68ae8daa8c204c8f7e813db47d6a7280dcf2", size = 8322, upload-time = "2026-05-20T19:21:44.164Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a6/a3/17c284b4f4d8ad50f0f9ba70ad8fcc35c777aeafcdbbffdd91bbdc5ab379/python_frontmatter-1.3.0-py3-none-any.whl", hash = "sha256:9f7dd9260bec99044219159a329f64f039087f9d1a2124c9442556f2fe6f82ec", size = 10562, upload-time = "2026-05-20T19:21:43.323Z" },
+]
+
+[[package]]
+name = "python-json-logger"
+version = "4.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f7/ff/3cc9165fd44106973cd7ac9facb674a65ed853494592541d339bdc9a30eb/python_json_logger-4.1.0.tar.gz", hash = "sha256:b396b9e3ed782b09ff9d6e4f1683d46c83ad0d35d2e407c09a9ebbf038f88195", size = 17573, upload-time = "2026-03-29T04:39:56.805Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/27/be/0631a861af4d1c875f096c07d34e9a63639560a717130e7a87cbc82b7e3f/python_json_logger-4.1.0-py3-none-any.whl", hash = "sha256:132994765cf75bf44554be9aa49b06ef2345d23661a96720262716438141b6b2", size = 15021, upload-time = "2026-03-29T04:39:55.266Z" },
 ]
 
 [[package]]
@@ -1106,9 +6036,6 @@ name = "pywin32"
 version = "311"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7c/af/449a6a91e5d6db51420875c54f6aff7c97a86a3b13a0b4f1a5c13b988de3/pywin32-311-cp311-cp311-win32.whl", hash = "sha256:184eb5e436dea364dcd3d2316d577d625c0351bf237c4e9a5fabbcfa5a58b151", size = 8697031, upload-time = "2025-07-14T20:13:13.266Z" },
-    { url = "https://files.pythonhosted.org/packages/51/8f/9bb81dd5bb77d22243d33c8397f09377056d5c687aa6d4042bea7fbf8364/pywin32-311-cp311-cp311-win_amd64.whl", hash = "sha256:3ce80b34b22b17ccbd937a6e78e7225d80c52f5ab9940fe0506a1a16f3dab503", size = 9508308, upload-time = "2025-07-14T20:13:15.147Z" },
-    { url = "https://files.pythonhosted.org/packages/44/7b/9c2ab54f74a138c491aba1b1cd0795ba61f144c711daea84a88b63dc0f6c/pywin32-311-cp311-cp311-win_arm64.whl", hash = "sha256:a733f1388e1a842abb67ffa8e7aad0e70ac519e09b0f6a784e65a136ec7cefd2", size = 8703930, upload-time = "2025-07-14T20:13:16.945Z" },
     { url = "https://files.pythonhosted.org/packages/e7/ab/01ea1943d4eba0f850c3c61e78e8dd59757ff815ff3ccd0a84de5f541f42/pywin32-311-cp312-cp312-win32.whl", hash = "sha256:750ec6e621af2b948540032557b10a2d43b0cee2ae9758c54154d711cc852d31", size = 8706543, upload-time = "2025-07-14T20:13:20.765Z" },
     { url = "https://files.pythonhosted.org/packages/d1/a8/a0e8d07d4d051ec7502cd58b291ec98dcc0c3fff027caad0470b72cfcc2f/pywin32-311-cp312-cp312-win_amd64.whl", hash = "sha256:b8c095edad5c211ff31c05223658e71bf7116daa0ecf3ad85f3201ea3190d067", size = 9495040, upload-time = "2025-07-14T20:13:22.543Z" },
     { url = "https://files.pythonhosted.org/packages/ba/3a/2ae996277b4b50f17d61f0603efd8253cb2d79cc7ae159468007b586396d/pywin32-311-cp312-cp312-win_arm64.whl", hash = "sha256:e286f46a9a39c4a18b319c28f59b61de793654af2f395c102b4f819e584b5852", size = 8710102, upload-time = "2025-07-14T20:13:24.682Z" },
@@ -1121,20 +6048,20 @@ wheels = [
 ]
 
 [[package]]
+name = "pywin32-ctypes"
+version = "0.2.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/85/9f/01a1a99704853cb63f253eea009390c88e7131c67e66a0a02099a8c917cb/pywin32-ctypes-0.2.3.tar.gz", hash = "sha256:d162dc04946d704503b2edc4d55f3dba5c1d539ead017afa00142c38b9885755", size = 29471, upload-time = "2024-08-14T10:15:34.626Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/de/3d/8161f7711c017e01ac9f008dfddd9410dff3674334c233bde66e7ba65bbf/pywin32_ctypes-0.2.3-py3-none-any.whl", hash = "sha256:8a1513379d709975552d202d942d9837758905c8d01eb82b8bcc30918929e7b8", size = 30756, upload-time = "2024-08-14T10:15:33.187Z" },
+]
+
+[[package]]
 name = "pyyaml"
 version = "6.0.3"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/05/8e/961c0007c59b8dd7729d542c61a4d537767a59645b82a0b521206e1e25c2/pyyaml-6.0.3.tar.gz", hash = "sha256:d76623373421df22fb4cf8817020cbb7ef15c725b9d5e45f17e189bfc384190f", size = 130960, upload-time = "2025-09-25T21:33:16.546Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6d/16/a95b6757765b7b031c9374925bb718d55e0a9ba8a1b6a12d25962ea44347/pyyaml-6.0.3-cp311-cp311-macosx_10_13_x86_64.whl", hash = "sha256:44edc647873928551a01e7a563d7452ccdebee747728c1080d881d68af7b997e", size = 185826, upload-time = "2025-09-25T21:31:58.655Z" },
-    { url = "https://files.pythonhosted.org/packages/16/19/13de8e4377ed53079ee996e1ab0a9c33ec2faf808a4647b7b4c0d46dd239/pyyaml-6.0.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:652cb6edd41e718550aad172851962662ff2681490a8a711af6a4d288dd96824", size = 175577, upload-time = "2025-09-25T21:32:00.088Z" },
-    { url = "https://files.pythonhosted.org/packages/0c/62/d2eb46264d4b157dae1275b573017abec435397aa59cbcdab6fc978a8af4/pyyaml-6.0.3-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:10892704fc220243f5305762e276552a0395f7beb4dbf9b14ec8fd43b57f126c", size = 775556, upload-time = "2025-09-25T21:32:01.31Z" },
-    { url = "https://files.pythonhosted.org/packages/10/cb/16c3f2cf3266edd25aaa00d6c4350381c8b012ed6f5276675b9eba8d9ff4/pyyaml-6.0.3-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:850774a7879607d3a6f50d36d04f00ee69e7fc816450e5f7e58d7f17f1ae5c00", size = 882114, upload-time = "2025-09-25T21:32:03.376Z" },
-    { url = "https://files.pythonhosted.org/packages/71/60/917329f640924b18ff085ab889a11c763e0b573da888e8404ff486657602/pyyaml-6.0.3-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b8bb0864c5a28024fac8a632c443c87c5aa6f215c0b126c449ae1a150412f31d", size = 806638, upload-time = "2025-09-25T21:32:04.553Z" },
-    { url = "https://files.pythonhosted.org/packages/dd/6f/529b0f316a9fd167281a6c3826b5583e6192dba792dd55e3203d3f8e655a/pyyaml-6.0.3-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:1d37d57ad971609cf3c53ba6a7e365e40660e3be0e5175fa9f2365a379d6095a", size = 767463, upload-time = "2025-09-25T21:32:06.152Z" },
-    { url = "https://files.pythonhosted.org/packages/f2/6a/b627b4e0c1dd03718543519ffb2f1deea4a1e6d42fbab8021936a4d22589/pyyaml-6.0.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:37503bfbfc9d2c40b344d06b2199cf0e96e97957ab1c1b546fd4f87e53e5d3e4", size = 794986, upload-time = "2025-09-25T21:32:07.367Z" },
-    { url = "https://files.pythonhosted.org/packages/45/91/47a6e1c42d9ee337c4839208f30d9f09caa9f720ec7582917b264defc875/pyyaml-6.0.3-cp311-cp311-win32.whl", hash = "sha256:8098f252adfa6c80ab48096053f512f2321f0b998f98150cea9bd23d83e1467b", size = 142543, upload-time = "2025-09-25T21:32:08.95Z" },
-    { url = "https://files.pythonhosted.org/packages/da/e3/ea007450a105ae919a72393cb06f122f288ef60bba2dc64b26e2646fa315/pyyaml-6.0.3-cp311-cp311-win_amd64.whl", hash = "sha256:9f3bfb4965eb874431221a3ff3fdcddc7e74e3b07799e0e84ca4a0f867d449bf", size = 158763, upload-time = "2025-09-25T21:32:09.96Z" },
     { url = "https://files.pythonhosted.org/packages/d1/33/422b98d2195232ca1826284a76852ad5a86fe23e31b009c9886b2d0fb8b2/pyyaml-6.0.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:7f047e29dcae44602496db43be01ad42fc6f1cc0d8cd6c83d342306c32270196", size = 182063, upload-time = "2025-09-25T21:32:11.445Z" },
     { url = "https://files.pythonhosted.org/packages/89/a0/6cf41a19a1f2f3feab0e9c0b74134aa2ce6849093d5517a0c550fe37a648/pyyaml-6.0.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:fc09d0aa354569bc501d4e787133afc08552722d3ab34836a80547331bb5d4a0", size = 173973, upload-time = "2025-09-25T21:32:12.492Z" },
     { url = "https://files.pythonhosted.org/packages/ed/23/7a778b6bd0b9a8039df8b1b1d80e2e2ad78aa04171592c8a5c43a56a6af4/pyyaml-6.0.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9149cad251584d5fb4981be1ecde53a1ca46c891a79788c0df828d2f166bda28", size = 775116, upload-time = "2025-09-25T21:32:13.652Z" },
@@ -1176,6 +6103,15 @@ wheels = [
 ]
 
 [[package]]
+name = "redis"
+version = "8.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/ae/ed461cca5780b5fc8b9fe8ca0ed98d89508645fb9d880c24cc42c087678f/redis-8.0.0.tar.gz", hash = "sha256:a00c5355432051ac14e593b8b197fc76c887ee12d55a0984f69328a1115fdc49", size = 5101591, upload-time = "2026-05-28T12:45:13.5Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/27/e3/b519734372d305bd547534a9f32e4ce9f98552af753dce72cf3483a0ff0b/redis-8.0.0-py3-none-any.whl", hash = "sha256:c938c18338585009f0bc310f4c7e4e4b4d37639356c4ac072cedf3af570c8dc7", size = 499870, upload-time = "2026-05-28T12:45:11.697Z" },
+]
+
+[[package]]
 name = "referencing"
 version = "0.37.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1187,6 +6123,107 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/22/f5/df4e9027acead3ecc63e50fe1e36aca1523e1719559c499951bb4b53188f/referencing-0.37.0.tar.gz", hash = "sha256:44aefc3142c5b842538163acb373e24cce6632bd54bdb01b21ad5863489f50d8", size = 78036, upload-time = "2025-10-13T15:30:48.871Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2c/58/ca301544e1fa93ed4f80d724bf5b194f6e4b945841c5bfd555878eea9fcb/referencing-0.37.0-py3-none-any.whl", hash = "sha256:381329a9f99628c9069361716891d34ad94af76e461dcb0335825aecc7692231", size = 26766, upload-time = "2025-10-13T15:30:47.625Z" },
+]
+
+[[package]]
+name = "regex"
+version = "2026.5.9"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/dc/0e/49aee608ad09480e7fd276898c99ec6192985fa331abe4eb3a986094490b/regex-2026.5.9.tar.gz", hash = "sha256:a8234aa23ec39894bfe4a3f1b85616a7032481964a13ac6fc9f10de4f6fca270", size = 416074, upload-time = "2026-05-09T23:15:19.37Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/50/9b/6550044bc44e17c84d312c031c2ec42fbdb6a4ec4e29093be3a172d08772/regex-2026.5.9-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:57eeeb05db7979413dec5438f2db21d7ecbba787cde7a711df1a6f6df672aa06", size = 490451, upload-time = "2026-05-09T23:12:34.72Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/95/fc7ba4303b5a0f92446a12ee6778ef2c6c799233f5060042a31bf390cfe9/regex-2026.5.9-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:398c521292f4c7fb807001dcd54694d3a1fcafc179a36ad9cc56f98df85930b6", size = 292112, upload-time = "2026-05-09T23:12:36.285Z" },
+    { url = "https://files.pythonhosted.org/packages/54/4b/ee27938d1b2c443e89a9a10e00d2d19aa5ee300cd3d61140644e93bb083e/regex-2026.5.9-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:f7a7c26137296beba7784de6eba69c6a93a63ccebc385e4962fe67e267a91225", size = 289599, upload-time = "2026-05-09T23:12:38.089Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/dd/ba103dc19614e25f3880800ca67ce093d6e21b325d72b8383c7bf906e9fa/regex-2026.5.9-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6441cc660d76107934a09c22167200839a0e89604a6297f78a974e66e931d2c0", size = 796732, upload-time = "2026-05-09T23:12:40.062Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/e7/f035b4fd858b050b0080bf302968dc0f59ba34e391872d54936758e6844e/regex-2026.5.9-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:91328f1c23d47595ca3ef0a7557fa129c5a23404b775c770697d2f35b33e0107", size = 865440, upload-time = "2026-05-09T23:12:42.059Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/51/8cd301ecc899aea28124357f729f4272f44de7806fc7ca02490bfbe253e8/regex-2026.5.9-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:93a7860539414dddaefba2b40f8771765ae17949d4c7182b876ce429e11a8309", size = 912329, upload-time = "2026-05-09T23:12:44.373Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/1e/3fbe2fa1e8cebd62f3bb7d3321cff1640aca2e240b51d9bd624aad949260/regex-2026.5.9-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:dd2810d22146b6d838acc5ec15602cb6b47920aa4e33015df3868eedfd20bab8", size = 801239, upload-time = "2026-05-09T23:12:46.268Z" },
+    { url = "https://files.pythonhosted.org/packages/17/2f/6f6008682bf2cf98040a0d3153a8e557b6ab728d7713d045cee4ce544ab8/regex-2026.5.9-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:daff2bdbaf1d23e52fdff7c0b7bc2048b68f978df6a4d107ac981f94caef2e66", size = 777054, upload-time = "2026-05-09T23:12:48.051Z" },
+    { url = "https://files.pythonhosted.org/packages/19/2b/eee0d20a6842ba04df4b8847a920b57ef56853f14ef85405473e586b605a/regex-2026.5.9-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:4eeb011098fcb77af513dcef521a3dbecbf8849b1e38940759d293b7a93f5026", size = 785098, upload-time = "2026-05-09T23:12:49.851Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/98/6fc1e6410feefb92159edaed5041992bfe390e8d26c721865434acbca558/regex-2026.5.9-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:ea9c8ecfa1b73c73b626534d6626e5340d429630943672b8480724f44e84b962", size = 860095, upload-time = "2026-05-09T23:12:51.666Z" },
+    { url = "https://files.pythonhosted.org/packages/18/a3/bd855e0f2cb1a978ecf6fa6bb69632dd9c3f6ea3b81cde62fde14c9daec7/regex-2026.5.9-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:cd2846168eb9ee3c513902bc8225409cb1caab31d04728b145171fa1625d9621", size = 765762, upload-time = "2026-05-09T23:12:53.413Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/66/0ae8c092e60b14c79d24f8e0b7f0aea5bfbffdcab00b5483d13404d3c3a5/regex-2026.5.9-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:39617fb0cde9c0e6306dc70e3bfc096f3da793219879f7ae7aa341a69fbdcf6d", size = 852100, upload-time = "2026-05-09T23:12:55.256Z" },
+    { url = "https://files.pythonhosted.org/packages/21/de/8dfde60fc1b21c946a893ba273403b72617edb261370cb1087099a83f088/regex-2026.5.9-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:fd03c4f0e33280d15cae17159b899245d6b7c53d21def19b263b39655061f5ce", size = 789479, upload-time = "2026-05-09T23:12:57.573Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/1c/bdcc98f9a4af4fdd166c74941174619ccff4726d3ce32faa8e9a2ecd38dd/regex-2026.5.9-cp312-cp312-win32.whl", hash = "sha256:164eba9b755ea6f244b0d881196fbc1fac09714e9782c9e2732b813142033c8e", size = 266699, upload-time = "2026-05-09T23:12:59.14Z" },
+    { url = "https://files.pythonhosted.org/packages/78/87/240d36864f9e48ace85f72e79ced97ceb7f27ce87739a947dcb834b4e6bc/regex-2026.5.9-cp312-cp312-win_amd64.whl", hash = "sha256:86f40a5d6444db30a125c9c9177e6b25dad981cbc37451fd838f145e6edac92e", size = 277783, upload-time = "2026-05-09T23:13:00.789Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/b5/7b30f312b0669dff5beebe5b0989dc2d1a312b1a44fab852199c387a5b96/regex-2026.5.9-cp312-cp312-win_arm64.whl", hash = "sha256:96f5f58b54a063d7ea9dca08e1cf57bfe10499c4d579ee672da284f57f5f0070", size = 270513, upload-time = "2026-05-09T23:13:02.426Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/da/797e91ecec6f84135da778ddce78c20e0af5d2a15c26f87a81bc3eadb6db/regex-2026.5.9-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:d626b84406444b165fc0ba981604edea39f0588ff1f92baa23fe50799ea9afdb", size = 490303, upload-time = "2026-05-09T23:13:04.382Z" },
+    { url = "https://files.pythonhosted.org/packages/44/da/bf30abaaa737b58f4a4b8c4a03659e02fd92092c822e0197ed9e0daab917/regex-2026.5.9-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:d7bdc0ab8f3dd7e1b4f9ab88634e13374669db86bb3c72e8292f07ae313f539f", size = 292019, upload-time = "2026-05-09T23:13:06.022Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/e7/d0eaf5713828417b9e5648cf81fa9bacd4961f6ab98c380c2034f8716e35/regex-2026.5.9-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:a8820737949116ffff55fe18f9fc644530063ba6ebfcb8314239416e78f1347c", size = 289468, upload-time = "2026-05-09T23:13:08.214Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/9b/b3fdd62b003baa1a9b593cd8c8699c9651c2e80cc21a5c715707983c42d7/regex-2026.5.9-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:aa0fbdbac82cb3e4450d0ccde7d7a35607f4cb2dd9fba4b8b69bfaf8c9fa6aed", size = 796749, upload-time = "2026-05-09T23:13:10.573Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/30/66ab84588765f5b4b271a9ca09ef7ce2b87caa95176ec3d2ad65d7bc4902/regex-2026.5.9-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:57e8915c7986aa33d25e4d3629cef711cd2863f2961b10409f0c04cb8b7d9020", size = 865445, upload-time = "2026-05-09T23:13:12.523Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/89/f05169e8588aac365f35ffc7f3bc3184f095ef4cfded7cfaa3c7fd5dbd89/regex-2026.5.9-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:508f56a89ba9cb26e4168cbc37dbd60a28d82430a9e18ad1d25fe0883c314ca2", size = 912322, upload-time = "2026-05-09T23:13:14.281Z" },
+    { url = "https://files.pythonhosted.org/packages/30/e1/c93444052cf41581f3c884ab3fb5823daf0992f11cd4388d4275ca610558/regex-2026.5.9-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b6d189041f15691cfa2b6c4290448ec221244d225b3f5fe9e7771b34ffcdf6e2", size = 801269, upload-time = "2026-05-09T23:13:16.569Z" },
+    { url = "https://files.pythonhosted.org/packages/50/fe/0cf96b882f540e62e8b9956599798203d599c44cf4c77917ca27400ff69b/regex-2026.5.9-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e82db382b44d0111b22601c509c89f64434816c9e0eef9d1989cda8cc6ff1c04", size = 777085, upload-time = "2026-05-09T23:13:18.675Z" },
+    { url = "https://files.pythonhosted.org/packages/23/5c/d78d4924e7fc875557b9e9b768423925fdfaac5549d06da7810019a9bd26/regex-2026.5.9-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:2acfb48634f64996b57f90f39afa692ff362162722581921fe92239a59960f3c", size = 785153, upload-time = "2026-05-09T23:13:20.525Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/e0/5214774090e7b4524dcea3e3c4aa74141d43043f8beb49c1599db1c8b53a/regex-2026.5.9-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:d29eebfc9525db68cad3c97eedd7f754fa265aa5cd0cf4f863b2421e1b48fc9f", size = 860164, upload-time = "2026-05-09T23:13:22.263Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/e1/4a57a83350319b1271f0d7a249b8672513ed928b237a741631270de6caea/regex-2026.5.9-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:debb893095e944091c16e641a6e33c1b0f4cb61ab945ec5afbf53ce7068834d8", size = 765731, upload-time = "2026-05-09T23:13:24.277Z" },
+    { url = "https://files.pythonhosted.org/packages/12/f4/499e74a20c156fc75836ee04a72a38d1a063978f600937f9760467beb1b0/regex-2026.5.9-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:d659eee77986549c9ea45b861c7567e44d6287c3dc9a4565478853f7b9fe2ff6", size = 852062, upload-time = "2026-05-09T23:13:26.125Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/92/7eebc0d0a01e78629695f342ba17e0deaff8fb45e79cc0d7b98287da6e3e/regex-2026.5.9-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:2efa205e6d98b24d1f3ab395c11aa15cdf10935bca283d0285e0499c284fba21", size = 789577, upload-time = "2026-05-09T23:13:27.814Z" },
+    { url = "https://files.pythonhosted.org/packages/05/a4/018e71f7d2ad48c1ebe6d3ae0026f9b7cb4802fd15c7cc02fdf724355102/regex-2026.5.9-cp313-cp313-win32.whl", hash = "sha256:f3844f134e834076677dd369976e9f5068679fcb8e50102fdf6b7ac96a3ec127", size = 266691, upload-time = "2026-05-09T23:13:29.549Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/1d/861a93719fb9ee7dbfc3761b3797b7a3e112a5d42c6129459d2d741be9b5/regex-2026.5.9-cp313-cp313-win_amd64.whl", hash = "sha256:3527bb4942d2c14552155406cdedd906567456821848aed1cb4933a391bf5eca", size = 277747, upload-time = "2026-05-09T23:13:31.859Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/c6/0a2436ae4da1ba76e51cb98943c6838a9a721faa40ebe2dce07694ae34e3/regex-2026.5.9-cp313-cp313-win_arm64.whl", hash = "sha256:56a33f191f17d8c417f99945ebdc1e691d3af9605d86ec68c7e54a57e3e17af6", size = 270500, upload-time = "2026-05-09T23:13:33.525Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/e9/d21346f7b60ed58789371358ed66b09d00f832e1bd7c06e55d9da5679882/regex-2026.5.9-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:01f28d868834624c934b8d2e0aa1c8341337e37831f4a012f18a5afcba4cbaf3", size = 494172, upload-time = "2026-05-09T23:13:35.935Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/43/fd1177a2032037c681baecdb3422ee4e1424aec4e4f470ef47793d325274/regex-2026.5.9-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:48036f6374aaa79eb3b754ec29c61d1c6b1606749d705a13f8854fa2539671f6", size = 293952, upload-time = "2026-05-09T23:13:38.307Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/7d/9fbf919768368d3f8a4f6c692cf2aa61e482b2b81ec6a298ace4cbf02480/regex-2026.5.9-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:b96350aa424e79d4fd6b567b344dcbe2b2d6bfc48dfe7717587e1fa6d43da6ff", size = 292314, upload-time = "2026-05-09T23:13:40.353Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/6c/e41bfeecb589716843e7c4df09ba46ff2a42961457afece19059d85caeef/regex-2026.5.9-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8f3af7a4903c5c04a11a196a5aa75cdd7dd3f8508132f9fb3259d9f5908e3b88", size = 811681, upload-time = "2026-05-09T23:13:42.543Z" },
+    { url = "https://files.pythonhosted.org/packages/87/83/a5c1c525fba0aa656e88ad0face0b1829788ef4c2fb6b26df58aa1151b84/regex-2026.5.9-cp313-cp313t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:7e87577720152d2caae19fe2baaf1f8d5ca12091e9e229f03915c37d1e4b9178", size = 871135, upload-time = "2026-05-09T23:13:44.326Z" },
+    { url = "https://files.pythonhosted.org/packages/18/d4/80882e799e440dd878b0979cbebf8fa4d54624a332c83037c7a701649e3f/regex-2026.5.9-cp313-cp313t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:c8b9b9d294cfea3cd19c718ade7cc93492b2c4991abd9a68d0b3477ae6d8e100", size = 917265, upload-time = "2026-05-09T23:13:47.295Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/ff/8db60211e2286e396aad7dc7725356c502bff0901ea05bd6cdc2e1a042b9/regex-2026.5.9-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:728d8bfd28a8845c8b6bc5dc7ce010453d206396786c0765c2740cb65f37791e", size = 816311, upload-time = "2026-05-09T23:13:49.885Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/47/742ef579c61730f8d268e5cf1f9ce0e37e2ea041ad0f5644724f2378e463/regex-2026.5.9-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:7e30b874d341fac767d7df5a0870540541c2c054b80cfaac116e8d367a8a7ff2", size = 785498, upload-time = "2026-05-09T23:13:52.25Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/ab/cb0999802dcb0fb95b1ab005e8d4163d8afdd67efc2cb6b6630ac13f8cb1/regex-2026.5.9-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:fd190e88a895a8901325fad284a3f74ea52b1da8525b76cc811fa9b1edf0ce2b", size = 801348, upload-time = "2026-05-09T23:13:54.127Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/62/8ca59a24c55bc34d166eefaf3717bd77772f329fdbf984d86581e0a3571c/regex-2026.5.9-cp313-cp313t-musllinux_1_2_ppc64le.whl", hash = "sha256:8e76e8161ad00694cfce6767d5dea860c6391ac5b83e5c3a39661e696f11fc7e", size = 866493, upload-time = "2026-05-09T23:13:56.067Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/3d/30f2ae62cef3278bb5bb821f467277a55fb73f01032cf85997e15e8289a8/regex-2026.5.9-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:ddda5340e6c01a293027dd46232fa79eaff1b48058ce7a98f572b6445b088041", size = 772811, upload-time = "2026-05-09T23:13:57.867Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/ae/7d2089bcd78ad0c0161bc684339df50032acb438a7bd3305e7ddb1193cec/regex-2026.5.9-cp313-cp313t-musllinux_1_2_s390x.whl", hash = "sha256:205109e96b3cf5adf8f4cd62bedde9487feb282b9497a3535451e5a24cd706a0", size = 856584, upload-time = "2026-05-09T23:13:59.679Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/29/92ff47f75990131ea4f24ba17819e5a9d141e10819807e09addd73409af6/regex-2026.5.9-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:dfbe4579b9f08036aa7d101d1835437a20783574ac66327e6b29b4018a138081", size = 803453, upload-time = "2026-05-09T23:14:01.978Z" },
+    { url = "https://files.pythonhosted.org/packages/04/99/eff29f1037dcab36702c9ee5d6858cf1ce2336ea8ea2987f64245b99ea5e/regex-2026.5.9-cp313-cp313t-win32.whl", hash = "sha256:ed2c9e8068b614c574d8d30e543d617cf5379b0535d46f97ef00e904745a08b5", size = 269951, upload-time = "2026-05-09T23:14:03.661Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/9d/8870b8981d27b22cda77bb26a5ac7ebfa9c7d9e0dea195a834a82380e748/regex-2026.5.9-cp313-cp313t-win_amd64.whl", hash = "sha256:b46b0f094dc1d3b90356c85a0bd2c9bafc4a6a190b9d6f8ddd5a033b6e088ed4", size = 281240, upload-time = "2026-05-09T23:14:05.56Z" },
+    { url = "https://files.pythonhosted.org/packages/72/b1/3379415e8f135c13ac551353397cc4fe97b4978f3cac73c5fcbcded548b8/regex-2026.5.9-cp313-cp313t-win_arm64.whl", hash = "sha256:872acc074bd29ffc9913ecdfedf6ea77502312ca44a4aa0d3779089c6069d8de", size = 272383, upload-time = "2026-05-09T23:14:07.843Z" },
+    { url = "https://files.pythonhosted.org/packages/13/3e/9c3cd292d8808b3645a2ce517e200179b6d0e903f176300bd8b542e14de5/regex-2026.5.9-cp314-cp314-macosx_10_13_universal2.whl", hash = "sha256:1bd7587a2948b4085195d5a3374eaf4a425dc3e55784c038175355ecf3bbbf8a", size = 490376, upload-time = "2026-05-09T23:14:09.64Z" },
+    { url = "https://files.pythonhosted.org/packages/60/70/d43ee8a2ca0a8b68d167f21658b85520ac0574617c7f320367c5047f7556/regex-2026.5.9-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:dea2e88e1cce4522496cce630e11e67b98b7076620bc4336c3f674bc21a375f4", size = 291964, upload-time = "2026-05-09T23:14:11.424Z" },
+    { url = "https://files.pythonhosted.org/packages/21/91/9d50b433828d8e74196904e168a43abf1e6e88b2a15d47ed742456720c37/regex-2026.5.9-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:2099f7e7ff7b6aa3192312650a56e91cc091e49d50b04e4f6f8b6e28b3b27f1c", size = 289682, upload-time = "2026-05-09T23:14:13.123Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/d2/b835e3cafbb9d977736912436259ff551d60919f7d7b3d37d46659c63564/regex-2026.5.9-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ecd353045824e4477562a2ac718c25799cdaaa41f7aa925a806a8a3e6848a5b9", size = 796996, upload-time = "2026-05-09T23:14:14.923Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/a6/9f992d00019166b9de01c546dd4549bc679f2a68df11b877740b0760b7c2/regex-2026.5.9-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:65c8c8c37377794bd5b2f3ebe51919042bf17aec802e23c833d89782ed0c78af", size = 866089, upload-time = "2026-05-09T23:14:17.757Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/08/4d32af657e049b19cb62b02e46e38fe1518797bfb2203ee93a510b21b0dc/regex-2026.5.9-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:5b73ab8afcf66c622db143d1c6fda4e58e4d537ee4f125229ad47b1ab80f34c0", size = 911530, upload-time = "2026-05-09T23:14:20.353Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/27/2af43dd1dc201d1fecefda64a45f4ad0995855b92724f795a777b402ee69/regex-2026.5.9-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0de5cf193997384ed2ca6f1cd4f78055b255d93d82d5a8cd6ba0d11c10b167e4", size = 800643, upload-time = "2026-05-09T23:14:22.265Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/dd/23a249047013b5321d4a60c4d2437462086f601b061776a525e5fba2a59f/regex-2026.5.9-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:d641a8c9a61618047796d572a39a79b26167b0411d2c3031937b2fe2d081e2cf", size = 777223, upload-time = "2026-05-09T23:14:24.179Z" },
+    { url = "https://files.pythonhosted.org/packages/94/6a/e85ed9538cd19586d0465076a4578a12e093ce776d15f3f8ce92733a8dd6/regex-2026.5.9-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:24b2355ef5cc9aa5b8f07d17704face1c166fdcc2290fa7bd6e6c925655a8346", size = 785760, upload-time = "2026-05-09T23:14:26.065Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/c4/f25473209438638e947c55f9156fd8f236f74169229028cc99116380868e/regex-2026.5.9-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:a24852d3c29ad9e47593593d8a247c44ccc3d0548ef12c822d6ed0810affe676", size = 860891, upload-time = "2026-05-09T23:14:28.17Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/f7/f4f86e3c74419c37370e91f150ae0c2ef7d34b2e0e4cdd5da046a02e4022/regex-2026.5.9-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:916714069da19329ef7de197dcbc77bb3104145c7c2c864dbfbe318f46b88b14", size = 765891, upload-time = "2026-05-09T23:14:30.06Z" },
+    { url = "https://files.pythonhosted.org/packages/26/70/704d8e13765939146b1cd0ef4e2feb71d7929727d2290f026eed10095955/regex-2026.5.9-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:fa411799ca8da32a8d38d020a88faa5b6f91657d284761352940ecf9f7c3bbdd", size = 851380, upload-time = "2026-05-09T23:14:32.123Z" },
+    { url = "https://files.pythonhosted.org/packages/26/29/1a13582a8460038edc38e49f64ceb0dd7c60f5caba77571f4bf6601965d9/regex-2026.5.9-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:1e6da47d679b7010ef27556b6e0f99771b744936db1792a10ceac6547ae1503e", size = 789350, upload-time = "2026-05-09T23:14:34.799Z" },
+    { url = "https://files.pythonhosted.org/packages/73/56/3dcafe34fc72e271d62ad9a291801e88a1457bb251c132f15fcc2e5aad1a/regex-2026.5.9-cp314-cp314-win32.whl", hash = "sha256:98bd73080e8756255137e1bd3f3f00295bbc5aa383c0e0f973920e9134d7c4ad", size = 272130, upload-time = "2026-05-09T23:14:36.729Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/9c/02eebf0be95efe416c664db7fb8b6b05b7a0b06a7544f2884f2558b0526f/regex-2026.5.9-cp314-cp314-win_amd64.whl", hash = "sha256:ff8d372ac2acdc048d1c19916f27ee61bc5722728458ba6ca5052f2c72d51763", size = 280999, upload-time = "2026-05-09T23:14:39.126Z" },
+    { url = "https://files.pythonhosted.org/packages/70/5a/1dd1abee76cb7a846a0bcf42fdc87e5720c3c33c24f3e37814310a513d9f/regex-2026.5.9-cp314-cp314-win_arm64.whl", hash = "sha256:e1d93bf647916292e8edcec150c07ddf3dc50179ccaf770c04a7f9e452155372", size = 273500, upload-time = "2026-05-09T23:14:41.059Z" },
+    { url = "https://files.pythonhosted.org/packages/86/c1/c5f619b0057a7965cb78ec559c1d7a45ce8c99a35bea95483d64959a93d9/regex-2026.5.9-cp314-cp314t-macosx_10_13_universal2.whl", hash = "sha256:83d0ee4a57d1c87cb549e195ec300b8f0ec3a82eba66d835e4e2ed8634fe4499", size = 494269, upload-time = "2026-05-09T23:14:42.869Z" },
+    { url = "https://files.pythonhosted.org/packages/05/2c/5d01f1aee33de4bbe60c8452945bfc8477ca7c5ae4450f6bfe711036cb36/regex-2026.5.9-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:d3d7eb5c9a7f6df82ed3cfac9beb93882a5cbcb5b8b157b56cb2b3b276574ac1", size = 293954, upload-time = "2026-05-09T23:14:44.822Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/fe/e8988b2ae2108c6ef71bd4aa8d87fbe257976dd0810e826cd75f701c68b6/regex-2026.5.9-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:075160bf16658e16d35233300b8453aac25de4cbea808d22348b6979668e924d", size = 292405, upload-time = "2026-05-09T23:14:47.211Z" },
+    { url = "https://files.pythonhosted.org/packages/79/34/d2b0937faa7859263f7f0a3c6b103a1296306be6952dc173d0154e9a2f49/regex-2026.5.9-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:45375819235558a4ff1c4971dc32881f022613abdb180128f5cb4768c1765a1c", size = 811855, upload-time = "2026-05-09T23:14:49.21Z" },
+    { url = "https://files.pythonhosted.org/packages/80/fe/daf53a47457a8486db66c66c01ceb9c2303eecee3f87197f1e77eb1a736d/regex-2026.5.9-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:ead4b163ac30a29574510cd4b3e2e985ac5290c05fc7095557d6a5f403fc31b5", size = 871189, upload-time = "2026-05-09T23:14:51.555Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/75/058fc4470cbfbf57d800aff1a0022b929a3f9fa553ee10a0cdf2070eb31f/regex-2026.5.9-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:8c6e4218fbdfbcd4f6c19efca40930d24a621bf4b48cb76bc6640543bd28ef20", size = 917485, upload-time = "2026-05-09T23:14:53.633Z" },
+    { url = "https://files.pythonhosted.org/packages/88/e7/179cfda3a28bc843b5c6cfe7f79f23489c791ed95f151083803660878432/regex-2026.5.9-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6351571c8a42b505eb555c0dc47d740d0fb66977dc142919eea6f4325b7c56a0", size = 816369, upload-time = "2026-05-09T23:14:56.198Z" },
+    { url = "https://files.pythonhosted.org/packages/41/90/6f0cc422071688266d344fca8462d787cba0a2c144acb25721f9a61ec265/regex-2026.5.9-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:002205cafd2a9e78c6290c7d1df277bf3277b3b7a30e0b4bb0dac2e2e3f7cb2d", size = 785869, upload-time = "2026-05-09T23:14:58.602Z" },
+    { url = "https://files.pythonhosted.org/packages/02/67/a31f1760f09c27b251ef39e9beb541f462cf977381d067faa764c2c0e393/regex-2026.5.9-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:8abd33fef90b2a9efac5557d6033ca82d1195ed3a15fea5af15ba7b463c6a63b", size = 801427, upload-time = "2026-05-09T23:15:00.642Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/c4/1a80654597b6bc1e1ea0494824c31200e8a956abe290afae9b19a166a148/regex-2026.5.9-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:31037c82eccb44b7ea2e9e221d7c01429430e989a1f4b91ea5a855f6017b509a", size = 866482, upload-time = "2026-05-09T23:15:03.384Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/11/960724e06482c08466ff5611e242e86f80062949cdf6b4b9cc317b9dd93d/regex-2026.5.9-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:5604dfd046dc37eca90250fc3be938b076c8059fa772ac0ed6f499b0f0fb0415", size = 773022, upload-time = "2026-05-09T23:15:05.625Z" },
+    { url = "https://files.pythonhosted.org/packages/50/a8/a9979c3e7918280e93159ebcab5ef1a65116dd4f3bd6091be0eae4a126e8/regex-2026.5.9-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:0e1b1b4e496afbb24f4a62aba855ee4f88f25578927697b340702e48c9ee6bc2", size = 856642, upload-time = "2026-05-09T23:15:07.966Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/d4/a9b732f2f0072c0ab12227483abb24fffcb9f73f8a2b203df0a6d0434735/regex-2026.5.9-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:be3372b9df6ddecff6486d37e19095a7b4973137caf5512407a89f4455361f41", size = 803552, upload-time = "2026-05-09T23:15:10.215Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/fe/1b3113817447a1d4155e4ac76d2e072f42c0bcba2f43fa8a0e756ea2cd91/regex-2026.5.9-cp314-cp314t-win32.whl", hash = "sha256:3ddd90103f9e5c471c49c7852ecc1fe27c7e45eb99e977aefe7caa4e779f4f58", size = 275746, upload-time = "2026-05-09T23:15:12.609Z" },
+    { url = "https://files.pythonhosted.org/packages/92/73/93d42045302636c91f2e5ef588b65b84b01428f28ec77de256b1dfdfbe5c/regex-2026.5.9-cp314-cp314t-win_amd64.whl", hash = "sha256:ca518ed29c46eecba6010b15f1b9a479314d2de409536e71b6a13aa04e3b8a77", size = 285685, upload-time = "2026-05-09T23:15:15.086Z" },
+    { url = "https://files.pythonhosted.org/packages/da/80/35b4c33c804a165a7f55289afda3ea9e3eb6d15800341a2d66455c0f1f30/regex-2026.5.9-cp314-cp314t-win_arm64.whl", hash = "sha256:5e41809d2683fcde7d5a8c87a6567ba1fb1ce0de9f31bff578de00a4b2d76daa", size = 275713, upload-time = "2026-05-09T23:15:16.98Z" },
+]
+
+[[package]]
+name = "reportlab"
+version = "4.5.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "charset-normalizer" },
+    { name = "pillow" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4d/3f/b3861b7e40c9d66f4a04e018958d681d16b948bfd1963c962d43a8c23f66/reportlab-4.5.1.tar.gz", hash = "sha256:9fdf68f4de9171ec66acb4a5feed8f8ca2af43479e707a6fbb0daa75d88e5494", size = 3939748, upload-time = "2026-05-12T10:14:13.663Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a7/45/ea7fad10122440de6e845568d106bffdc456ca0e8a1d8ae10b46016087e4/reportlab-4.5.1-py3-none-any.whl", hash = "sha256:06fce8cb56c83307cfa4909cdf4e6a2ddbb44e5d6ef4d2edca896d7e9769f091", size = 1957812, upload-time = "2026-05-12T10:14:10.622Z" },
 ]
 
 [[package]]
@@ -1202,6 +6239,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/ac/c3/e2a2b89f2d3e2179abd6d00ebd70bff6273f37fb3e0cc209f48b39d00cbf/requests-2.34.2.tar.gz", hash = "sha256:f288924cae4e29463698d6d60bc6a4da69c89185ad1e0bcc4104f584e960b9ed", size = 142856, upload-time = "2026-05-14T19:25:27.735Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a0/f4/c67b0b3f1b9245e8d266f0f112c500d50e5b4e83cb6f3b71b6528104182a/requests-2.34.2-py3-none-any.whl", hash = "sha256:2a0d60c172f83ac6ab31e4554906c0f3b3588d37b5cb939b1c061f4907e278e0", size = 73075, upload-time = "2026-05-14T19:25:26.443Z" },
+]
+
+[[package]]
+name = "requests-oauthlib"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "oauthlib" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/42/f2/05f29bc3913aea15eb670be136045bf5c5bbf4b99ecb839da9b422bb2c85/requests-oauthlib-2.0.0.tar.gz", hash = "sha256:b3dffaebd884d8cd778494369603a9e7b58d29111bf6b41bdc2dcd87203af4e9", size = 55650, upload-time = "2024-03-22T20:32:29.939Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3b/5d/63d4ae3b9daea098d5d6f5da83984853c1bbacd5dc826764b249fe119d24/requests_oauthlib-2.0.0-py2.py3-none-any.whl", hash = "sha256:7dd8a5c40426b779b0868c404bdef9768deccf22749cde15852df527e6269b36", size = 24179, upload-time = "2024-03-22T20:32:28.055Z" },
 ]
 
 [[package]]
@@ -1230,26 +6280,24 @@ wheels = [
 ]
 
 [[package]]
+name = "rich-rst"
+version = "2.0.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pygments" },
+    { name = "rich" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/57/56/3191bae66b08ccc637ea8120426068bcb361cc323c96404c310886937067/rich_rst-2.0.1.tar.gz", hash = "sha256:cbe236ed0901d1ec8427cc6a50bf0a34353ba28ad014dc24def68bfe7f3b9e68", size = 300570, upload-time = "2026-05-16T00:47:57.362Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/3d/55c17d3ebdf3cd81356002afe5bef9bb8af631db2819785b6eac845b925b/rich_rst-2.0.1-py3-none-any.whl", hash = "sha256:7ee15f345ce25fa02b582c272a6cdbaf0c21243e38061cea273cff659bf3ef61", size = 272922, upload-time = "2026-05-16T00:47:55.508Z" },
+]
+
+[[package]]
 name = "rpds-py"
 version = "0.30.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/20/af/3f2f423103f1113b36230496629986e0ef7e199d2aa8392452b484b38ced/rpds_py-0.30.0.tar.gz", hash = "sha256:dd8ff7cf90014af0c0f787eea34794ebf6415242ee1d6fa91eaba725cc441e84", size = 69469, upload-time = "2025-11-30T20:24:38.837Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/4d/6e/f964e88b3d2abee2a82c1ac8366da848fce1c6d834dc2132c3fda3970290/rpds_py-0.30.0-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:a2bffea6a4ca9f01b3f8e548302470306689684e61602aa3d141e34da06cf425", size = 370157, upload-time = "2025-11-30T20:21:53.789Z" },
-    { url = "https://files.pythonhosted.org/packages/94/ba/24e5ebb7c1c82e74c4e4f33b2112a5573ddc703915b13a073737b59b86e0/rpds_py-0.30.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:dc4f992dfe1e2bc3ebc7444f6c7051b4bc13cd8e33e43511e8ffd13bf407010d", size = 359676, upload-time = "2025-11-30T20:21:55.475Z" },
-    { url = "https://files.pythonhosted.org/packages/84/86/04dbba1b087227747d64d80c3b74df946b986c57af0a9f0c98726d4d7a3b/rpds_py-0.30.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:422c3cb9856d80b09d30d2eb255d0754b23e090034e1deb4083f8004bd0761e4", size = 389938, upload-time = "2025-11-30T20:21:57.079Z" },
-    { url = "https://files.pythonhosted.org/packages/42/bb/1463f0b1722b7f45431bdd468301991d1328b16cffe0b1c2918eba2c4eee/rpds_py-0.30.0-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:07ae8a593e1c3c6b82ca3292efbe73c30b61332fd612e05abee07c79359f292f", size = 402932, upload-time = "2025-11-30T20:21:58.47Z" },
-    { url = "https://files.pythonhosted.org/packages/99/ee/2520700a5c1f2d76631f948b0736cdf9b0acb25abd0ca8e889b5c62ac2e3/rpds_py-0.30.0-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:12f90dd7557b6bd57f40abe7747e81e0c0b119bef015ea7726e69fe550e394a4", size = 525830, upload-time = "2025-11-30T20:21:59.699Z" },
-    { url = "https://files.pythonhosted.org/packages/e0/ad/bd0331f740f5705cc555a5e17fdf334671262160270962e69a2bdef3bf76/rpds_py-0.30.0-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:99b47d6ad9a6da00bec6aabe5a6279ecd3c06a329d4aa4771034a21e335c3a97", size = 412033, upload-time = "2025-11-30T20:22:00.991Z" },
-    { url = "https://files.pythonhosted.org/packages/f8/1e/372195d326549bb51f0ba0f2ecb9874579906b97e08880e7a65c3bef1a99/rpds_py-0.30.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:33f559f3104504506a44bb666b93a33f5d33133765b0c216a5bf2f1e1503af89", size = 390828, upload-time = "2025-11-30T20:22:02.723Z" },
-    { url = "https://files.pythonhosted.org/packages/ab/2b/d88bb33294e3e0c76bc8f351a3721212713629ffca1700fa94979cb3eae8/rpds_py-0.30.0-cp311-cp311-manylinux_2_31_riscv64.whl", hash = "sha256:946fe926af6e44f3697abbc305ea168c2c31d3e3ef1058cf68f379bf0335a78d", size = 404683, upload-time = "2025-11-30T20:22:04.367Z" },
-    { url = "https://files.pythonhosted.org/packages/50/32/c759a8d42bcb5289c1fac697cd92f6fe01a018dd937e62ae77e0e7f15702/rpds_py-0.30.0-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:495aeca4b93d465efde585977365187149e75383ad2684f81519f504f5c13038", size = 421583, upload-time = "2025-11-30T20:22:05.814Z" },
-    { url = "https://files.pythonhosted.org/packages/2b/81/e729761dbd55ddf5d84ec4ff1f47857f4374b0f19bdabfcf929164da3e24/rpds_py-0.30.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:d9a0ca5da0386dee0655b4ccdf46119df60e0f10da268d04fe7cc87886872ba7", size = 572496, upload-time = "2025-11-30T20:22:07.713Z" },
-    { url = "https://files.pythonhosted.org/packages/14/f6/69066a924c3557c9c30baa6ec3a0aa07526305684c6f86c696b08860726c/rpds_py-0.30.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:8d6d1cc13664ec13c1b84241204ff3b12f9bb82464b8ad6e7a5d3486975c2eed", size = 598669, upload-time = "2025-11-30T20:22:09.312Z" },
-    { url = "https://files.pythonhosted.org/packages/5f/48/905896b1eb8a05630d20333d1d8ffd162394127b74ce0b0784ae04498d32/rpds_py-0.30.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:3896fa1be39912cf0757753826bc8bdc8ca331a28a7c4ae46b7a21280b06bb85", size = 561011, upload-time = "2025-11-30T20:22:11.309Z" },
-    { url = "https://files.pythonhosted.org/packages/22/16/cd3027c7e279d22e5eb431dd3c0fbc677bed58797fe7581e148f3f68818b/rpds_py-0.30.0-cp311-cp311-win32.whl", hash = "sha256:55f66022632205940f1827effeff17c4fa7ae1953d2b74a8581baaefb7d16f8c", size = 221406, upload-time = "2025-11-30T20:22:13.101Z" },
-    { url = "https://files.pythonhosted.org/packages/fa/5b/e7b7aa136f28462b344e652ee010d4de26ee9fd16f1bfd5811f5153ccf89/rpds_py-0.30.0-cp311-cp311-win_amd64.whl", hash = "sha256:a51033ff701fca756439d641c0ad09a41d9242fa69121c7d8769604a0a629825", size = 236024, upload-time = "2025-11-30T20:22:14.853Z" },
-    { url = "https://files.pythonhosted.org/packages/14/a6/364bba985e4c13658edb156640608f2c9e1d3ea3c81b27aa9d889fff0e31/rpds_py-0.30.0-cp311-cp311-win_arm64.whl", hash = "sha256:47b0ef6231c58f506ef0b74d44e330405caa8428e770fec25329ed2cb971a229", size = 229069, upload-time = "2025-11-30T20:22:16.577Z" },
     { url = "https://files.pythonhosted.org/packages/03/e7/98a2f4ac921d82f33e03f3835f5bf3a4a40aa1bfdc57975e74a97b2b4bdd/rpds_py-0.30.0-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:a161f20d9a43006833cd7068375a94d035714d73a172b681d8881820600abfad", size = 375086, upload-time = "2025-11-30T20:22:17.93Z" },
     { url = "https://files.pythonhosted.org/packages/4d/a1/bca7fd3d452b272e13335db8d6b0b3ecde0f90ad6f16f3328c6fb150c889/rpds_py-0.30.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:6abc8880d9d036ecaafe709079969f56e876fcf107f7a8e9920ba6d5a3878d05", size = 359053, upload-time = "2025-11-30T20:22:19.297Z" },
     { url = "https://files.pythonhosted.org/packages/65/1c/ae157e83a6357eceff62ba7e52113e3ec4834a84cfe07fa4b0757a7d105f/rpds_py-0.30.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ca28829ae5f5d569bb62a79512c842a03a12576375d5ece7d2cadf8abe96ec28", size = 390763, upload-time = "2025-11-30T20:22:21.661Z" },
@@ -1323,18 +6371,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/85/70/92482ccffb96f5441aab93e26c4d66489eb599efdcf96fad90c14bbfb976/rpds_py-0.30.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:dbd936cde57abfee19ab3213cf9c26be06d60750e60a8e4dd85d1ab12c8b1f40", size = 556030, upload-time = "2025-11-30T20:24:10.956Z" },
     { url = "https://files.pythonhosted.org/packages/20/53/7c7e784abfa500a2b6b583b147ee4bb5a2b3747a9166bab52fec4b5b5e7d/rpds_py-0.30.0-cp314-cp314t-win32.whl", hash = "sha256:dc824125c72246d924f7f796b4f63c1e9dc810c7d9e2355864b3c3a73d59ade0", size = 211570, upload-time = "2025-11-30T20:24:12.735Z" },
     { url = "https://files.pythonhosted.org/packages/d0/02/fa464cdfbe6b26e0600b62c528b72d8608f5cc49f96b8d6e38c95d60c676/rpds_py-0.30.0-cp314-cp314t-win_amd64.whl", hash = "sha256:27f4b0e92de5bfbc6f86e43959e6edd1425c33b5e69aab0984a72047f2bcf1e3", size = 226532, upload-time = "2025-11-30T20:24:14.634Z" },
-    { url = "https://files.pythonhosted.org/packages/69/71/3f34339ee70521864411f8b6992e7ab13ac30d8e4e3309e07c7361767d91/rpds_py-0.30.0-pp311-pypy311_pp73-macosx_10_12_x86_64.whl", hash = "sha256:c2262bdba0ad4fc6fb5545660673925c2d2a5d9e2e0fb603aad545427be0fc58", size = 372292, upload-time = "2025-11-30T20:24:16.537Z" },
-    { url = "https://files.pythonhosted.org/packages/57/09/f183df9b8f2d66720d2ef71075c59f7e1b336bec7ee4c48f0a2b06857653/rpds_py-0.30.0-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:ee6af14263f25eedc3bb918a3c04245106a42dfd4f5c2285ea6f997b1fc3f89a", size = 362128, upload-time = "2025-11-30T20:24:18.086Z" },
-    { url = "https://files.pythonhosted.org/packages/7a/68/5c2594e937253457342e078f0cc1ded3dd7b2ad59afdbf2d354869110a02/rpds_py-0.30.0-pp311-pypy311_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3adbb8179ce342d235c31ab8ec511e66c73faa27a47e076ccc92421add53e2bb", size = 391542, upload-time = "2025-11-30T20:24:20.092Z" },
-    { url = "https://files.pythonhosted.org/packages/49/5c/31ef1afd70b4b4fbdb2800249f34c57c64beb687495b10aec0365f53dfc4/rpds_py-0.30.0-pp311-pypy311_pp73-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:250fa00e9543ac9b97ac258bd37367ff5256666122c2d0f2bc97577c60a1818c", size = 404004, upload-time = "2025-11-30T20:24:22.231Z" },
-    { url = "https://files.pythonhosted.org/packages/e3/63/0cfbea38d05756f3440ce6534d51a491d26176ac045e2707adc99bb6e60a/rpds_py-0.30.0-pp311-pypy311_pp73-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9854cf4f488b3d57b9aaeb105f06d78e5529d3145b1e4a41750167e8c213c6d3", size = 527063, upload-time = "2025-11-30T20:24:24.302Z" },
-    { url = "https://files.pythonhosted.org/packages/42/e6/01e1f72a2456678b0f618fc9a1a13f882061690893c192fcad9f2926553a/rpds_py-0.30.0-pp311-pypy311_pp73-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:993914b8e560023bc0a8bf742c5f303551992dcb85e247b1e5c7f4a7d145bda5", size = 413099, upload-time = "2025-11-30T20:24:25.916Z" },
-    { url = "https://files.pythonhosted.org/packages/b8/25/8df56677f209003dcbb180765520c544525e3ef21ea72279c98b9aa7c7fb/rpds_py-0.30.0-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:58edca431fb9b29950807e301826586e5bbf24163677732429770a697ffe6738", size = 392177, upload-time = "2025-11-30T20:24:27.834Z" },
-    { url = "https://files.pythonhosted.org/packages/4a/b4/0a771378c5f16f8115f796d1f437950158679bcd2a7c68cf251cfb00ed5b/rpds_py-0.30.0-pp311-pypy311_pp73-manylinux_2_31_riscv64.whl", hash = "sha256:dea5b552272a944763b34394d04577cf0f9bd013207bc32323b5a89a53cf9c2f", size = 406015, upload-time = "2025-11-30T20:24:29.457Z" },
-    { url = "https://files.pythonhosted.org/packages/36/d8/456dbba0af75049dc6f63ff295a2f92766b9d521fa00de67a2bd6427d57a/rpds_py-0.30.0-pp311-pypy311_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:ba3af48635eb83d03f6c9735dfb21785303e73d22ad03d489e88adae6eab8877", size = 423736, upload-time = "2025-11-30T20:24:31.22Z" },
-    { url = "https://files.pythonhosted.org/packages/13/64/b4d76f227d5c45a7e0b796c674fd81b0a6c4fbd48dc29271857d8219571c/rpds_py-0.30.0-pp311-pypy311_pp73-musllinux_1_2_aarch64.whl", hash = "sha256:dff13836529b921e22f15cb099751209a60009731a68519630a24d61f0b1b30a", size = 573981, upload-time = "2025-11-30T20:24:32.934Z" },
-    { url = "https://files.pythonhosted.org/packages/20/91/092bacadeda3edf92bf743cc96a7be133e13a39cdbfd7b5082e7ab638406/rpds_py-0.30.0-pp311-pypy311_pp73-musllinux_1_2_i686.whl", hash = "sha256:1b151685b23929ab7beec71080a8889d4d6d9fa9a983d213f07121205d48e2c4", size = 599782, upload-time = "2025-11-30T20:24:35.169Z" },
-    { url = "https://files.pythonhosted.org/packages/d1/b7/b95708304cd49b7b6f82fdd039f1748b66ec2b21d6a45180910802f1abf1/rpds_py-0.30.0-pp311-pypy311_pp73-musllinux_1_2_x86_64.whl", hash = "sha256:ac37f9f516c51e5753f27dfdef11a88330f04de2d564be3991384b2f3535d02e", size = 562191, upload-time = "2025-11-30T20:24:36.853Z" },
 ]
 
 [[package]]
@@ -1363,6 +6399,32 @@ wheels = [
 ]
 
 [[package]]
+name = "screeninfo"
+version = "0.8.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cython", marker = "sys_platform == 'darwin'" },
+    { name = "pyobjc-framework-cocoa", marker = "sys_platform == 'darwin'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ec/bb/e69e5e628d43f118e0af4fc063c20058faa8635c95a1296764acc8167e27/screeninfo-0.8.1.tar.gz", hash = "sha256:9983076bcc7e34402a1a9e4d7dabf3729411fd2abb3f3b4be7eba73519cd2ed1", size = 10666, upload-time = "2022-09-09T11:35:23.419Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6e/bf/c5205d480307bef660e56544b9e3d7ff687da776abb30c9cb3f330887570/screeninfo-0.8.1-py3-none-any.whl", hash = "sha256:e97d6b173856edcfa3bd282f81deb528188aff14b11ec3e195584e7641be733c", size = 12907, upload-time = "2022-09-09T11:35:21.351Z" },
+]
+
+[[package]]
+name = "secretstorage"
+version = "3.5.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography" },
+    { name = "jeepney" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1c/03/e834bcd866f2f8a49a85eaff47340affa3bfa391ee9912a952a1faa68c7b/secretstorage-3.5.0.tar.gz", hash = "sha256:f04b8e4689cbce351744d5537bf6b1329c6fc68f91fa666f60a380edddcd11be", size = 19884, upload-time = "2025-11-23T19:02:53.191Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/46/f5af3402b579fd5e11573ce652019a67074317e18c1935cc0b4ba9b35552/secretstorage-3.5.0-py3-none-any.whl", hash = "sha256:0ce65888c0725fcb2c5bc0fdb8e5438eece02c523557ea40ce0703c266248137", size = 15554, upload-time = "2025-11-23T19:02:51.545Z" },
+]
+
+[[package]]
 name = "shellingham"
 version = "1.5.4"
 source = { registry = "https://pypi.org/simple" }
@@ -1372,12 +6434,48 @@ wheels = [
 ]
 
 [[package]]
+name = "six"
+version = "1.17.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
+]
+
+[[package]]
 name = "sniffio"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc", size = 20372, upload-time = "2024-02-25T23:20:04.057Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235, upload-time = "2024-02-25T23:20:01.196Z" },
+]
+
+[[package]]
+name = "socksio"
+version = "1.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f8/5c/48a7d9495be3d1c651198fd99dbb6ce190e2274d0f28b9051307bdec6b85/socksio-1.0.0.tar.gz", hash = "sha256:f88beb3da5b5c38b9890469de67d0cb0f9d494b78b106ca1845f96c10b91c4ac", size = 19055, upload-time = "2020-04-17T15:50:34.664Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/37/c3/6eeb6034408dac0fa653d126c9204ade96b819c936e136c5e8a6897eee9c/socksio-1.0.0-py3-none-any.whl", hash = "sha256:95dc1f15f9b34e8d7b16f06d74b8ccf48f609af32ab33c608d08761c5dcbb1f3", size = 12763, upload-time = "2020-04-17T15:50:31.878Z" },
+]
+
+[[package]]
+name = "sortedcontainers"
+version = "2.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e8/c4/ba2f8066cceb6f23394729afe52f3bf7adec04bf9ed2c820b39e19299111/sortedcontainers-2.4.0.tar.gz", hash = "sha256:25caa5a06cc30b6b83d11423433f65d1f9d76c4c6a0c90e3379eaa43b9bfdb88", size = 30594, upload-time = "2021-05-16T22:03:42.897Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/32/46/9cb0e58b2deb7f82b84065f37f3bffeb12413f947f9388e4cac22c4621ce/sortedcontainers-2.4.0-py2.py3-none-any.whl", hash = "sha256:a163dcaede0f1c021485e957a39245190e74249897e2ae4b2aa38595db237ee0", size = 29575, upload-time = "2021-05-16T22:03:41.177Z" },
+]
+
+[[package]]
+name = "soupsieve"
+version = "2.8.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/47/2c/0a5f6f8ee0d5589e48c7640213ed5175d52cf540a06725b628cc1a45d6ce/soupsieve-2.8.4.tar.gz", hash = "sha256:e121fd02e975c695e4e9e8774a5ee35d74714b59307868dcc5319ad2d9e3328e", size = 121110, upload-time = "2026-05-24T13:55:57.154Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5e/f5/0c41cb68dcae6b7de4fac4188a3a9589e21fb31df21ea3a2e888db95e6c9/soupsieve-2.8.4-py3-none-any.whl", hash = "sha256:e7e6b0769c8f51ed59acab6e994b00621096cfb1c640a7509295987388fbaf65", size = 37304, upload-time = "2026-05-24T13:55:55.406Z" },
 ]
 
 [[package]]
@@ -1416,6 +6514,98 @@ wheels = [
 ]
 
 [[package]]
+name = "tiktoken"
+version = "0.13.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "regex" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e4/e5/5f3cb2159769d0f4324c0e9e87f9de3c4b1cd45848a96b2eb3566ad5ca77/tiktoken-0.13.0.tar.gz", hash = "sha256:c9435714c3a84c2319499de9a300c0e604449dd0799ff246458b3bb6a7f433c1", size = 38986, upload-time = "2026-05-15T04:51:27.153Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/85/8e/144bde4e01df66b34bb865557c7cd754ed08b036217ebd79c9db5e9048a9/tiktoken-0.13.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:32ac870a806cfb260a02d0cb70426aef02e038297f8ad50df5040bb5af360791", size = 1034888, upload-time = "2026-05-15T04:50:31.579Z" },
+    { url = "https://files.pythonhosted.org/packages/36/18/d4ac9d20956cdebca04841316660ed584c2fecdc2b81722a28bc7ad3b1e4/tiktoken-0.13.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:4d9980f11429ed2d737c463bb1fb78cf330caa026adf002f714aced7849a687b", size = 982970, upload-time = "2026-05-15T04:50:32.961Z" },
+    { url = "https://files.pythonhosted.org/packages/74/ed/6bb8d05b9f731f749fee5c6f5ca63e981143c826a5985877330507bd13b7/tiktoken-0.13.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:3f277ebea5edd7b8bf03c6f9431e1d67d517530115572b2dc1d465326e8f88c7", size = 1115741, upload-time = "2026-05-15T04:50:34.475Z" },
+    { url = "https://files.pythonhosted.org/packages/34/de/2ca96b07a82d972b74fe4b46de055b79c904e45c7eab699354a0bfa697dc/tiktoken-0.13.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:a116178fa7e1b4065bff05214360373a65cac22f965be7b3f73d00a0dbfe7649", size = 1136523, upload-time = "2026-05-15T04:50:35.782Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/dc/9dafec002c2d4424378563cf4cf5c7fb93631d2a55013c8b87554ee4012c/tiktoken-0.13.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:2c397ddda233208345b01bd30f2fca79ff730e55731d0108a603f9bc57f6af3b", size = 1181954, upload-time = "2026-05-15T04:50:36.99Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/d0/1f8578c45b2f24759b46f0b50d31878c63c73e6bf0f2227e10ec5c5408dc/tiktoken-0.13.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:95097e4f89b06403976e498abf61a0ee73a7497e73fb599cb211d8197a054d91", size = 1240069, upload-time = "2026-05-15T04:50:38.221Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/90/28d7f154888610aa9237e541986beb62b479df29d193a5a0617dbb1514d0/tiktoken-0.13.0-cp312-cp312-win_amd64.whl", hash = "sha256:8f2d16e7a7c783ad81f36e457d046d1f1c8af70b22aec8a13238efe531977c41", size = 874748, upload-time = "2026-05-15T04:50:39.587Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/83/b096c859c2a47c11731bf2f5885f4028b809dfe2396582883eed9cae372f/tiktoken-0.13.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:5df5d1507bd245f1ccad4a074698240021239e455eb0bb4ced4e3d7181872154", size = 1034228, upload-time = "2026-05-15T04:50:40.988Z" },
+    { url = "https://files.pythonhosted.org/packages/53/61/c68e123b6d753e3fc2751e9b18e732c9d8bf1e1926762e736eee935d931c/tiktoken-0.13.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:8fe806a50664e83a6ffd56cbd1e4f5dcc6cd32a3e7538f70dc38b1a271384545", size = 982978, upload-time = "2026-05-15T04:50:42.195Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/8b/96cc178cc584e65d363134500f297790b06cd48cdeb1e8fcf7bbe60f4715/tiktoken-0.13.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:125bc05005e747f993a83dc67934249932d6e4209854452cd4c0b1d53fba3ba2", size = 1116355, upload-time = "2026-05-15T04:50:43.564Z" },
+    { url = "https://files.pythonhosted.org/packages/86/f5/bab735d2c72ea55404b295d02d092644eb5f7cc6205e34d35eb9abfb9ab2/tiktoken-0.13.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:5e6358911cab4adee6712da27d65573496a4f68cf8a2b5fca6a4ad10fc5748cf", size = 1135772, upload-time = "2026-05-15T04:50:44.782Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/b9/6de04ebdf904edfaad87788011b3735087a0c9ea671b9027e1e4e965e8c8/tiktoken-0.13.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:975cbd78d085d75d26b59660e262736dcaed1e35f8f142cd6291025c01d25486", size = 1182415, upload-time = "2026-05-15T04:50:46.422Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/9c/470a05f3b1caf038f44880e334d47ab674e0c80d514c66b375d14d5afa10/tiktoken-0.13.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:75ab9bc99fa020a4c283424590ecd7f3afd70c1c281cb3fa3192a6c3af9f9615", size = 1239879, upload-time = "2026-05-15T04:50:48.052Z" },
+    { url = "https://files.pythonhosted.org/packages/42/a6/c1936d16055436cb32e6c6128d68629622e00f4768562f55653752d34768/tiktoken-0.13.0-cp313-cp313-win_amd64.whl", hash = "sha256:6b1615f0ff71953d19729ceb18865429c185b0a23c5353f1bbca34a394bf60f7", size = 874829, upload-time = "2026-05-15T04:50:49.202Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/07/acb5992c3772b5a36284f742cfb7a5895aa4471d1848ac31464ad50d7fdf/tiktoken-0.13.0-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:6eb4a5bfbc6426938026b1a334e898ac53541360d62d8c689870160cc80abd67", size = 1033600, upload-time = "2026-05-15T04:50:50.4Z" },
+    { url = "https://files.pythonhosted.org/packages/14/e9/742e9aec30f59b9f161f7ff7cd072e02ea836c9e1c0854a8076dfcd40d5c/tiktoken-0.13.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:43cee3e5400573b2046fbf092cc7a5bc30164f9e4c95ce20714da929df48737a", size = 982516, upload-time = "2026-05-15T04:50:52.03Z" },
+    { url = "https://files.pythonhosted.org/packages/72/74/ca1541b053e7648254d2e4b42a253e1bb4359f2c91a0a8d49228c794e1a0/tiktoken-0.13.0-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:7de52e3f566d19b3b11bd37eea552c6c305ad74081f736882bd44d148ed4c48d", size = 1115518, upload-time = "2026-05-15T04:50:53.543Z" },
+    { url = "https://files.pythonhosted.org/packages/46/e3/93825eaf5a4a504795b787e5d5dea07fbeb3dabf97aa7b450be8bde59c89/tiktoken-0.13.0-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:51384448aa508e4df84c0f7c1dc3211c7f7b8096325660ee5fc82f3e11b381ce", size = 1136867, upload-time = "2026-05-15T04:50:55.191Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/46/002b68de6827091d5ae90b048f326e8aad8d953520950e5ce1508879414f/tiktoken-0.13.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:e28157350f7ebf35008dd8e9e0fdb621f976e4230c881099c85e8cf07eaa50e2", size = 1181826, upload-time = "2026-05-15T04:50:56.296Z" },
+    { url = "https://files.pythonhosted.org/packages/db/c6/d393e3185a276505182f7abd93fe714f3c444a2be9180798fa052347504e/tiktoken-0.13.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:165cf1820ea4a354985c2490a5205d4cc74661c934aca79dd0368232fff94e0f", size = 1239489, upload-time = "2026-05-15T04:50:57.918Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/4d/bc07d1f1635d4897a202acc0ae11c2886eaa7325c359ba4741b47bf8e225/tiktoken-0.13.0-cp313-cp313t-win_amd64.whl", hash = "sha256:6c43a675ca14f6f2749ba7f12075d37456015a24b859f2517b9beb4ef30807ec", size = 873820, upload-time = "2026-05-15T04:50:59.528Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/93/0dd6adca026a616c3a92974566b43381eea4b475ce1f36c062b8271a9ac5/tiktoken-0.13.0-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:eaaaef47c2406277181d2086484c317bf7fc433e2d5d03ff94f56b0dcec87471", size = 1034977, upload-time = "2026-05-15T04:51:00.957Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/77/5ec6e6bc5b30bed6d93f7f2162d8f6b32437b3ba27cb527cfe004f6109c9/tiktoken-0.13.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:ca8b310bd93b3772cb1b7922d915446864860f562bdfe4825c63a0aed3fb28cd", size = 983635, upload-time = "2026-05-15T04:51:02.629Z" },
+    { url = "https://files.pythonhosted.org/packages/94/b0/c8ae9aff00d625c50659b4513e707a0462c4bf5d4d6cc1b802103225c02e/tiktoken-0.13.0-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:32e0c12305105002c047b3bb1070b0dd9a73b0cb3b2856a8972b810e7a4f5881", size = 1116036, upload-time = "2026-05-15T04:51:04.082Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/ac/6a5dddd1d0a6018ecb389bd0353e6b4a515eb4d2286611bd0ace1937b9e1/tiktoken-0.13.0-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:5ba5fd62507a932d1241346179e3b39bc7bf7408f03c272652d93b3bedf5db24", size = 1135544, upload-time = "2026-05-15T04:51:05.229Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/b8/585032b4384b2f7dcdaddcb52865c83a701a420d09e3c2b4a2be1c450c57/tiktoken-0.13.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:d108bc2d470fc53c8ecd24f2c0fd2b5f98c33e87cdb6aa2e9b8c5dced703d273", size = 1182217, upload-time = "2026-05-15T04:51:06.517Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/b6/993ff1ded3958215fd341a847b8e5ffeb5de473f435296870d314fc91ac4/tiktoken-0.13.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:cb99cb5127449f58d0a2d5f5ccfb390d8dbdfd919c221246caaee29d8725ed51", size = 1239404, upload-time = "2026-05-15T04:51:07.843Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/3d/fef7e06e3b33e7538db0ced734cf9fe23b6832d2ac4990c119c377aec55e/tiktoken-0.13.0-cp314-cp314-win_amd64.whl", hash = "sha256:115c4f26ffa11caac8b54eea35c2ad38c612c20a48d35dd15d70a02ac6f51f58", size = 918686, upload-time = "2026-05-15T04:51:08.925Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/82/a7fc44582bc32ab00de988a2299bf77c077f59068b233109e34b7d6ca7e6/tiktoken-0.13.0-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:472527e9132952f2fbf77cd290658bacf003d4d5a3fabc18e5fbd407cbae4d9b", size = 1034454, upload-time = "2026-05-15T04:51:10.035Z" },
+    { url = "https://files.pythonhosted.org/packages/37/d0/24d8a890c14f432a05cea669c17bebeaa99f96a7c79523b590f564246411/tiktoken-0.13.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:4e2f67d27c9626cdd25fe33d9313c5cdb3d8d82da646b68d6eb8e7e9c20e6448", size = 982976, upload-time = "2026-05-15T04:51:11.23Z" },
+    { url = "https://files.pythonhosted.org/packages/49/b7/2ab43f62788a9266187a9bfc1d3af99ad83e5eaa25fbef168a69cd5ad14f/tiktoken-0.13.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:2b920b35805cd64585a37c3dc7ce65fba4d2d36016be01e1d7942482ca29093a", size = 1115526, upload-time = "2026-05-15T04:51:12.608Z" },
+    { url = "https://files.pythonhosted.org/packages/64/39/1494321ed323ce7a14d88e3cd6cb9058625977df1c6961ddc492bd10a9f3/tiktoken-0.13.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:493af3aa28a4aaf2e3d2600a2ee717252c9bf5ab38fff94eb5a02db5ab77e5ad", size = 1136466, upload-time = "2026-05-15T04:51:13.926Z" },
+    { url = "https://files.pythonhosted.org/packages/96/d9/dfd086aa2d918c563a140720e0ce296cada1634efd2783d5cf51e05f984e/tiktoken-0.13.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:6644c9c2b5cf3916f5a3641d7d12fdb3f006a7b3d9ff6acdaec44e29ab1ff91e", size = 1181863, upload-time = "2026-05-15T04:51:15.025Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/68/a18b4f307086954fdae32714cb4f85562e34f9d34ab206e61f1816aa6018/tiktoken-0.13.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:5cb65b60b9408563676d874a3a4ee573370066f0dc4e29d84e82e989c6517424", size = 1239218, upload-time = "2026-05-15T04:51:16.103Z" },
+    { url = "https://files.pythonhosted.org/packages/16/5b/f2aa703a4fc5d2dff73460a7d46cc2f3f44aa0f3dd8eeb20d2a0ecf68862/tiktoken-0.13.0-cp314-cp314t-win_amd64.whl", hash = "sha256:85b78cc3a2c3d48723ca751fa981f1fedccd54194ca0471b957364353a898b07", size = 918110, upload-time = "2026-05-15T04:51:17.237Z" },
+]
+
+[[package]]
+name = "tokenizers"
+version = "0.23.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "huggingface-hub" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c1/60/21f715d9faba5f5407ff759472ade058ec4a507ad62bcea47cb847239a73/tokenizers-0.23.1.tar.gz", hash = "sha256:1feeeadf865a7915adc25445dea30e9933e593c31bb96c277cee36de227c8bfa", size = 365748, upload-time = "2026-04-27T14:43:25.606Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/87/39/b87a87d5bb9470610b80a2d31df42fcffeaf35118b8b97952b2aff598cc7/tokenizers-0.23.1-cp310-abi3-macosx_10_12_x86_64.whl", hash = "sha256:e03d6ffcbe0d56ee9c1ccd070e70a13fa750727c0277e138152acbc0252c2224", size = 3146732, upload-time = "2026-04-27T14:43:15.427Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/6a/068ed9f6e444c9d7e9d55ce134181325700f3d7f30410721bdc8f848d727/tokenizers-0.23.1-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:e0948bbb1ac1d7cdfc9fb6d62c596e3b7550036ad60ecd654a66ad273326324e", size = 3054954, upload-time = "2026-04-27T14:43:13.745Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/36/e006edf031154cba92b8416057d92c3abe3635e4c4b0aa0b5b9bb39dde70/tokenizers-0.23.1-cp310-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1bf13402aff9bc533c89cb849ec3b412dc3fbeacc9744840e423d7bf3f7dc0e3", size = 3374081, upload-time = "2026-04-27T14:43:01.241Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/ef/7735d226f9c7f874a6bee5e3f27fb25ecabdf207d37b8cf45286d0795893/tokenizers-0.23.1-cp310-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:f836ca703b89ae07919a309f9651f7a88fd5a33d5f718ba5ad0870ec0256bad6", size = 3247641, upload-time = "2026-04-27T14:43:03.856Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/d9/24827036f6e21297bfffda0768e58eb6096a4f411e932964a01707857931/tokenizers-0.23.1-cp310-abi3-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:ae848657742035523fdf261773630cb819a26995fcd3d9ecae0c1daf6e5a4959", size = 3585624, upload-time = "2026-04-27T14:43:10.664Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/9a/22f3582b3a4f49358293a5206e25317621ee4526bfe9cdaa0f07a12e770e/tokenizers-0.23.1-cp310-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:53b09e85775d5187941e7bab30e941b4134ab4a7dd8c68e783d231fb7ca27c51", size = 3844062, upload-time = "2026-04-27T14:43:05.643Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/65/b8f8814eef95800f20721384136d9a1d22241d50b2874357cb70542c392f/tokenizers-0.23.1-cp310-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:ea5a0ce170074329faaa8ea3f6400ecde604b6678192688533af80980daae71a", size = 3460098, upload-time = "2026-04-27T14:43:08.854Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/d5/1353e5f677ec27c2494fb6a6725e82d56c985f53e90ec511369e7e4f02c6/tokenizers-0.23.1-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5075b405006415ea148a992d093699c66eb01952bf59f4d5727089a98bda45a4", size = 3346235, upload-time = "2026-04-27T14:43:12.377Z" },
+    { url = "https://files.pythonhosted.org/packages/71/89/39b6b8fc073fb6d413d0147aa333dc7eff7be65639ac9d19930a0b21bf33/tokenizers-0.23.1-cp310-abi3-manylinux_2_31_riscv64.whl", hash = "sha256:56f3a77de629917652f876294dc9fe6bad4a0c43bc229dc72e59bb23a0f4729a", size = 3426398, upload-time = "2026-04-27T14:43:07.264Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/80/127c854da64827e5b79264ce524993a90dddcb320e5cd42412c5c02f9e8a/tokenizers-0.23.1-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:9d10a6d957ef01896dc274e890eee27d41bd0e74ef31e60616f0fc311345184e", size = 9823279, upload-time = "2026-04-27T14:43:17.222Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/ba/44c2502feb1a058f096ddfb4e0996ef3225a01a388e1a9b094e91689fe93/tokenizers-0.23.1-cp310-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:1974288a609c343774f1b897c8b482c791ab17b75ab5c8c2b1737565c1d82288", size = 9644986, upload-time = "2026-04-27T14:43:19.45Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/c1/464019a9fb059870bfe4eebb4ba12208f3042035e258bf5e782906bd3847/tokenizers-0.23.1-cp310-abi3-musllinux_1_2_i686.whl", hash = "sha256:120468fb4c24faf0543c835a4fabafa4deb3f20a035c9b6e83d0b553a97615d4", size = 9976181, upload-time = "2026-04-27T14:43:21.463Z" },
+    { url = "https://files.pythonhosted.org/packages/79/94/3ac1432bda31626071e9b6a12709b97ae05131c804b94c8f3ac622c5da32/tokenizers-0.23.1-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:e3d8f40ea6268047de7046906326abed5134f27d4e8447b23763afe5808c8a96", size = 10113853, upload-time = "2026-04-27T14:43:23.617Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/dd/631b21433c771b1382535326f0eca80b9c9cee2e64961dd993bc9ac4669e/tokenizers-0.23.1-cp310-abi3-win32.whl", hash = "sha256:93120a930b919416da7cd10a2f606ac9919cc69cacae7980fa2140e277660948", size = 2536263, upload-time = "2026-04-27T14:43:29.888Z" },
+    { url = "https://files.pythonhosted.org/packages/97/c9/2553f72aaf65a2797d4229e37fa7fbe38ffbf3e32912d31bdd78b3323e59/tokenizers-0.23.1-cp310-abi3-win_amd64.whl", hash = "sha256:e7bfaf995c1bdbbd21d13539decb6650967013759318627d85daeb7881af16b7", size = 2798223, upload-time = "2026-04-27T14:43:28.51Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/2b/2be299bab55fc595e3d38567edb1a87f86e594842968fa9515a07bdcf422/tokenizers-0.23.1-cp310-abi3-win_arm64.whl", hash = "sha256:a26197957d8e4425dfba746315f3c425ea00cfa8367c5fbc4ec73447893dcea9", size = 2664127, upload-time = "2026-04-27T14:43:26.949Z" },
+]
+
+[[package]]
+name = "tom-swe"
+version = "1.0.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jinja2" },
+    { name = "json-repair" },
+    { name = "litellm" },
+    { name = "pydantic" },
+    { name = "python-dotenv" },
+    { name = "tiktoken" },
+    { name = "tqdm" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f7/61/418dc04c9657a77b5b79d7238974ace8616709cbf4109b3ffff3f883ff49/tom_swe-1.0.3.tar.gz", hash = "sha256:57c97d0104e563f15bd39edaf2aa6ac4c3e9444afd437fb92458700d22c6c0f5", size = 44509, upload-time = "2025-11-26T01:50:42.406Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0f/c6/112d1fbfa40fa86140ff02a648931710488993b73caf214dee4e2bf07179/tom_swe-1.0.3-py3-none-any.whl", hash = "sha256:7b1172b29eb5c8fb7f1975016e7b6a238511b9ac2a7a980bd400dcb4e29773f2", size = 54772, upload-time = "2025-11-26T01:50:40.862Z" },
+]
+
+[[package]]
 name = "tqdm"
 version = "4.67.3"
 source = { registry = "https://pypi.org/simple" }
@@ -1425,6 +6615,51 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/09/a9/6ba95a270c6f1fbcd8dac228323f2777d886cb206987444e4bce66338dd4/tqdm-4.67.3.tar.gz", hash = "sha256:7d825f03f89244ef73f1d4ce193cb1774a8179fd96f31d7e1dcde62092b960bb", size = 169598, upload-time = "2026-02-03T17:35:53.048Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/16/e1/3079a9ff9b8e11b846c6ac5c8b5bfb7ff225eee721825310c91b3b50304f/tqdm-4.67.3-py3-none-any.whl", hash = "sha256:ee1e4c0e59148062281c49d80b25b67771a127c85fc9676d3be5f243206826bf", size = 78374, upload-time = "2026-02-03T17:35:50.982Z" },
+]
+
+[[package]]
+name = "tree-sitter"
+version = "0.25.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/66/7c/0350cfc47faadc0d3cf7d8237a4e34032b3014ddf4a12ded9933e1648b55/tree-sitter-0.25.2.tar.gz", hash = "sha256:fe43c158555da46723b28b52e058ad444195afd1db3ca7720c59a254544e9c20", size = 177961, upload-time = "2025-09-25T17:37:59.751Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3c/9e/20c2a00a862f1c2897a436b17edb774e831b22218083b459d0d081c9db33/tree_sitter-0.25.2-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:ddabfff809ffc983fc9963455ba1cecc90295803e06e140a4c83e94c1fa3d960", size = 146941, upload-time = "2025-09-25T17:37:34.813Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/04/8512e2062e652a1016e840ce36ba1cc33258b0dcc4e500d8089b4054afec/tree_sitter-0.25.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:c0c0ab5f94938a23fe81928a21cc0fac44143133ccc4eb7eeb1b92f84748331c", size = 137699, upload-time = "2025-09-25T17:37:36.349Z" },
+    { url = "https://files.pythonhosted.org/packages/47/8a/d48c0414db19307b0fb3bb10d76a3a0cbe275bb293f145ee7fba2abd668e/tree_sitter-0.25.2-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:dd12d80d91d4114ca097626eb82714618dcdfacd6a5e0955216c6485c350ef99", size = 607125, upload-time = "2025-09-25T17:37:37.725Z" },
+    { url = "https://files.pythonhosted.org/packages/39/d1/b95f545e9fc5001b8a78636ef942a4e4e536580caa6a99e73dd0a02e87aa/tree_sitter-0.25.2-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b43a9e4c89d4d0839de27cd4d6902d33396de700e9ff4c5ab7631f277a85ead9", size = 635418, upload-time = "2025-09-25T17:37:38.922Z" },
+    { url = "https://files.pythonhosted.org/packages/de/4d/b734bde3fb6f3513a010fa91f1f2875442cdc0382d6a949005cd84563d8f/tree_sitter-0.25.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:fbb1706407c0e451c4f8cc016fec27d72d4b211fdd3173320b1ada7a6c74c3ac", size = 631250, upload-time = "2025-09-25T17:37:40.039Z" },
+    { url = "https://files.pythonhosted.org/packages/46/f2/5f654994f36d10c64d50a192239599fcae46677491c8dd53e7579c35a3e3/tree_sitter-0.25.2-cp312-cp312-win_amd64.whl", hash = "sha256:6d0302550bbe4620a5dc7649517c4409d74ef18558276ce758419cf09e578897", size = 127156, upload-time = "2025-09-25T17:37:41.132Z" },
+    { url = "https://files.pythonhosted.org/packages/67/23/148c468d410efcf0a9535272d81c258d840c27b34781d625f1f627e2e27d/tree_sitter-0.25.2-cp312-cp312-win_arm64.whl", hash = "sha256:0c8b6682cac77e37cfe5cf7ec388844957f48b7bd8d6321d0ca2d852994e10d5", size = 113984, upload-time = "2025-09-25T17:37:42.074Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/67/67492014ce32729b63d7ef318a19f9cfedd855d677de5773476caf771e96/tree_sitter-0.25.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:0628671f0de69bb279558ef6b640bcfc97864fe0026d840f872728a86cd6b6cd", size = 146926, upload-time = "2025-09-25T17:37:43.041Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/9c/a278b15e6b263e86c5e301c82a60923fa7c59d44f78d7a110a89a413e640/tree_sitter-0.25.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:f5ddcd3e291a749b62521f71fc953f66f5fd9743973fd6dd962b092773569601", size = 137712, upload-time = "2025-09-25T17:37:44.039Z" },
+    { url = "https://files.pythonhosted.org/packages/54/9a/423bba15d2bf6473ba67846ba5244b988cd97a4b1ea2b146822162256794/tree_sitter-0.25.2-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:bd88fbb0f6c3a0f28f0a68d72df88e9755cf5215bae146f5a1bdc8362b772053", size = 607873, upload-time = "2025-09-25T17:37:45.477Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/4c/b430d2cb43f8badfb3a3fa9d6cd7c8247698187b5674008c9d67b2a90c8e/tree_sitter-0.25.2-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b878e296e63661c8e124177cc3084b041ba3f5936b43076d57c487822426f614", size = 636313, upload-time = "2025-09-25T17:37:46.68Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/27/5f97098dbba807331d666a0997662e82d066e84b17d92efab575d283822f/tree_sitter-0.25.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:d77605e0d353ba3fe5627e5490f0fbfe44141bafa4478d88ef7954a61a848dae", size = 631370, upload-time = "2025-09-25T17:37:47.993Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/3c/87caaed663fabc35e18dc704cd0e9800a0ee2f22bd18b9cbe7c10799895d/tree_sitter-0.25.2-cp313-cp313-win_amd64.whl", hash = "sha256:463c032bd02052d934daa5f45d183e0521ceb783c2548501cf034b0beba92c9b", size = 127157, upload-time = "2025-09-25T17:37:48.967Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/23/f8467b408b7988aff4ea40946a4bd1a2c1a73d17156a9d039bbaff1e2ceb/tree_sitter-0.25.2-cp313-cp313-win_arm64.whl", hash = "sha256:b3f63a1796886249bd22c559a5944d64d05d43f2be72961624278eff0dcc5cb8", size = 113975, upload-time = "2025-09-25T17:37:49.922Z" },
+    { url = "https://files.pythonhosted.org/packages/07/e3/d9526ba71dfbbe4eba5e51d89432b4b333a49a1e70712aa5590cd22fc74f/tree_sitter-0.25.2-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:65d3c931013ea798b502782acab986bbf47ba2c452610ab0776cf4a8ef150fc0", size = 146776, upload-time = "2025-09-25T17:37:50.898Z" },
+    { url = "https://files.pythonhosted.org/packages/42/97/4bd4ad97f85a23011dd8a535534bb1035c4e0bac1234d58f438e15cff51f/tree_sitter-0.25.2-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:bda059af9d621918efb813b22fb06b3fe00c3e94079c6143fcb2c565eb44cb87", size = 137732, upload-time = "2025-09-25T17:37:51.877Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/19/1e968aa0b1b567988ed522f836498a6a9529a74aab15f09dd9ac1e41f505/tree_sitter-0.25.2-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:eac4e8e4c7060c75f395feec46421eb61212cb73998dbe004b7384724f3682ab", size = 609456, upload-time = "2025-09-25T17:37:52.925Z" },
+    { url = "https://files.pythonhosted.org/packages/48/b6/cf08f4f20f4c9094006ef8828555484e842fc468827ad6e56011ab668dbd/tree_sitter-0.25.2-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:260586381b23be33b6191a07cea3d44ecbd6c01aa4c6b027a0439145fcbc3358", size = 636772, upload-time = "2025-09-25T17:37:54.647Z" },
+    { url = "https://files.pythonhosted.org/packages/57/e2/d42d55bf56360987c32bc7b16adb06744e425670b823fb8a5786a1cea991/tree_sitter-0.25.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:7d2ee1acbacebe50ba0f85fff1bc05e65d877958f00880f49f9b2af38dce1af0", size = 631522, upload-time = "2025-09-25T17:37:55.833Z" },
+    { url = "https://files.pythonhosted.org/packages/03/87/af9604ebe275a9345d88c3ace0cf2a1341aa3f8ef49dd9fc11662132df8a/tree_sitter-0.25.2-cp314-cp314-win_amd64.whl", hash = "sha256:4973b718fcadfb04e59e746abfbb0288694159c6aeecd2add59320c03368c721", size = 130864, upload-time = "2025-09-25T17:37:57.453Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/6e/e64621037357acb83d912276ffd30a859ef117f9c680f2e3cb955f47c680/tree_sitter-0.25.2-cp314-cp314-win_arm64.whl", hash = "sha256:b8d4429954a3beb3e844e2872610d2a4800ba4eb42bb1990c6a4b1949b18459f", size = 117470, upload-time = "2025-09-25T17:37:58.431Z" },
+]
+
+[[package]]
+name = "tree-sitter-bash"
+version = "0.25.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8e/0e/f0108be910f1eef6499eabce517e79fe3b12057280ed398da67ce2426cba/tree_sitter_bash-0.25.1.tar.gz", hash = "sha256:bfc0bdaa77bc1e86e3c6652e5a6e140c40c0a16b84185c2b63ad7cd809b88f14", size = 419703, upload-time = "2025-12-02T17:01:08.849Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/30/8e/37e7364d9c9c58da89e05c510671d8c45818afd7b31c6939ab72f8dc6c04/tree_sitter_bash-0.25.1-cp310-abi3-macosx_10_9_x86_64.whl", hash = "sha256:0e6235f59e366d220dde7d830196bed597d01e853e44d8ccd1a82c5dd2500acf", size = 194160, upload-time = "2025-12-02T17:00:59.047Z" },
+    { url = "https://files.pythonhosted.org/packages/23/bb/2d2cfbb1f89aaeb1ec892624f069d92d058d06bb66f16b9ec9fb5873ab60/tree_sitter_bash-0.25.1-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:f4a34a6504c7c5b2a9b8c5c4065531dea19ca2c35026e706cf2eeeebe2c92512", size = 202659, upload-time = "2025-12-02T17:01:00.275Z" },
+    { url = "https://files.pythonhosted.org/packages/25/f0/1bb25519be27460255d3899db677313cfa1e6306988fbf456a3d7e211bbb/tree_sitter_bash-0.25.1-cp310-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e76c4cfb20b076552406782b7f8c2a3946835993df0a44df006de54b7030c7dc", size = 230596, upload-time = "2025-12-02T17:01:01.759Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/22/9f70bc3d3b942ab9fc0f89c1dc9e087519a3a94f64ae6b7377aae3a7a0f0/tree_sitter_bash-0.25.1-cp310-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3f484c4bb8796cde7a87ca351e6116f09653edac0eb3c6d238566359dd28b117", size = 231981, upload-time = "2025-12-02T17:01:02.859Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/c3/f1540e42cd41b323c6821e45e52e1aed6ed386209aad52db996f05703963/tree_sitter_bash-0.25.1-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:5e76af6df46d958c7f5b6d5884c9743218e3902a00ccb493ec92728b1084430b", size = 228364, upload-time = "2025-12-02T17:01:03.997Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/a0/c3050a6277dfcac8c480f514dc4fe49f3f65f0eac68b4702cbaca2584e85/tree_sitter_bash-0.25.1-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:a3332d71c7b7d5f78259b19d02d0ea111fcb82b72712ee4a93aaa5b226d3f0a8", size = 230074, upload-time = "2025-12-02T17:01:05.05Z" },
+    { url = "https://files.pythonhosted.org/packages/71/0f/203fe6b27211387f4b9ba8c4a321567ca4ded2624dae6ccdbd2b6e940e17/tree_sitter_bash-0.25.1-cp310-abi3-win_amd64.whl", hash = "sha256:52a6802d9218f86278aa3e8b459c3abdad67eed0fde1f9f13aca5b6c634217a6", size = 195574, upload-time = "2025-12-02T17:01:06.412Z" },
+    { url = "https://files.pythonhosted.org/packages/47/75/4ca1a9fabd8fb5aea78cea70f7837ce4dbf2afae115f62051e5fa99cba1c/tree_sitter_bash-0.25.1-cp310-abi3-win_arm64.whl", hash = "sha256:59115057ec2bae319e8082ff29559861045002964c3431ccb0fc92aa4bc9bccb", size = 191196, upload-time = "2025-12-02T17:01:07.486Z" },
 ]
 
 [[package]]
@@ -1464,6 +6699,24 @@ wheels = [
 ]
 
 [[package]]
+name = "uncalled-for"
+version = "0.3.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b5/82/345cc927f7fbdae6065e7768759932fcc827fc20b29b45dfbafa2f1f7da4/uncalled_for-0.3.2.tar.gz", hash = "sha256:89f5dbcd71e2b8f47c030b1fa302e6cce2ec795d1ac565eeb6525c5fe55cb8a2", size = 50032, upload-time = "2026-05-06T13:38:25.204Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3b/25/2c87754f3a9e692315f7b811244090e68f362979fc8886b3fbd2985a1d8c/uncalled_for-0.3.2-py3-none-any.whl", hash = "sha256:0ff60b142c7d1f8070bde9d42afaa70aedc77dcc10998c227687e9c15713418e", size = 11444, upload-time = "2026-05-06T13:38:24.025Z" },
+]
+
+[[package]]
+name = "uritemplate"
+version = "4.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/98/60/f174043244c5306c9988380d2cb10009f91563fc4b31293d27e17201af56/uritemplate-4.2.0.tar.gz", hash = "sha256:480c2ed180878955863323eea31b0ede668795de182617fef9c6ca09e6ec9d0e", size = 33267, upload-time = "2025-06-02T15:12:06.318Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a9/99/3ae339466c9183ea5b8ae87b34c0b897eda475d2aec2307cae60e5cd4f29/uritemplate-4.2.0-py3-none-any.whl", hash = "sha256:962201ba1c4edcab02e60f9a0d3821e82dfc5d2d6662a21abd533879bdb8a686", size = 11488, upload-time = "2025-06-02T15:12:03.405Z" },
+]
+
+[[package]]
 name = "urllib3"
 version = "2.7.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1478,20 +6731,6 @@ version = "0.15.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/0b/f6/1856dc5935a947a062fb8fefd8a26e0f9f6694320e7203c7e85bd291dc93/uuid_utils-0.15.0.tar.gz", hash = "sha256:f182733e3d88edd2ceeca292627e2b1d5fa8693abe00b160de5517616ed399ea", size = 42182, upload-time = "2026-05-11T12:07:01.82Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/15/d8/06ebb55d495ce27a0647942c24fc699b7beab953338fa516029fd31e466f/uuid_utils-0.15.0-cp311-cp311-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:62fd9267b40d82e2d9d148f560e86436f5b2daa9a1623c329ed0ec7e61fefc4d", size = 564112, upload-time = "2026-05-11T12:08:46.093Z" },
-    { url = "https://files.pythonhosted.org/packages/f0/72/6b34c1ee02e50f74bb8d92660b5fae1b87a13ada868c62b8621ec1c7fe5d/uuid_utils-0.15.0-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:93b30c7bcb148fa23497779ac53dfe34a0de6f53e300f6d585ac759e9e6718ef", size = 289704, upload-time = "2026-05-11T12:06:26.263Z" },
-    { url = "https://files.pythonhosted.org/packages/bd/d5/f2b167910bd9043a6a110db4b1d2c0d2c41c5c11bc6e59a945f3955d97d2/uuid_utils-0.15.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:dc391e241f9b3d98901c5ada27546ddb49b71f1ad2f9dfe41cd91d6d69d84156", size = 327011, upload-time = "2026-05-11T12:07:14.199Z" },
-    { url = "https://files.pythonhosted.org/packages/8e/fc/057c41b224c330680325b1d3b5f7acda96ebcd0e104bc6bdcb9c2969da35/uuid_utils-0.15.0-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:072bacb159ded3c2c4c5b1b23191c72cb0906937816561fd6b71e8ab6612394e", size = 333546, upload-time = "2026-05-11T12:07:42.64Z" },
-    { url = "https://files.pythonhosted.org/packages/cf/24/297a7c112a312173f0f960f64214db633ba8b22c95cb78f490902072dccd/uuid_utils-0.15.0-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:c97357517e59bf767c7e0d13e9fe02c26f241b4ebf297c7479b100fea277c0b2", size = 447716, upload-time = "2026-05-11T12:06:58.739Z" },
-    { url = "https://files.pythonhosted.org/packages/f0/64/e4face9cb91260587b0193bb81ba058f476204a9a7d1ca754d31e414fc92/uuid_utils-0.15.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8399dd0dcfcb57db99090dae944644ba23151c57497226585f94926af9d93ae7", size = 326500, upload-time = "2026-05-11T12:08:24.14Z" },
-    { url = "https://files.pythonhosted.org/packages/c1/2a/d6bf1469889348aedaf65d8a71dbba8c2132539840b866c66a7a6cd7b987/uuid_utils-0.15.0-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:d3d1a1ede7d85f80cbad381f8a09467f083b3bd9978f3daa32cc8b6f09cdc3fe", size = 352092, upload-time = "2026-05-11T12:06:53.295Z" },
-    { url = "https://files.pythonhosted.org/packages/ad/4d/96970e4597c82eecc24f13bf1892abe299fa3d381d628a4854cd4259591b/uuid_utils-0.15.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:51c66955aeee2c284fb8cc5181e64587a63748e9835405de4b88f333f70a06fa", size = 503708, upload-time = "2026-05-11T12:08:13.232Z" },
-    { url = "https://files.pythonhosted.org/packages/74/9a/42e593d97980a7819621f79953d0e477b421f2f00d698815ee5fd73643fb/uuid_utils-0.15.0-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:05777b4e9a15b43707fba9789581bc39803172e7865e7c7932faf3e2f4299a4e", size = 608745, upload-time = "2026-05-11T12:08:06.097Z" },
-    { url = "https://files.pythonhosted.org/packages/b3/2f/45377b749ce7e052dbd9b47d29fea3b465aff8bcb486e591d895c119819c/uuid_utils-0.15.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:ab7a1bf10777953c375e8525bd7070072566c8b247ffc4d3c082dad5f1a66e86", size = 568216, upload-time = "2026-05-11T12:06:27.292Z" },
-    { url = "https://files.pythonhosted.org/packages/ab/8a/99104dd3af9609e494a62097328bf4f469797b8b1845258bfea68240b802/uuid_utils-0.15.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:c6435d27f2d541506590ea3db6ab92701bad24652678e1b6b2d8e48d8888152b", size = 531565, upload-time = "2026-05-11T12:08:09.985Z" },
-    { url = "https://files.pythonhosted.org/packages/db/58/ab984258b5213615a26a08b47b43b28245efa3cd4aeba159c48c8ba9e3af/uuid_utils-0.15.0-cp311-cp311-win32.whl", hash = "sha256:7d06408fb951d187677d1ec5adf9073c873d818704be502e2ece178685a68bbf", size = 169849, upload-time = "2026-05-11T12:06:28.808Z" },
-    { url = "https://files.pythonhosted.org/packages/c0/33/c40caf02a33f69a00de04d211ec58ffca191ed16d9a169a0441d0d2e4533/uuid_utils-0.15.0-cp311-cp311-win_amd64.whl", hash = "sha256:a8fb2aad5bb6256324de967bbf86f2227884586c3598a3e14fd5c339d3bfc20f", size = 175939, upload-time = "2026-05-11T12:08:32.376Z" },
-    { url = "https://files.pythonhosted.org/packages/a8/76/6b39fc4a9a0f425cb4ccf65ce872c64c12821f105e7e1ef2c02d3c19a403/uuid_utils-0.15.0-cp311-cp311-win_arm64.whl", hash = "sha256:d6b61e5f201535b525956817e3f8a09a90ec5b7d389b5a511b4f985427f23476", size = 174315, upload-time = "2026-05-11T12:07:40.271Z" },
     { url = "https://files.pythonhosted.org/packages/e5/1d/5869a54e85753078a532958d7fc27dbccb48f10f428498f5a77ae700be28/uuid_utils-0.15.0-cp312-cp312-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:2e68c9d2927ab3b79892f6f9d857cffdb2043be33044854b05a84634ffdad88b", size = 559609, upload-time = "2026-05-11T12:08:38.493Z" },
     { url = "https://files.pythonhosted.org/packages/f6/83/142a2ea23cca01609587b878c4a471ccec82dfab40e70fc1f463d98a618b/uuid_utils-0.15.0-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:bceb8aefc5c26ed896f93a36344ff476085f340d051a73074603426ef7588e4d", size = 288304, upload-time = "2026-05-11T12:07:47.94Z" },
     { url = "https://files.pythonhosted.org/packages/b2/78/8c75511cf355e749f9fb71c0a8e228e82b47efd9db1214daecb69db8bd07/uuid_utils-0.15.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:bfaab7ec64936ceae273ec195673acbee247d69525a2186159360d46d54819a0", size = 324652, upload-time = "2026-05-11T12:06:24.798Z" },
@@ -1562,14 +6801,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/27/8b/2eea5e55d8d2185527cc37e481a363b77ac893534bdda4b9e277cdd71aa1/uuid_utils-0.15.0-cp314-cp314t-win32.whl", hash = "sha256:30e7340f8b55f552a78d90eab2b2be6f68520c380215ddb7fb70a6d234ce154d", size = 168093, upload-time = "2026-05-11T12:06:33.548Z" },
     { url = "https://files.pythonhosted.org/packages/1e/e5/7524e94c316fc0194c3da1a91e51cce69722520e5fc499c4ece53007a967/uuid_utils-0.15.0-cp314-cp314t-win_amd64.whl", hash = "sha256:5ef6edbb10a4956755614e116aee4b558d75284b52dbedcf5f7505c518eb1011", size = 174063, upload-time = "2026-05-11T12:08:03.414Z" },
     { url = "https://files.pythonhosted.org/packages/d8/64/8be140712e3fa9d8406f0cb61876ce6d02f72067d4f9d31d1bf73e127c01/uuid_utils-0.15.0-cp314-cp314t-win_arm64.whl", hash = "sha256:b3f0e567b5e992b28a50f50e0aeba546a2e2d3e463590eb5543204cb5d0f40b3", size = 171358, upload-time = "2026-05-11T12:07:30.282Z" },
-    { url = "https://files.pythonhosted.org/packages/c1/a0/1e4a1833326627a2134fad5fb45ecc00b8638a83a99525e189dfa94b098e/uuid_utils-0.15.0-pp311-pypy311_pp73-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:81b8caec4b40925cbe2f0533af266cd9cd4485d94e48ecbb34663d5941c033aa", size = 566931, upload-time = "2026-05-11T12:07:35.687Z" },
-    { url = "https://files.pythonhosted.org/packages/ab/2f/5bf043f87df4bb1fdfa54acad9ab09fee40a3c47bfcf99911c3ba15e1599/uuid_utils-0.15.0-pp311-pypy311_pp73-macosx_10_12_x86_64.whl", hash = "sha256:e5763f07d99e2237742ebd0155ca18c1c8233de457c9e8e59bdc4d130895d15a", size = 291304, upload-time = "2026-05-11T12:07:58.421Z" },
-    { url = "https://files.pythonhosted.org/packages/20/2c/4316821fe2780eee11d277c9a3188b361fb1cabe52255e010b3b521efe68/uuid_utils-0.15.0-pp311-pypy311_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:90be3946ab215e180adb9827a90f9c63b6965af93b116c566f32e280bad6cccd", size = 327798, upload-time = "2026-05-11T12:08:02.35Z" },
-    { url = "https://files.pythonhosted.org/packages/3e/59/5340e801865d863aad50cc16e3e5f9e2e14806c12f76474721073b396b52/uuid_utils-0.15.0-pp311-pypy311_pp73-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:a1a02705b659a2b9874de0e2187f0c64277e14dae3299b392f0c46c762bd1144", size = 334131, upload-time = "2026-05-11T12:07:21.956Z" },
-    { url = "https://files.pythonhosted.org/packages/54/d7/0fa1443fbec25d7e8232324f7c9e4ac64390574cf7481608a15bd6eecc0d/uuid_utils-0.15.0-pp311-pypy311_pp73-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:39a05db4e66ae5fe39b1d328446cdc560c29073dbe00c7abfea3d7a02dce62a1", size = 448571, upload-time = "2026-05-11T12:08:08.868Z" },
-    { url = "https://files.pythonhosted.org/packages/ab/68/a0aedbf39885d7d6d3b3b419a796214fd3e92a7e6a556b336bfee2246fdc/uuid_utils-0.15.0-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2422feb60039ce88daf02b9885665b060f0d2deb80a3debffaaedc443d9aa673", size = 327546, upload-time = "2026-05-11T12:06:21.687Z" },
-    { url = "https://files.pythonhosted.org/packages/fd/1c/347970e5706f3b7fc1964227493aa98dd43c7348fe2a84a3aeb3f1b9299b/uuid_utils-0.15.0-pp311-pypy311_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:14481b7c98fbac536783d475b4d4cc7a4a21ec4f1ce794fc66557d3540b0c8b7", size = 354981, upload-time = "2026-05-11T12:07:26.505Z" },
-    { url = "https://files.pythonhosted.org/packages/08/13/5e2d92fe7d7b8df48b0c7c0ec714d828863227ee099e17caaa0d6ed23203/uuid_utils-0.15.0-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:21af6cc771a769e4a8ef9ab245f7ee811a56fbcdd021e1163d845172a9c01e60", size = 176805, upload-time = "2026-05-11T12:07:09.967Z" },
+]
+
+[[package]]
+name = "uuid7"
+version = "0.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5c/19/7472bd526591e2192926247109dbf78692e709d3e56775792fec877a7720/uuid7-0.1.0.tar.gz", hash = "sha256:8c57aa32ee7456d3cc68c95c4530bc571646defac01895cfc73545449894a63c", size = 14052, upload-time = "2021-12-29T01:38:21.897Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b5/77/8852f89a91453956582a85024d80ad96f30a41fed4c2b3dce0c9f12ecc7e/uuid7-0.1.0-py2.py3-none-any.whl", hash = "sha256:5e259bb63c8cb4aded5927ff41b444a80d0c7124e8a0ced7cf44efa1f5cccf61", size = 7477, upload-time = "2021-12-29T01:38:20.418Z" },
 ]
 
 [[package]]
@@ -1602,12 +6842,6 @@ version = "0.22.1"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/06/f0/18d39dbd1971d6d62c4629cc7fa67f74821b0dc1f5a77af43719de7936a7/uvloop-0.22.1.tar.gz", hash = "sha256:6c84bae345b9147082b17371e3dd5d42775bddce91f885499017f4607fdaf39f", size = 2443250, upload-time = "2025-10-16T22:17:19.342Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c7/d5/69900f7883235562f1f50d8184bb7dd84a2fb61e9ec63f3782546fdbd057/uvloop-0.22.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:c60ebcd36f7b240b30788554b6f0782454826a0ed765d8430652621b5de674b9", size = 1352420, upload-time = "2025-10-16T22:16:21.187Z" },
-    { url = "https://files.pythonhosted.org/packages/a8/73/c4e271b3bce59724e291465cc936c37758886a4868787da0278b3b56b905/uvloop-0.22.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:3b7f102bf3cb1995cfeaee9321105e8f5da76fdb104cdad8986f85461a1b7b77", size = 748677, upload-time = "2025-10-16T22:16:22.558Z" },
-    { url = "https://files.pythonhosted.org/packages/86/94/9fb7fad2f824d25f8ecac0d70b94d0d48107ad5ece03769a9c543444f78a/uvloop-0.22.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:53c85520781d84a4b8b230e24a5af5b0778efdb39142b424990ff1ef7c48ba21", size = 3753819, upload-time = "2025-10-16T22:16:23.903Z" },
-    { url = "https://files.pythonhosted.org/packages/74/4f/256aca690709e9b008b7108bc85fba619a2bc37c6d80743d18abad16ee09/uvloop-0.22.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:56a2d1fae65fd82197cb8c53c367310b3eabe1bbb9fb5a04d28e3e3520e4f702", size = 3804529, upload-time = "2025-10-16T22:16:25.246Z" },
-    { url = "https://files.pythonhosted.org/packages/7f/74/03c05ae4737e871923d21a76fe28b6aad57f5c03b6e6bfcfa5ad616013e4/uvloop-0.22.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:40631b049d5972c6755b06d0bfe8233b1bd9a8a6392d9d1c45c10b6f9e9b2733", size = 3621267, upload-time = "2025-10-16T22:16:26.819Z" },
-    { url = "https://files.pythonhosted.org/packages/75/be/f8e590fe61d18b4a92070905497aec4c0e64ae1761498cad09023f3f4b3e/uvloop-0.22.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:535cc37b3a04f6cd2c1ef65fa1d370c9a35b6695df735fcff5427323f2cd5473", size = 3723105, upload-time = "2025-10-16T22:16:28.252Z" },
     { url = "https://files.pythonhosted.org/packages/3d/ff/7f72e8170be527b4977b033239a83a68d5c881cc4775fca255c677f7ac5d/uvloop-0.22.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:fe94b4564e865d968414598eea1a6de60adba0c040ba4ed05ac1300de402cd42", size = 1359936, upload-time = "2025-10-16T22:16:29.436Z" },
     { url = "https://files.pythonhosted.org/packages/c3/c6/e5d433f88fd54d81ef4be58b2b7b0cea13c442454a1db703a1eea0db1a59/uvloop-0.22.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:51eb9bd88391483410daad430813d982010f9c9c89512321f5b60e2cddbdddd6", size = 752769, upload-time = "2025-10-16T22:16:30.493Z" },
     { url = "https://files.pythonhosted.org/packages/24/68/a6ac446820273e71aa762fa21cdcc09861edd3536ff47c5cd3b7afb10eeb/uvloop-0.22.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:700e674a166ca5778255e0e1dc4e9d79ab2acc57b9171b79e65feba7184b3370", size = 4317413, upload-time = "2025-10-16T22:16:31.644Z" },
@@ -1643,19 +6877,6 @@ dependencies = [
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/c2/c9/8869df9b2a2d6c59d79220a4db37679e74f807c559ffe5265e08b227a210/watchfiles-1.1.1.tar.gz", hash = "sha256:a173cb5c16c4f40ab19cecf48a534c409f7ea983ab8fed0741304a1c0a31b3f2", size = 94440, upload-time = "2025-10-14T15:06:21.08Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1f/f8/2c5f479fb531ce2f0564eda479faecf253d886b1ab3630a39b7bf7362d46/watchfiles-1.1.1-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:f57b396167a2565a4e8b5e56a5a1c537571733992b226f4f1197d79e94cf0ae5", size = 406529, upload-time = "2025-10-14T15:04:32.899Z" },
-    { url = "https://files.pythonhosted.org/packages/fe/cd/f515660b1f32f65df671ddf6f85bfaca621aee177712874dc30a97397977/watchfiles-1.1.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:421e29339983e1bebc281fab40d812742268ad057db4aee8c4d2bce0af43b741", size = 394384, upload-time = "2025-10-14T15:04:33.761Z" },
-    { url = "https://files.pythonhosted.org/packages/7b/c3/28b7dc99733eab43fca2d10f55c86e03bd6ab11ca31b802abac26b23d161/watchfiles-1.1.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6e43d39a741e972bab5d8100b5cdacf69db64e34eb19b6e9af162bccf63c5cc6", size = 448789, upload-time = "2025-10-14T15:04:34.679Z" },
-    { url = "https://files.pythonhosted.org/packages/4a/24/33e71113b320030011c8e4316ccca04194bf0cbbaeee207f00cbc7d6b9f5/watchfiles-1.1.1-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:f537afb3276d12814082a2e9b242bdcf416c2e8fd9f799a737990a1dbe906e5b", size = 460521, upload-time = "2025-10-14T15:04:35.963Z" },
-    { url = "https://files.pythonhosted.org/packages/f4/c3/3c9a55f255aa57b91579ae9e98c88704955fa9dac3e5614fb378291155df/watchfiles-1.1.1-cp311-cp311-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b2cd9e04277e756a2e2d2543d65d1e2166d6fd4c9b183f8808634fda23f17b14", size = 488722, upload-time = "2025-10-14T15:04:37.091Z" },
-    { url = "https://files.pythonhosted.org/packages/49/36/506447b73eb46c120169dc1717fe2eff07c234bb3232a7200b5f5bd816e9/watchfiles-1.1.1-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:5f3f58818dc0b07f7d9aa7fe9eb1037aecb9700e63e1f6acfed13e9fef648f5d", size = 596088, upload-time = "2025-10-14T15:04:38.39Z" },
-    { url = "https://files.pythonhosted.org/packages/82/ab/5f39e752a9838ec4d52e9b87c1e80f1ee3ccdbe92e183c15b6577ab9de16/watchfiles-1.1.1-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9bb9f66367023ae783551042d31b1d7fd422e8289eedd91f26754a66f44d5cff", size = 472923, upload-time = "2025-10-14T15:04:39.666Z" },
-    { url = "https://files.pythonhosted.org/packages/af/b9/a419292f05e302dea372fa7e6fda5178a92998411f8581b9830d28fb9edb/watchfiles-1.1.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:aebfd0861a83e6c3d1110b78ad54704486555246e542be3e2bb94195eabb2606", size = 456080, upload-time = "2025-10-14T15:04:40.643Z" },
-    { url = "https://files.pythonhosted.org/packages/b0/c3/d5932fd62bde1a30c36e10c409dc5d54506726f08cb3e1d8d0ba5e2bc8db/watchfiles-1.1.1-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:5fac835b4ab3c6487b5dbad78c4b3724e26bcc468e886f8ba8cc4306f68f6701", size = 629432, upload-time = "2025-10-14T15:04:41.789Z" },
-    { url = "https://files.pythonhosted.org/packages/f7/77/16bddd9779fafb795f1a94319dc965209c5641db5bf1edbbccace6d1b3c0/watchfiles-1.1.1-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:399600947b170270e80134ac854e21b3ccdefa11a9529a3decc1327088180f10", size = 623046, upload-time = "2025-10-14T15:04:42.718Z" },
-    { url = "https://files.pythonhosted.org/packages/46/ef/f2ecb9a0f342b4bfad13a2787155c6ee7ce792140eac63a34676a2feeef2/watchfiles-1.1.1-cp311-cp311-win32.whl", hash = "sha256:de6da501c883f58ad50db3a32ad397b09ad29865b5f26f64c24d3e3281685849", size = 271473, upload-time = "2025-10-14T15:04:43.624Z" },
-    { url = "https://files.pythonhosted.org/packages/94/bc/f42d71125f19731ea435c3948cad148d31a64fccde3867e5ba4edee901f9/watchfiles-1.1.1-cp311-cp311-win_amd64.whl", hash = "sha256:35c53bd62a0b885bf653ebf6b700d1bf05debb78ad9292cf2a942b23513dc4c4", size = 287598, upload-time = "2025-10-14T15:04:44.516Z" },
-    { url = "https://files.pythonhosted.org/packages/57/c9/a30f897351f95bbbfb6abcadafbaca711ce1162f4db95fc908c98a9165f3/watchfiles-1.1.1-cp311-cp311-win_arm64.whl", hash = "sha256:57ca5281a8b5e27593cb7d82c2ac927ad88a96ed406aa446f6344e4328208e9e", size = 277210, upload-time = "2025-10-14T15:04:45.883Z" },
     { url = "https://files.pythonhosted.org/packages/74/d5/f039e7e3c639d9b1d09b07ea412a6806d38123f0508e5f9b48a87b0a76cc/watchfiles-1.1.1-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:8c89f9f2f740a6b7dcc753140dd5e1ab9215966f7a3530d0c0705c83b401bd7d", size = 404745, upload-time = "2025-10-14T15:04:46.731Z" },
     { url = "https://files.pythonhosted.org/packages/a5/96/a881a13aa1349827490dab2d363c8039527060cfcc2c92cc6d13d1b1049e/watchfiles-1.1.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:bd404be08018c37350f0d6e34676bd1e2889990117a2b90070b3007f172d0610", size = 391769, upload-time = "2025-10-14T15:04:48.003Z" },
     { url = "https://files.pythonhosted.org/packages/4b/5b/d3b460364aeb8da471c1989238ea0e56bec24b6042a68046adf3d9ddb01c/watchfiles-1.1.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8526e8f916bb5b9a0a777c8317c23ce65de259422bba5b31325a6fa6029d33af", size = 449374, upload-time = "2025-10-14T15:04:49.179Z" },
@@ -1715,10 +6936,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/4f/55/2af26693fd15165c4ff7857e38330e1b61ab8c37d15dc79118cdba115b7a/watchfiles-1.1.1-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8c91ed27800188c2ae96d16e3149f199d62f86c7af5f5f4d2c61a3ed8cd3666c", size = 455072, upload-time = "2025-10-14T15:05:48.928Z" },
     { url = "https://files.pythonhosted.org/packages/66/1d/d0d200b10c9311ec25d2273f8aad8c3ef7cc7ea11808022501811208a750/watchfiles-1.1.1-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:311ff15a0bae3714ffb603e6ba6dbfba4065ab60865d15a6ec544133bdb21099", size = 629104, upload-time = "2025-10-14T15:05:49.908Z" },
     { url = "https://files.pythonhosted.org/packages/e3/bd/fa9bb053192491b3867ba07d2343d9f2252e00811567d30ae8d0f78136fe/watchfiles-1.1.1-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:a916a2932da8f8ab582f242c065f5c81bed3462849ca79ee357dd9551b0e9b01", size = 622112, upload-time = "2025-10-14T15:05:50.941Z" },
-    { url = "https://files.pythonhosted.org/packages/d3/8e/e500f8b0b77be4ff753ac94dc06b33d8f0d839377fee1b78e8c8d8f031bf/watchfiles-1.1.1-pp311-pypy311_pp73-macosx_10_12_x86_64.whl", hash = "sha256:db476ab59b6765134de1d4fe96a1a9c96ddf091683599be0f26147ea1b2e4b88", size = 408250, upload-time = "2025-10-14T15:06:10.264Z" },
-    { url = "https://files.pythonhosted.org/packages/bd/95/615e72cd27b85b61eec764a5ca51bd94d40b5adea5ff47567d9ebc4d275a/watchfiles-1.1.1-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:89eef07eee5e9d1fda06e38822ad167a044153457e6fd997f8a858ab7564a336", size = 396117, upload-time = "2025-10-14T15:06:11.28Z" },
-    { url = "https://files.pythonhosted.org/packages/c9/81/e7fe958ce8a7fb5c73cc9fb07f5aeaf755e6aa72498c57d760af760c91f8/watchfiles-1.1.1-pp311-pypy311_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ce19e06cbda693e9e7686358af9cd6f5d61312ab8b00488bc36f5aabbaf77e24", size = 450493, upload-time = "2025-10-14T15:06:12.321Z" },
-    { url = "https://files.pythonhosted.org/packages/6e/d4/ed38dd3b1767193de971e694aa544356e63353c33a85d948166b5ff58b9e/watchfiles-1.1.1-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3e6f39af2eab0118338902798b5aa6664f46ff66bc0280de76fca67a7f262a49", size = 457546, upload-time = "2025-10-14T15:06:13.372Z" },
+]
+
+[[package]]
+name = "wcwidth"
+version = "0.8.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/49/b4/51fe890511f0f242d07cb1ebe6a5b6db417262b9d2568b460347c57d95cc/wcwidth-0.8.1.tar.gz", hash = "sha256:faf5b4a5366a72dc49cad48cdf21f52bdf63bdda995178e483ba247ff79089b9", size = 1466072, upload-time = "2026-06-08T05:57:23.146Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bd/6e/95b0e537de1f4d4301f76f944642c6da50d1511cc7b3d64dc418a66c7509/wcwidth-0.8.1-py3-none-any.whl", hash = "sha256:f453740b1e4a4f3291faa37944c555d71056c4da08d59809b307ef4feba695c8", size = 323092, upload-time = "2026-06-08T05:57:21.413Z" },
 ]
 
 [[package]]
@@ -1727,15 +6953,6 @@ version = "16.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/04/24/4b2031d72e840ce4c1ccb255f693b15c334757fc50023e4db9537080b8c4/websockets-16.0.tar.gz", hash = "sha256:5f6261a5e56e8d5c42a4497b364ea24d94d9563e8fbd44e78ac40879c60179b5", size = 179346, upload-time = "2026-01-10T09:23:47.181Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f2/db/de907251b4ff46ae804ad0409809504153b3f30984daf82a1d84a9875830/websockets-16.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:31a52addea25187bde0797a97d6fc3d2f92b6f72a9370792d65a6e84615ac8a8", size = 177340, upload-time = "2026-01-10T09:22:34.539Z" },
-    { url = "https://files.pythonhosted.org/packages/f3/fa/abe89019d8d8815c8781e90d697dec52523fb8ebe308bf11664e8de1877e/websockets-16.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:417b28978cdccab24f46400586d128366313e8a96312e4b9362a4af504f3bbad", size = 175022, upload-time = "2026-01-10T09:22:36.332Z" },
-    { url = "https://files.pythonhosted.org/packages/58/5d/88ea17ed1ded2079358b40d31d48abe90a73c9e5819dbcde1606e991e2ad/websockets-16.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:af80d74d4edfa3cb9ed973a0a5ba2b2a549371f8a741e0800cb07becdd20f23d", size = 175319, upload-time = "2026-01-10T09:22:37.602Z" },
-    { url = "https://files.pythonhosted.org/packages/d2/ae/0ee92b33087a33632f37a635e11e1d99d429d3d323329675a6022312aac2/websockets-16.0-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:08d7af67b64d29823fed316505a89b86705f2b7981c07848fb5e3ea3020c1abe", size = 184631, upload-time = "2026-01-10T09:22:38.789Z" },
-    { url = "https://files.pythonhosted.org/packages/c8/c5/27178df583b6c5b31b29f526ba2da5e2f864ecc79c99dae630a85d68c304/websockets-16.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7be95cfb0a4dae143eaed2bcba8ac23f4892d8971311f1b06f3c6b78952ee70b", size = 185870, upload-time = "2026-01-10T09:22:39.893Z" },
-    { url = "https://files.pythonhosted.org/packages/87/05/536652aa84ddc1c018dbb7e2c4cbcd0db884580bf8e95aece7593fde526f/websockets-16.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:d6297ce39ce5c2e6feb13c1a996a2ded3b6832155fcfc920265c76f24c7cceb5", size = 185361, upload-time = "2026-01-10T09:22:41.016Z" },
-    { url = "https://files.pythonhosted.org/packages/6d/e2/d5332c90da12b1e01f06fb1b85c50cfc489783076547415bf9f0a659ec19/websockets-16.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:1c1b30e4f497b0b354057f3467f56244c603a79c0d1dafce1d16c283c25f6e64", size = 184615, upload-time = "2026-01-10T09:22:42.442Z" },
-    { url = "https://files.pythonhosted.org/packages/77/fb/d3f9576691cae9253b51555f841bc6600bf0a983a461c79500ace5a5b364/websockets-16.0-cp311-cp311-win32.whl", hash = "sha256:5f451484aeb5cafee1ccf789b1b66f535409d038c56966d6101740c1614b86c6", size = 178246, upload-time = "2026-01-10T09:22:43.654Z" },
-    { url = "https://files.pythonhosted.org/packages/54/67/eaff76b3dbaf18dcddabc3b8c1dba50b483761cccff67793897945b37408/websockets-16.0-cp311-cp311-win_amd64.whl", hash = "sha256:8d7f0659570eefb578dacde98e24fb60af35350193e4f56e11190787bee77dac", size = 178684, upload-time = "2026-01-10T09:22:44.941Z" },
     { url = "https://files.pythonhosted.org/packages/84/7b/bac442e6b96c9d25092695578dda82403c77936104b5682307bd4deb1ad4/websockets-16.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:71c989cbf3254fbd5e84d3bff31e4da39c43f884e64f2551d14bb3c186230f00", size = 177365, upload-time = "2026-01-10T09:22:46.787Z" },
     { url = "https://files.pythonhosted.org/packages/b0/fe/136ccece61bd690d9c1f715baaeefd953bb2360134de73519d5df19d29ca/websockets-16.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:8b6e209ffee39ff1b6d0fa7bfef6de950c60dfb91b8fcead17da4ee539121a79", size = 175038, upload-time = "2026-01-10T09:22:47.999Z" },
     { url = "https://files.pythonhosted.org/packages/40/1e/9771421ac2286eaab95b8575b0cb701ae3663abf8b5e1f64f1fd90d0a673/websockets-16.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:86890e837d61574c92a97496d590968b23c2ef0aeb8a9bc9421d174cd378ae39", size = 175328, upload-time = "2026-01-10T09:22:49.809Z" },
@@ -1772,12 +6989,56 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/88/a8/a080593f89b0138b6cba1b28f8df5673b5506f72879322288b031337c0b8/websockets-16.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:32da954ffa2814258030e5a57bc73a3635463238e797c7375dc8091327434206", size = 185356, upload-time = "2026-01-10T09:23:32.627Z" },
     { url = "https://files.pythonhosted.org/packages/c2/b6/b9afed2afadddaf5ebb2afa801abf4b0868f42f8539bfe4b071b5266c9fe/websockets-16.0-cp314-cp314t-win32.whl", hash = "sha256:5a4b4cc550cb665dd8a47f868c8d04c8230f857363ad3c9caf7a0c3bf8c61ca6", size = 178085, upload-time = "2026-01-10T09:23:33.816Z" },
     { url = "https://files.pythonhosted.org/packages/9f/3e/28135a24e384493fa804216b79a6a6759a38cc4ff59118787b9fb693df93/websockets-16.0-cp314-cp314t-win_amd64.whl", hash = "sha256:b14dc141ed6d2dde437cddb216004bcac6a1df0935d79656387bd41632ba0bbd", size = 178531, upload-time = "2026-01-10T09:23:35.016Z" },
-    { url = "https://files.pythonhosted.org/packages/72/07/c98a68571dcf256e74f1f816b8cc5eae6eb2d3d5cfa44d37f801619d9166/websockets-16.0-pp311-pypy311_pp73-macosx_10_15_x86_64.whl", hash = "sha256:349f83cd6c9a415428ee1005cadb5c2c56f4389bc06a9af16103c3bc3dcc8b7d", size = 174947, upload-time = "2026-01-10T09:23:36.166Z" },
-    { url = "https://files.pythonhosted.org/packages/7e/52/93e166a81e0305b33fe416338be92ae863563fe7bce446b0f687b9df5aea/websockets-16.0-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:4a1aba3340a8dca8db6eb5a7986157f52eb9e436b74813764241981ca4888f03", size = 175260, upload-time = "2026-01-10T09:23:37.409Z" },
-    { url = "https://files.pythonhosted.org/packages/56/0c/2dbf513bafd24889d33de2ff0368190a0e69f37bcfa19009ef819fe4d507/websockets-16.0-pp311-pypy311_pp73-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:f4a32d1bd841d4bcbffdcb3d2ce50c09c3909fbead375ab28d0181af89fd04da", size = 176071, upload-time = "2026-01-10T09:23:39.158Z" },
-    { url = "https://files.pythonhosted.org/packages/a5/8f/aea9c71cc92bf9b6cc0f7f70df8f0b420636b6c96ef4feee1e16f80f75dd/websockets-16.0-pp311-pypy311_pp73-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0298d07ee155e2e9fda5be8a9042200dd2e3bb0b8a38482156576f863a9d457c", size = 176968, upload-time = "2026-01-10T09:23:41.031Z" },
-    { url = "https://files.pythonhosted.org/packages/9a/3f/f70e03f40ffc9a30d817eef7da1be72ee4956ba8d7255c399a01b135902a/websockets-16.0-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:a653aea902e0324b52f1613332ddf50b00c06fdaf7e92624fbf8c77c78fa5767", size = 178735, upload-time = "2026-01-10T09:23:42.259Z" },
     { url = "https://files.pythonhosted.org/packages/6f/28/258ebab549c2bf3e64d2b0217b973467394a9cea8c42f70418ca2c5d0d2e/websockets-16.0-py3-none-any.whl", hash = "sha256:1637db62fad1dc833276dded54215f2c7fa46912301a24bd94d45d46a011ceec", size = 171598, upload-time = "2026-01-10T09:23:45.395Z" },
+]
+
+[[package]]
+name = "wrapt"
+version = "1.17.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/95/8f/aeb76c5b46e273670962298c23e7ddde79916cb74db802131d49a85e4b7d/wrapt-1.17.3.tar.gz", hash = "sha256:f66eb08feaa410fe4eebd17f2a2c8e2e46d3476e9f8c783daa8e09e0faa666d0", size = 55547, upload-time = "2025-08-12T05:53:21.714Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9f/41/cad1aba93e752f1f9268c77270da3c469883d56e2798e7df6240dcb2287b/wrapt-1.17.3-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:ab232e7fdb44cdfbf55fc3afa31bcdb0d8980b9b95c38b6405df2acb672af0e0", size = 53998, upload-time = "2025-08-12T05:51:47.138Z" },
+    { url = "https://files.pythonhosted.org/packages/60/f8/096a7cc13097a1869fe44efe68dace40d2a16ecb853141394047f0780b96/wrapt-1.17.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:9baa544e6acc91130e926e8c802a17f3b16fbea0fd441b5a60f5cf2cc5c3deba", size = 39020, upload-time = "2025-08-12T05:51:35.906Z" },
+    { url = "https://files.pythonhosted.org/packages/33/df/bdf864b8997aab4febb96a9ae5c124f700a5abd9b5e13d2a3214ec4be705/wrapt-1.17.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:6b538e31eca1a7ea4605e44f81a48aa24c4632a277431a6ed3f328835901f4fd", size = 39098, upload-time = "2025-08-12T05:51:57.474Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/81/5d931d78d0eb732b95dc3ddaeeb71c8bb572fb01356e9133916cd729ecdd/wrapt-1.17.3-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:042ec3bb8f319c147b1301f2393bc19dba6e176b7da446853406d041c36c7828", size = 88036, upload-time = "2025-08-12T05:52:34.784Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/38/2e1785df03b3d72d34fc6252d91d9d12dc27a5c89caef3335a1bbb8908ca/wrapt-1.17.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3af60380ba0b7b5aeb329bc4e402acd25bd877e98b3727b0135cb5c2efdaefe9", size = 88156, upload-time = "2025-08-12T05:52:13.599Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/8b/48cdb60fe0603e34e05cffda0b2a4adab81fd43718e11111a4b0100fd7c1/wrapt-1.17.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:0b02e424deef65c9f7326d8c19220a2c9040c51dc165cddb732f16198c168396", size = 87102, upload-time = "2025-08-12T05:52:14.56Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/51/d81abca783b58f40a154f1b2c56db1d2d9e0d04fa2d4224e357529f57a57/wrapt-1.17.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:74afa28374a3c3a11b3b5e5fca0ae03bef8450d6aa3ab3a1e2c30e3a75d023dc", size = 87732, upload-time = "2025-08-12T05:52:36.165Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/b1/43b286ca1392a006d5336412d41663eeef1ad57485f3e52c767376ba7e5a/wrapt-1.17.3-cp312-cp312-win32.whl", hash = "sha256:4da9f45279fff3543c371d5ababc57a0384f70be244de7759c85a7f989cb4ebe", size = 36705, upload-time = "2025-08-12T05:53:07.123Z" },
+    { url = "https://files.pythonhosted.org/packages/28/de/49493f962bd3c586ab4b88066e967aa2e0703d6ef2c43aa28cb83bf7b507/wrapt-1.17.3-cp312-cp312-win_amd64.whl", hash = "sha256:e71d5c6ebac14875668a1e90baf2ea0ef5b7ac7918355850c0908ae82bcb297c", size = 38877, upload-time = "2025-08-12T05:53:05.436Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/48/0f7102fe9cb1e8a5a77f80d4f0956d62d97034bbe88d33e94699f99d181d/wrapt-1.17.3-cp312-cp312-win_arm64.whl", hash = "sha256:604d076c55e2fdd4c1c03d06dc1a31b95130010517b5019db15365ec4a405fc6", size = 36885, upload-time = "2025-08-12T05:52:54.367Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/f6/759ece88472157acb55fc195e5b116e06730f1b651b5b314c66291729193/wrapt-1.17.3-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:a47681378a0439215912ef542c45a783484d4dd82bac412b71e59cf9c0e1cea0", size = 54003, upload-time = "2025-08-12T05:51:48.627Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/a9/49940b9dc6d47027dc850c116d79b4155f15c08547d04db0f07121499347/wrapt-1.17.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:54a30837587c6ee3cd1a4d1c2ec5d24e77984d44e2f34547e2323ddb4e22eb77", size = 39025, upload-time = "2025-08-12T05:51:37.156Z" },
+    { url = "https://files.pythonhosted.org/packages/45/35/6a08de0f2c96dcdd7fe464d7420ddb9a7655a6561150e5fc4da9356aeaab/wrapt-1.17.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:16ecf15d6af39246fe33e507105d67e4b81d8f8d2c6598ff7e3ca1b8a37213f7", size = 39108, upload-time = "2025-08-12T05:51:58.425Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/37/6faf15cfa41bf1f3dba80cd3f5ccc6622dfccb660ab26ed79f0178c7497f/wrapt-1.17.3-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:6fd1ad24dc235e4ab88cda009e19bf347aabb975e44fd5c2fb22a3f6e4141277", size = 88072, upload-time = "2025-08-12T05:52:37.53Z" },
+    { url = "https://files.pythonhosted.org/packages/78/f2/efe19ada4a38e4e15b6dff39c3e3f3f73f5decf901f66e6f72fe79623a06/wrapt-1.17.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0ed61b7c2d49cee3c027372df5809a59d60cf1b6c2f81ee980a091f3afed6a2d", size = 88214, upload-time = "2025-08-12T05:52:15.886Z" },
+    { url = "https://files.pythonhosted.org/packages/40/90/ca86701e9de1622b16e09689fc24b76f69b06bb0150990f6f4e8b0eeb576/wrapt-1.17.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:423ed5420ad5f5529db9ce89eac09c8a2f97da18eb1c870237e84c5a5c2d60aa", size = 87105, upload-time = "2025-08-12T05:52:17.914Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/e0/d10bd257c9a3e15cbf5523025252cc14d77468e8ed644aafb2d6f54cb95d/wrapt-1.17.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:e01375f275f010fcbf7f643b4279896d04e571889b8a5b3f848423d91bf07050", size = 87766, upload-time = "2025-08-12T05:52:39.243Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/cf/7d848740203c7b4b27eb55dbfede11aca974a51c3d894f6cc4b865f42f58/wrapt-1.17.3-cp313-cp313-win32.whl", hash = "sha256:53e5e39ff71b3fc484df8a522c933ea2b7cdd0d5d15ae82e5b23fde87d44cbd8", size = 36711, upload-time = "2025-08-12T05:53:10.074Z" },
+    { url = "https://files.pythonhosted.org/packages/57/54/35a84d0a4d23ea675994104e667ceff49227ce473ba6a59ba2c84f250b74/wrapt-1.17.3-cp313-cp313-win_amd64.whl", hash = "sha256:1f0b2f40cf341ee8cc1a97d51ff50dddb9fcc73241b9143ec74b30fc4f44f6cb", size = 38885, upload-time = "2025-08-12T05:53:08.695Z" },
+    { url = "https://files.pythonhosted.org/packages/01/77/66e54407c59d7b02a3c4e0af3783168fff8e5d61def52cda8728439d86bc/wrapt-1.17.3-cp313-cp313-win_arm64.whl", hash = "sha256:7425ac3c54430f5fc5e7b6f41d41e704db073309acfc09305816bc6a0b26bb16", size = 36896, upload-time = "2025-08-12T05:52:55.34Z" },
+    { url = "https://files.pythonhosted.org/packages/02/a2/cd864b2a14f20d14f4c496fab97802001560f9f41554eef6df201cd7f76c/wrapt-1.17.3-cp314-cp314-macosx_10_13_universal2.whl", hash = "sha256:cf30f6e3c077c8e6a9a7809c94551203c8843e74ba0c960f4a98cd80d4665d39", size = 54132, upload-time = "2025-08-12T05:51:49.864Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/46/d011725b0c89e853dc44cceb738a307cde5d240d023d6d40a82d1b4e1182/wrapt-1.17.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:e228514a06843cae89621384cfe3a80418f3c04aadf8a3b14e46a7be704e4235", size = 39091, upload-time = "2025-08-12T05:51:38.935Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/9e/3ad852d77c35aae7ddebdbc3b6d35ec8013af7d7dddad0ad911f3d891dae/wrapt-1.17.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:5ea5eb3c0c071862997d6f3e02af1d055f381b1d25b286b9d6644b79db77657c", size = 39172, upload-time = "2025-08-12T05:51:59.365Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/f7/c983d2762bcce2326c317c26a6a1e7016f7eb039c27cdf5c4e30f4160f31/wrapt-1.17.3-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:281262213373b6d5e4bb4353bc36d1ba4084e6d6b5d242863721ef2bf2c2930b", size = 87163, upload-time = "2025-08-12T05:52:40.965Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/0f/f673f75d489c7f22d17fe0193e84b41540d962f75fce579cf6873167c29b/wrapt-1.17.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:dc4a8d2b25efb6681ecacad42fca8859f88092d8732b170de6a5dddd80a1c8fa", size = 87963, upload-time = "2025-08-12T05:52:20.326Z" },
+    { url = "https://files.pythonhosted.org/packages/df/61/515ad6caca68995da2fac7a6af97faab8f78ebe3bf4f761e1b77efbc47b5/wrapt-1.17.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:373342dd05b1d07d752cecbec0c41817231f29f3a89aa8b8843f7b95992ed0c7", size = 86945, upload-time = "2025-08-12T05:52:21.581Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/bd/4e70162ce398462a467bc09e768bee112f1412e563620adc353de9055d33/wrapt-1.17.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:d40770d7c0fd5cbed9d84b2c3f2e156431a12c9a37dc6284060fb4bec0b7ffd4", size = 86857, upload-time = "2025-08-12T05:52:43.043Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/b8/da8560695e9284810b8d3df8a19396a6e40e7518059584a1a394a2b35e0a/wrapt-1.17.3-cp314-cp314-win32.whl", hash = "sha256:fbd3c8319de8e1dc79d346929cd71d523622da527cca14e0c1d257e31c2b8b10", size = 37178, upload-time = "2025-08-12T05:53:12.605Z" },
+    { url = "https://files.pythonhosted.org/packages/db/c8/b71eeb192c440d67a5a0449aaee2310a1a1e8eca41676046f99ed2487e9f/wrapt-1.17.3-cp314-cp314-win_amd64.whl", hash = "sha256:e1a4120ae5705f673727d3253de3ed0e016f7cd78dc463db1b31e2463e1f3cf6", size = 39310, upload-time = "2025-08-12T05:53:11.106Z" },
+    { url = "https://files.pythonhosted.org/packages/45/20/2cda20fd4865fa40f86f6c46ed37a2a8356a7a2fde0773269311f2af56c7/wrapt-1.17.3-cp314-cp314-win_arm64.whl", hash = "sha256:507553480670cab08a800b9463bdb881b2edeed77dc677b0a5915e6106e91a58", size = 37266, upload-time = "2025-08-12T05:52:56.531Z" },
+    { url = "https://files.pythonhosted.org/packages/77/ed/dd5cf21aec36c80443c6f900449260b80e2a65cf963668eaef3b9accce36/wrapt-1.17.3-cp314-cp314t-macosx_10_13_universal2.whl", hash = "sha256:ed7c635ae45cfbc1a7371f708727bf74690daedc49b4dba310590ca0bd28aa8a", size = 56544, upload-time = "2025-08-12T05:51:51.109Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/96/450c651cc753877ad100c7949ab4d2e2ecc4d97157e00fa8f45df682456a/wrapt-1.17.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:249f88ed15503f6492a71f01442abddd73856a0032ae860de6d75ca62eed8067", size = 40283, upload-time = "2025-08-12T05:51:39.912Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/86/2fcad95994d9b572db57632acb6f900695a648c3e063f2cd344b3f5c5a37/wrapt-1.17.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:5a03a38adec8066d5a37bea22f2ba6bbf39fcdefbe2d91419ab864c3fb515454", size = 40366, upload-time = "2025-08-12T05:52:00.693Z" },
+    { url = "https://files.pythonhosted.org/packages/64/0e/f4472f2fdde2d4617975144311f8800ef73677a159be7fe61fa50997d6c0/wrapt-1.17.3-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:5d4478d72eb61c36e5b446e375bbc49ed002430d17cdec3cecb36993398e1a9e", size = 108571, upload-time = "2025-08-12T05:52:44.521Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/01/9b85a99996b0a97c8a17484684f206cbb6ba73c1ce6890ac668bcf3838fb/wrapt-1.17.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:223db574bb38637e8230eb14b185565023ab624474df94d2af18f1cdb625216f", size = 113094, upload-time = "2025-08-12T05:52:22.618Z" },
+    { url = "https://files.pythonhosted.org/packages/25/02/78926c1efddcc7b3aa0bc3d6b33a822f7d898059f7cd9ace8c8318e559ef/wrapt-1.17.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e405adefb53a435f01efa7ccdec012c016b5a1d3f35459990afc39b6be4d5056", size = 110659, upload-time = "2025-08-12T05:52:24.057Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/ee/c414501ad518ac3e6fe184753632fe5e5ecacdcf0effc23f31c1e4f7bfcf/wrapt-1.17.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:88547535b787a6c9ce4086917b6e1d291aa8ed914fdd3a838b3539dc95c12804", size = 106946, upload-time = "2025-08-12T05:52:45.976Z" },
+    { url = "https://files.pythonhosted.org/packages/be/44/a1bd64b723d13bb151d6cc91b986146a1952385e0392a78567e12149c7b4/wrapt-1.17.3-cp314-cp314t-win32.whl", hash = "sha256:41b1d2bc74c2cac6f9074df52b2efbef2b30bdfe5f40cb78f8ca22963bc62977", size = 38717, upload-time = "2025-08-12T05:53:15.214Z" },
+    { url = "https://files.pythonhosted.org/packages/79/d9/7cfd5a312760ac4dd8bf0184a6ee9e43c33e47f3dadc303032ce012b8fa3/wrapt-1.17.3-cp314-cp314t-win_amd64.whl", hash = "sha256:73d496de46cd2cdbdbcce4ae4bcdb4afb6a11234a1df9c085249d55166b95116", size = 41334, upload-time = "2025-08-12T05:53:14.178Z" },
+    { url = "https://files.pythonhosted.org/packages/46/78/10ad9781128ed2f99dbc474f43283b13fea8ba58723e98844367531c18e9/wrapt-1.17.3-cp314-cp314t-win_arm64.whl", hash = "sha256:f38e60678850c42461d4202739f9bf1e3a737c7ad283638251e79cc49effb6b6", size = 38471, upload-time = "2025-08-12T05:52:57.784Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/f6/a933bd70f98e9cf3e08167fc5cd7aaaca49147e48411c0bd5ae701bb2194/wrapt-1.17.3-py3-none-any.whl", hash = "sha256:7171ae35d2c33d326ac19dd8facb1e82e5fd04ef8c6c0e394d7af55a55051c22", size = 23591, upload-time = "2025-08-12T05:53:20.674Z" },
 ]
 
 [[package]]
@@ -1786,25 +7047,6 @@ version = "3.7.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/24/2f/e183a1b407002f5af81822bee18b61cdb94b8670208ef34734d8d2b8ebe9/xxhash-3.7.0.tar.gz", hash = "sha256:6cc4eefbb542a5d6ffd6d70ea9c502957c925e800f998c5630ecc809d6702bae", size = 82022, upload-time = "2026-04-25T11:10:32.553Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3b/f4/7bd35089ff1f8e2c96baa2dce05775a122aacd2e3830a73165e27a4d0848/xxhash-3.7.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:fdc7d06929ae28dda98297a18eef7b0fd38991a3b405d8d7b55c9ef24c296958", size = 33423, upload-time = "2026-04-25T11:05:47.628Z" },
-    { url = "https://files.pythonhosted.org/packages/a3/26/4e00c88a6a2c8a759cfb77d2a9a405f901e8aa66e60ef1fd0aeb35edda48/xxhash-3.7.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:ea6daa712f4e094a30830cf01e9b47d03b24d05cc9dab8609f0d9a9db8454712", size = 30857, upload-time = "2026-04-25T11:05:49.189Z" },
-    { url = "https://files.pythonhosted.org/packages/82/2f/eeb942c17a5a761a8f01cb9180a0b76bfb62a2c39e6f46b1f9001899027a/xxhash-3.7.0-cp311-cp311-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:9e6c0d843f1daf85ea23aeb053579135552bde575b7b98af20bfc667b6e4548d", size = 194702, upload-time = "2026-04-25T11:05:50.457Z" },
-    { url = "https://files.pythonhosted.org/packages/0e/fd/96f132c08b1e5951c68691d3b9ec351ec2edc028f6a01fcd294f46b9d9f0/xxhash-3.7.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:363c139bf15e1ac5f136b981d3c077eb551299b1effede7f12faa010b8590a60", size = 213613, upload-time = "2026-04-25T11:05:52.571Z" },
-    { url = "https://files.pythonhosted.org/packages/82/89/d4e92b796c5ed052d29ed324dbfc1dc1188e0c4bf64bebbf0f8fc20698df/xxhash-3.7.0-cp311-cp311-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:a778b25874cb0f862eaab5986bff4ca49ffb0def7c0a34c237b948b3c6c775b2", size = 236726, upload-time = "2026-04-25T11:05:54.395Z" },
-    { url = "https://files.pythonhosted.org/packages/40/f1/81fc4361921dc6e557a9c60cb3712f36d244d06eeeb71cd2f4252ac42678/xxhash-3.7.0-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:3e1860f1e43d40e9d904cf22d93e587ea42e010ebce4160877e46bcab4bc232a", size = 212443, upload-time = "2026-04-25T11:05:56.334Z" },
-    { url = "https://files.pythonhosted.org/packages/6a/d0/afeddd4cff50a332f50d4b8a2e8857673153ab0564ef472fcdeb0b5430df/xxhash-3.7.0-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:9122ad6f867c4a0f5e655f5c3bdf89103852009dbb442a3d23e688b9e699e800", size = 445793, upload-time = "2026-04-25T11:05:58.953Z" },
-    { url = "https://files.pythonhosted.org/packages/f7/d0/3c91e4e6a05ca4d7df8e39ec3a75b713609258ec84705ab34be6430826a1/xxhash-3.7.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d7d9110d0c3fb02679972837a033251fd186c529aa62f19c132fc909c74052b8", size = 193937, upload-time = "2026-04-25T11:06:00.546Z" },
-    { url = "https://files.pythonhosted.org/packages/4e/3a/a6b0772d9801dd4bea4ca4fd34734d6e9b51a711c8a611a24a79de26a878/xxhash-3.7.0-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:347a93f2b4ce67ce61959665e32a7447c380f8347e55e100daa23766baacf0e5", size = 285188, upload-time = "2026-04-25T11:06:01.96Z" },
-    { url = "https://files.pythonhosted.org/packages/6c/f8/cf8e31fd7282230fe7367cd501a2e75b4b67b222bfc7eacccfc20d2652cb/xxhash-3.7.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:acbb48679ddf3852c45280c10ff10d52ca2cd1da2e552fb81db1ff786c75d0e4", size = 210966, upload-time = "2026-04-25T11:06:03.453Z" },
-    { url = "https://files.pythonhosted.org/packages/cc/f0/fd36cc4a81bf52ee5633275daae2b93dd958aace67fd4f5d466ec83b5f35/xxhash-3.7.0-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:fe14c356f8b23ad811dc026077a6d4abccdaa7bce5ca98579605550657b6fcfb", size = 241994, upload-time = "2026-04-25T11:06:05.264Z" },
-    { url = "https://files.pythonhosted.org/packages/08/e1/67f5d9c9369be42eaf99ba02c01bf14c5ecd67087b02567960bfcee43b63/xxhash-3.7.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:f420ad3d41e38194353a498bbc9561fd5a9973a27b536ce46d8583479cf44335", size = 198707, upload-time = "2026-04-25T11:06:07.044Z" },
-    { url = "https://files.pythonhosted.org/packages/50/17/a4c865ca22d2da6b1bc7d739bf88cab209533cf52ba06ca9da27c3039bee/xxhash-3.7.0-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:693d02c6dc7d1aa0a45921d54cd8c1ff629e09dfdc2238471507af1f7a1c6f04", size = 210917, upload-time = "2026-04-25T11:06:08.853Z" },
-    { url = "https://files.pythonhosted.org/packages/49/8b/453b35810d697abac3c96bde3528bece685869227da274eb80a4a4d4a119/xxhash-3.7.0-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:14bf7a54e43825ec131ee7fe3c60e142e7c2c1e676ad0f93fc893432d15414af", size = 275772, upload-time = "2026-04-25T11:06:10.645Z" },
-    { url = "https://files.pythonhosted.org/packages/b5/ad/4eed7eab07fd3ee6678f416190f0413d097ab5d7c1278906bf1e9549d789/xxhash-3.7.0-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:ae3a39a4d96bdb6f8d154fd7f490c4ad06f0532fcd2bb656052a9a7762cf5d31", size = 414068, upload-time = "2026-04-25T11:06:12.511Z" },
-    { url = "https://files.pythonhosted.org/packages/d3/4e/fd6f8a680ba248fdb83054fa71a8bfa3891225200de1708b888ef2c49829/xxhash-3.7.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:1cc07c639e3a77ef1d32987464d3e408565b8a3be57b545d3542b191054d9923", size = 191459, upload-time = "2026-04-25T11:06:14.07Z" },
-    { url = "https://files.pythonhosted.org/packages/50/7c/8cb34b3bed4f44ca6827a534d50833f9bc6c006e83b0eb410ac9fa0793bd/xxhash-3.7.0-cp311-cp311-win32.whl", hash = "sha256:3281ba1d1e60ee7a382a7b958513ba03c2c0d5fcbd9a6f7517c0a81251a23422", size = 30628, upload-time = "2026-04-25T11:06:15.802Z" },
-    { url = "https://files.pythonhosted.org/packages/0b/47/a49767bd7b40782bedae9ff0721bfe1d7e4dd9dc1585dea684e57ba67c20/xxhash-3.7.0-cp311-cp311-win_amd64.whl", hash = "sha256:a7f25baec4c5d851d40718d6fae52285b31683093d4ff5207e63ab306ccf14a5", size = 31461, upload-time = "2026-04-25T11:06:17.104Z" },
-    { url = "https://files.pythonhosted.org/packages/7c/c6/3957bfacfb706bd687be246dfa8dd60f8df97c44186d229f7fd6e26c4b7e/xxhash-3.7.0-cp311-cp311-win_arm64.whl", hash = "sha256:4c2454448ce847c72635827bb75c15c5a3434b03ee1afd28cb6dc6fb2597d830", size = 27746, upload-time = "2026-04-25T11:06:18.716Z" },
     { url = "https://files.pythonhosted.org/packages/f2/8a/51a14cdef4728c6c2337db8a7d8704422cc65676d9199d77215464c880af/xxhash-3.7.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:082c87bfdd2b9f457606c7a4a53457f4c4b48b0cdc48de0277f4349d79bb3d7a", size = 33357, upload-time = "2026-04-25T11:06:20.44Z" },
     { url = "https://files.pythonhosted.org/packages/b9/1b/0c2c933809421ffd9bf42b59315552c143c755db5d9a816b2f1ae273e884/xxhash-3.7.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:5e7ce913b61f35b0c1c839a49ac9c8e75dd8d860150688aed353b0ce1bf409d8", size = 30869, upload-time = "2026-04-25T11:06:21.989Z" },
     { url = "https://files.pythonhosted.org/packages/03/a8/89d5fdd6ee12d70ba99451de46dd0e8010167468dcd913ec855653f4dd50/xxhash-3.7.0-cp312-cp312-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:3beb1de3b1e9694fcdd853e570ee64c631c7062435d2f8c69c1adf809bc086f0", size = 194100, upload-time = "2026-04-25T11:06:23.586Z" },
@@ -1910,12 +7152,97 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/ad/95/a26baa93b5241fd7630998816a4ec47a5a0bad193b3f8fc8f3593e1a4a67/xxhash-3.7.0-cp314-cp314t-win32.whl", hash = "sha256:a04a6cab47e2166435aaf5b9e5ee41d1532cc8300efdef87f2a4d0acb7db19ed", size = 31643, upload-time = "2026-04-25T11:09:08.153Z" },
     { url = "https://files.pythonhosted.org/packages/44/36/5454f13c447e395f9b06a3e91274c59f503d31fad84e1836efe3bdb71f6a/xxhash-3.7.0-cp314-cp314t-win_amd64.whl", hash = "sha256:8653dd7c2eda020545bb2c71c7f7039b53fe7434d0fc1a0a9deb79ab3f1a4fc1", size = 32522, upload-time = "2026-04-25T11:09:09.534Z" },
     { url = "https://files.pythonhosted.org/packages/74/35/698e7e3ff38e22992ea24870a511d8762474fb6783627a2910ff22a185c2/xxhash-3.7.0-cp314-cp314t-win_arm64.whl", hash = "sha256:468f0fc114faaa4b36699f8e328bbc3bb11dc418ba94ac52c26dd736d4b6c637", size = 28807, upload-time = "2026-04-25T11:09:11.234Z" },
-    { url = "https://files.pythonhosted.org/packages/54/c1/e57ac7317b1f58a92bab692da6d497e2a7ce44735b224e296347a7ecc754/xxhash-3.7.0-pp311-pypy311_pp73-macosx_10_15_x86_64.whl", hash = "sha256:ad3aa71e12ee634f22b39a0ff439357583706e50765f17f05550f92dbf128a23", size = 31232, upload-time = "2026-04-25T11:10:21.51Z" },
-    { url = "https://files.pythonhosted.org/packages/4f/4e/075559bd712bc62e84915ea46bbee859f935d285659082c129bdbff679dd/xxhash-3.7.0-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:5de686e73690cdaf72b96d4fa083c230ec9020bcc2627ce6316138e2cf2fe2d1", size = 28553, upload-time = "2026-04-25T11:10:23.1Z" },
-    { url = "https://files.pythonhosted.org/packages/92/ca/a9c78cb384d4b033b0c58196bd5c8509873cabe76389e195127b0302a741/xxhash-3.7.0-pp311-pypy311_pp73-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:7fbec49f5341bbdea0c471f7d1e2fb41ae8925af9b6f28025c28defd8eb94274", size = 41109, upload-time = "2026-04-25T11:10:25.022Z" },
-    { url = "https://files.pythonhosted.org/packages/bd/b1/dfe2629f7c77eb2fa234c72ff537cdd64939763df704e256446ed364a16d/xxhash-3.7.0-pp311-pypy311_pp73-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:48b542c347c2089f43dc5a6db31d2a6f3cdb04ee33505ec6e9f653834dbb0bde", size = 36307, upload-time = "2026-04-25T11:10:26.949Z" },
-    { url = "https://files.pythonhosted.org/packages/e7/f7/5a484afce0f48dd8083208b42e4911f290a82c7b52458ef2927e4d421a45/xxhash-3.7.0-pp311-pypy311_pp73-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a169a036bed0995e090d1493b283cc2cc8a6f5046821086b843abefff80643bc", size = 32534, upload-time = "2026-04-25T11:10:29.01Z" },
-    { url = "https://files.pythonhosted.org/packages/0f/5f/4acfcd490db9780cf36c58534d828003c564cde5350220a1c783c4d10776/xxhash-3.7.0-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:ec101643395d7f21405b640f728f6f627e6986557027d740f2f9b220955edafe", size = 31552, upload-time = "2026-04-25T11:10:30.727Z" },
+]
+
+[[package]]
+name = "yarl"
+version = "1.24.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "idna" },
+    { name = "multidict" },
+    { name = "propcache" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/79/12/1e8f37460ea0f7eb59c221fdaf0ed75e7ac43e97f8093b9c6f411df50a78/yarl-1.24.2.tar.gz", hash = "sha256:9ac374123c6fd7abf64d1fec93962b0bd4ee2c19751755a762a72dd96c0378f8", size = 210798, upload-time = "2026-05-19T21:31:05.599Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f0/da/866bcb01076ba49d2b42b309867bed3826421f1c479655eb7a607b44f20b/yarl-1.24.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:b975866c184564c827e0877380f0dae57dcca7e52782128381b72feff6dfceb8", size = 129957, upload-time = "2026-05-19T21:28:51.695Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/1d/fcefb70922ea2268a8971d8e5874d9a8218644200fb8465f1dcad55e6851/yarl-1.24.2-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:3b075301a2836a0e297b1b658cb6d6135df535d62efefdd60366bd589c2c82f2", size = 92164, upload-time = "2026-05-19T21:28:53.242Z" },
+    { url = "https://files.pythonhosted.org/packages/29/b6/170e2b8d4e3bc30e6bfdcca53556537f5bf595e938632dfcb059311f3ff6/yarl-1.24.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:8ae44649b00947634ab0dab2a374a638f52923a6e67083f2c156cd5cbd1a881d", size = 91688, upload-time = "2026-05-19T21:28:54.865Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/a5/c9f655d5553ea0b99fdac9d6a99ad3f9b3e73b8e5758bb46f58c9831f74c/yarl-1.24.2-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:507cc19f0b45454e2d6dcd62ff7d062b9f77a2812404e62dbdaec05b50faa035", size = 102902, upload-time = "2026-05-19T21:28:56.963Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/bc/6b9664d815d79af4ee553337f9d606c56bbf269186ada9172de45f1b5f60/yarl-1.24.2-cp312-cp312-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:c4c17bad5a530912d2111825d3f05e89bab2dd376aaa8cbc77e449e6db63e576", size = 97931, upload-time = "2026-05-19T21:28:58.56Z" },
+    { url = "https://files.pythonhosted.org/packages/98/ec/32ba48acae30fecd60928f5791188b80a9d6ee3840507ffda29fecd37b71/yarl-1.24.2-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:f5f0cbb112838a4a293985b6ed73948a547dadcc1ba6d2089938e7abdedceef8", size = 111030, upload-time = "2026-05-19T21:29:00.148Z" },
+    { url = "https://files.pythonhosted.org/packages/82/5a/6f4cd081e5f4934d2ae3a8ef4abe3afacc010d26f0035ee91b35cd7d7c37/yarl-1.24.2-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:5ec8356b8a6afcf81fc7aeeef13b1ff7a49dec00f313394bbb9e83830d32ccd7", size = 110392, upload-time = "2026-05-19T21:29:02.155Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/da/323a01c349bd5fb01bb6652e314d9bb218cee630a736bdb810ad50e4013f/yarl-1.24.2-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7e7ebcdef69dec6c6451e616f32b622a6d4a2e92b445c992f7c8e5274a6bbc4c", size = 105612, upload-time = "2026-05-19T21:29:04.247Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/80/264ab684f181e1a876389374519ff05d10248725535ae2ac4e8ac4e563d6/yarl-1.24.2-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:47a55d6cf6db2f401017a9e96e5288844e5051911fb4e0c8311a3980f5e59a7d", size = 104487, upload-time = "2026-05-19T21:29:06.491Z" },
+    { url = "https://files.pythonhosted.org/packages/41/07/efabe5df87e96d7ad5959760b888344be48cd6884db127b407c6b5503adc/yarl-1.24.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:3065657c80a2321225e804048597ad55658a7e76b32d6f5ee4074d04c50401db", size = 102333, upload-time = "2026-05-19T21:29:08.267Z" },
+    { url = "https://files.pythonhosted.org/packages/44/0c/bcf7c42603e1009295f586d8890f2ba032c8b53310e815adf0a202c73d9f/yarl-1.24.2-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:cb84b80d88e19ede158619b80813968713d8d008b0e2497a576e6a0557d50712", size = 99025, upload-time = "2026-05-19T21:29:10.682Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/82/84482ab1a57a0f21a08afe6a7004c61d741f8f2ecc3b05c321577c612164/yarl-1.24.2-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:990de4f680b1c217e77ff0d6aa0029f9eb79889c11fb3e9a3942c7eba29c1996", size = 110507, upload-time = "2026-05-19T21:29:12.954Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/8d/a546ba1dfe1b0f290e05fef145cd07614c0f15df1a707195e512d1e39d1d/yarl-1.24.2-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:abb8ec0323b80161e3802da3150ef660b41d0e9be2048b76a363d93eee992c2b", size = 103719, upload-time = "2026-05-19T21:29:14.893Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/b6/267f2a09213138473adfce6b8a6e17791d7fee70bd4d9003218e4dec58b0/yarl-1.24.2-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:e7977781f83638a4c73e0f88425563d70173e0dfd90ac006a45c65036293ee3c", size = 110438, upload-time = "2026-05-19T21:29:16.485Z" },
+    { url = "https://files.pythonhosted.org/packages/48/2d/1c8d89c7c5f9cad9fb2902445d94e2ab1d7aa35de029afbb8ae95c42d00f/yarl-1.24.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:e30dd55825dc554ec5b66a94953b8eda8745926514c5089dfcacecb9c99b5bd1", size = 105719, upload-time = "2026-05-19T21:29:18.367Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/25/722e3b93bd687009afb2d59a35e13d30ddd8f80571445bb0c4e4ce26ec66/yarl-1.24.2-cp312-cp312-win_amd64.whl", hash = "sha256:7dafe10c12ddd4d120d528c4b5599c953bd7b12845347d507b95451195bb6cad", size = 92901, upload-time = "2026-05-19T21:29:20.014Z" },
+    { url = "https://files.pythonhosted.org/packages/39/47/4486ccfb674c04854a1ef8aa77868b6a6f765feaf69633409d7ca4f02cb8/yarl-1.24.2-cp312-cp312-win_arm64.whl", hash = "sha256:044a09d8401fcf8681977faef6d286b8ade1e2d2e9dceda175d1cfa5ca496f30", size = 87229, upload-time = "2026-05-19T21:29:22.1Z" },
+    { url = "https://files.pythonhosted.org/packages/82/62/fcf0ce677f17e5c471c06311dd25964be38a4c586993632910d2e75278bc/yarl-1.24.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:491ac9141decf49ee8030199e1ee251cdff0e131f25678817ff6aa5f837a3536", size = 128978, upload-time = "2026-05-19T21:29:23.83Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/58/8e63299bb71ed61a834121d9d3fe6c9fcf2a6a5d09754ff4f20f2d20baf5/yarl-1.24.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:e89418f65eda18f99030386305bd44d7d504e328a7945db1ead514fbe03a0607", size = 91733, upload-time = "2026-05-19T21:29:25.375Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/24/16748d5dab6daec8b0ed81ccec639a1cded0f18dcc62a4f696b4fe366c37/yarl-1.24.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:cdfcce633b4a4bb8281913c57fcafd4b5933fbc19111a5e3930bbd299d6102f1", size = 91113, upload-time = "2026-05-19T21:29:26.928Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/66/b63fff7b71211e866624b21432d5943cbb633eb0c2872d9ee3070648f22c/yarl-1.24.2-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:863297ddede92ee49024e9a9b11ecb59f310ca85b60d8537f56bed9bbb5b1986", size = 103899, upload-time = "2026-05-19T21:29:28.842Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/ac/ba1974b8533909636f7733fe86cf677e3619527c3c2fa913e0ea89c48757/yarl-1.24.2-cp313-cp313-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:374423f70754a2c96942ede36a29d37dc6b0cb8f92f8d009ddf3ed78d3da5488", size = 97862, upload-time = "2026-05-19T21:29:31.086Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/a5/123ac993b5c2ba6f554a140305620cb8f150fa543711bbc49be3ec0a65a4/yarl-1.24.2-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:33a29b5d00ccbf3219bb3e351d7875739c19481e030779f48cc46a7a71681a9b", size = 111060, upload-time = "2026-05-19T21:29:32.657Z" },
+    { url = "https://files.pythonhosted.org/packages/23/37/c472d3af3509688392134a88a825276770a187f1daa4de3f6dc0a327a751/yarl-1.24.2-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a9532c57211730c515341af11fef6e9b61d157487272a096d0c04da445642592", size = 110613, upload-time = "2026-05-19T21:29:34.379Z" },
+    { url = "https://files.pythonhosted.org/packages/df/88/09c28dad91e662ccfaa1b78f1c57badde74fc9d0b23e74aef644750ecd73/yarl-1.24.2-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:91e72cf093fd833483a97ee648e0c053c7c629f51ff4a0e7edd84f806b0c5617", size = 107012, upload-time = "2026-05-19T21:29:36.216Z" },
+    { url = "https://files.pythonhosted.org/packages/07/ab/9d4f69d571a94f4d112fa7e2e007200f5a54d319f58c82ac7b7baa61f5c6/yarl-1.24.2-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:b3177bc0a768ef3bacceb4f272632990b7bea352f1b2f1eee9d6d6ff16516f92", size = 105887, upload-time = "2026-05-19T21:29:38.746Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/9a/000b2b66c0d772a499fc531d21dab92dfeb73b640a12eed6ba89f49bb2d0/yarl-1.24.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:e196952aacaf3b232e265ff02980b64d483dc0972bd49bcb061171ff22ac203a", size = 103620, upload-time = "2026-05-19T21:29:40.368Z" },
+    { url = "https://files.pythonhosted.org/packages/41/7c/7c1050f73450fbdaa3f0c72017059f00ce5e13366692f3dba25275a1083d/yarl-1.24.2-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:204e7a61ce99919c0de1bf904ab5d7aa188a129ea8f690a8f76cfb6e2844dc44", size = 100599, upload-time = "2026-05-19T21:29:42.66Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/b1/29e5756b3926705f5f6089bd5b9f50a56eaac550da6e260bf713ead44d04/yarl-1.24.2-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:4b156914620f0b9d78dc1adb3751141daee561cfec796088abb89ed49d220f1a", size = 110604, upload-time = "2026-05-19T21:29:44.632Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/4b/8415bc96e9b150cde942fbac9a8182985e58f40ce5c54c34ed015407d3ee/yarl-1.24.2-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:8372a2b976cf70654b2be6619ab6068acabb35f724c0fda7b277fbf53d66a5cf", size = 105161, upload-time = "2026-05-19T21:29:46.755Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/d4/cde059abfa229553b7298a2eadde2752e723d50aeedaef86ce59da2718ee/yarl-1.24.2-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:f9a1e9b622ca284143aab5d885848686dcd85453bb1ca9abcdb7503e64dc0056", size = 110619, upload-time = "2026-05-19T21:29:48.972Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/2c/d6a6c9a61549f7b6c7e6dc6937d195bcf069582b47b7200dcd0e7b256acf/yarl-1.24.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:810e19b685c8c3c5862f6a38160a1f4e4c0916c9390024ec347b6157a45a0992", size = 107362, upload-time = "2026-05-19T21:29:51Z" },
+    { url = "https://files.pythonhosted.org/packages/92/dd/3ae5fe417e9d1c353a548553326eb9935e76b6b727161563b424cc296df3/yarl-1.24.2-cp313-cp313-win_amd64.whl", hash = "sha256:7d37fb7c38f2b6edab0f845c4f85148d4c44204f52bc127021bd2bc9fdbf1656", size = 92667, upload-time = "2026-05-19T21:29:52.743Z" },
+    { url = "https://files.pythonhosted.org/packages/10/cc/a7beb239f78f27fca1b053c8e8595e4179c02e62249b4687ec218c370c50/yarl-1.24.2-cp313-cp313-win_arm64.whl", hash = "sha256:1e831894be7c2954240e49791fa4b50c05a0dc881de2552cfe3ffd8631c7f461", size = 87069, upload-time = "2026-05-19T21:29:54.442Z" },
+    { url = "https://files.pythonhosted.org/packages/40/0e/e08087695fc12789263821c5dc0f8dc52b5b17efd0887cacf419f8a43ba3/yarl-1.24.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:f9312b3c02d9b3d23840f67952913c9c8721d7f1b7db305289faefa878f364c2", size = 129670, upload-time = "2026-05-19T21:29:56.631Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/98/ab4b5ed1b1b5cd973c8a3eb994c3a6aefb6ce6d399e21bb5f0316c33815c/yarl-1.24.2-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:a4f4d6cd615823bfc7fb7e9b5987c3f41666371d870d51058f77e2680fbe9630", size = 91916, upload-time = "2026-05-19T21:29:58.645Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/b1/5297bb6a7df4782f7605bffc43b31f5044070935fbbcaa6c705a07e6ac65/yarl-1.24.2-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:0c3063e5c0a8e8e62fae6c2596fa01da1561e4cd1da6fec5789f5cf99a8aefd8", size = 91625, upload-time = "2026-05-19T21:30:00.412Z" },
+    { url = "https://files.pythonhosted.org/packages/02/a7/45baabfff76829264e623b185cff0c340d7e11bf3e1cd9ea37e7d17934bd/yarl-1.24.2-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:fecd17873a096036c1c87ab3486f1aef7f269ada7f23f7f856f93b1cc7744f14", size = 104574, upload-time = "2026-05-19T21:30:02.544Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/40/3a5ab144d3d650ca37d4f4b57e56169be8af3ca34c448793e064b30baaed/yarl-1.24.2-cp314-cp314-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:a46d1ab4ba4d32e6dc80daf8a28ce0bd83d08df52fbc32f3e288663427734535", size = 97534, upload-time = "2026-05-19T21:30:04.319Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/b5/5658fef3681fb5776b4513b052bec750009f47b3a592251c705d75375798/yarl-1.24.2-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:73e68edf6dfd5f73f9ca127d84e2a6f9213c65bdffb736bda19524c0564fcd14", size = 111481, upload-time = "2026-05-19T21:30:05.988Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/06/fdcd7dde037f00866dce123ed4ba23dba94beb56fc4cf561668d27be37f2/yarl-1.24.2-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a296ca617f2d25fbceafb962b88750d627e5984e75732c712154d058ae8d79a3", size = 111529, upload-time = "2026-05-19T21:30:07.738Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/53/d81269aaafccea0d33396c03035de997b743f11e648e6e27a0df99c72980/yarl-1.24.2-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e51b2cf5ec89a8b8470177641ed62a3ba22d74e1e898e06ad53aa77972487208", size = 107338, upload-time = "2026-05-19T21:30:09.713Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/04/23049463f729bd899df203a7960505a75333edd499cda8aa1d5a82b64df5/yarl-1.24.2-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:310fc687f7b2044ec54e372c8cbe923bb88f5c37bded0d3079e5791c2fc3cf50", size = 106147, upload-time = "2026-05-19T21:30:11.365Z" },
+    { url = "https://files.pythonhosted.org/packages/14/18/04a4b5830b43ed5e4c5015b40e9f6241ad91487d71611061b4e111d6ac80/yarl-1.24.2-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:297a2fe352ecf858b30a98f87948746ec16f001d279f84aebdbd3bd965e2f1bd", size = 104272, upload-time = "2026-05-19T21:30:12.978Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/f7/8cffdf319aee7a7c1dbd07b61d91c3e3fda460c7a93b5f93e445f3806c4c/yarl-1.24.2-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:2a263e76b97bc42bdcd7c5f4953dec1f7cd62a1112fa7f869e57255229390d67", size = 99962, upload-time = "2026-05-19T21:30:15.001Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/39/b3cce3b7dbef64ac700ad4cea156a207d01bede0f507587616c364b5468e/yarl-1.24.2-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:822519b64cf0b474f1a0aaef1dc621438ea46bb77c94df97a5b4d213a7d8a8b1", size = 111063, upload-time = "2026-05-19T21:30:16.683Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/ea/100818505e7ebf165c7242ff17fdf7d9fee79e27234aeca871c1082920d7/yarl-1.24.2-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:b6067060d9dc594899ba83e6db6c48c68d1e494a6dab158156ed86977ca7bcb1", size = 105438, upload-time = "2026-05-19T21:30:18.769Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/d2/e075a0b32aa6625087de9e653087df0759fed5de4a435fef594181102a77/yarl-1.24.2-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:0063adad533e57171b79db3943b229d40dfafeeee579767f96541f106bac5f1b", size = 111458, upload-time = "2026-05-19T21:30:21.024Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/5c/ceea7ba98b65c8eb8d947fdc52f9bedfcd43c6a57c9e3c90c17be8f324a3/yarl-1.24.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:ee8e3fb34513e8dc082b586ef4910c98335d43a6fab688cd44d4851bacfce3e8", size = 107589, upload-time = "2026-05-19T21:30:23.412Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/d9/5582d57e2b2db9b85eb6663a22efdd78e08805f3f5389566e9fcad254d1b/yarl-1.24.2-cp314-cp314-win_amd64.whl", hash = "sha256:afb00d7fd8e0f285ca29a44cc50df2d622ff2f7a6d933fa641577b5f9d5f3db0", size = 94424, upload-time = "2026-05-19T21:30:25.425Z" },
+    { url = "https://files.pythonhosted.org/packages/92/10/7dc07a0e22806a9280f42a57361395506e800c64e22737cd7b0886feab42/yarl-1.24.2-cp314-cp314-win_arm64.whl", hash = "sha256:68cf6eacd6028ef1142bc4b48376b81566385ca6f9e7dde3b0fa91be08ffcb57", size = 88690, upload-time = "2026-05-19T21:30:27.623Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/13/d5b8e2c8667db955bcb3de233f18798fefe7edf1d7429c2c9d4f9c401114/yarl-1.24.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:221ce1dd921ac4f603957f17d7c18c5cc0797fbb52f156941f92e04605d1d67b", size = 136248, upload-time = "2026-05-19T21:30:29.297Z" },
+    { url = "https://files.pythonhosted.org/packages/de/46/a4a97c05c9c9b8fd266bb2a0df12992c7fbd02391eb9640583411b6dab32/yarl-1.24.2-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:5f3224db28173a00d7afacdee07045cc4673dfab2b15492c7ae10deddbece761", size = 95084, upload-time = "2026-05-19T21:30:31.031Z" },
+    { url = "https://files.pythonhosted.org/packages/95/b2/845cf2074a015e6fe0d0808cf1a2d9e868386c4220d657ebd8302b199043/yarl-1.24.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:c557165320d6244ebe3a02431b2a201a20080e02f41f0cfa0ccc47a183765da8", size = 95272, upload-time = "2026-05-19T21:30:33.062Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/16/e69d4aa244aef45235ddfebc0e04036a6829842bc5a6a795aedc6c998d23/yarl-1.24.2-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:904065e6e85b1fa54d0d87438bd58c14c0bad97aad654ad1077fd9d87e8478ed", size = 101497, upload-time = "2026-05-19T21:30:34.842Z" },
+    { url = "https://files.pythonhosted.org/packages/15/94/c07107715d621076863ee88b3ddf183fa5e9d4aba5769623c9979828410a/yarl-1.24.2-cp314-cp314t-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:8cec2a38d70edc10e0e856ceda886af5327a017ccbde8e1de1bd44d300357543", size = 94002, upload-time = "2026-05-19T21:30:37.724Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/35/fc1bbdd895b5e4010b8fdd037f7ed3aa289d3863e08231b30231ca9a0815/yarl-1.24.2-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:e7484b9361ed222ee1ca5b4337aa4cbdcc4618ce5aff57d9ef1582fd95893fc0", size = 106524, upload-time = "2026-05-19T21:30:40.196Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/f2/32b66d0a4ba47c296cf86d03e2c67bff58399fe6d6d84d5205c04c66cc6d/yarl-1.24.2-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:84f9670b89f34db07f81e53aee83e0b938a3412329d51c8f922488be7fcc4024", size = 106165, upload-time = "2026-05-19T21:30:41.888Z" },
+    { url = "https://files.pythonhosted.org/packages/95/47/37cb5ff50c5e825d4d38e81bb04d1b7e96bf960f7ab89f9850b162f3f114/yarl-1.24.2-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:abb2759733d63a28b4956500a5dd57140f26486c92b2caedfb964ab7d9b79dbf", size = 103010, upload-time = "2026-05-19T21:30:43.985Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/d2/4597912315096f7bb359e46e13bf8b60994fcbb2db29b804c0902ef4eff5/yarl-1.24.2-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:081c2bf54efe03774d0311172bc04fedf9ca01e644d4cd8c805688e527209bdc", size = 101128, upload-time = "2026-05-19T21:30:46.291Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/d5/c8e86e120521e646013d02a8e3b8884392e28494be8f392366e50d208efc/yarl-1.24.2-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:86746bef442aa479107fe28132e1277237f9c24c2f00b0b0cf22b3ee0904f2bb", size = 101382, upload-time = "2026-05-19T21:30:48.085Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/98/70b229236118f89dbeb739b76f10225bbf53b5497725502594c9a01d699a/yarl-1.24.2-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:2d07d21d0bc4b17558e8de0b02fbfdf1e347d3bb3699edd00bb92e7c57925420", size = 95964, upload-time = "2026-05-19T21:30:49.785Z" },
+    { url = "https://files.pythonhosted.org/packages/87/f8/56c386981e3c8648d279fdef2397ffec577e8320fd5649745e34d54faeb7/yarl-1.24.2-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:4fb1ac3fc5fecd8ae7453ea237e4d22b49befa70266dfe1629924245c21a0c7f", size = 106204, upload-time = "2026-05-19T21:30:51.862Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/1e/765afe97811ca35933e2a7de70ac57b1997ea2e4ee895719ee7a231fb7e5/yarl-1.24.2-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:4da31a5512ed1729ca8d8aacde3f7faeb8843cde3165d6bcf7f88f74f17bb8aa", size = 101510, upload-time = "2026-05-19T21:30:53.62Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/78/393913f4b9039e1edd09ae8a9bbb9d539be909a8abf6d8a2084585bed4b7/yarl-1.24.2-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:533ded4dceb5f1f3da7906244f4e82cf46cfd40d84c69a1faf5ac506aa65ecbe", size = 105584, upload-time = "2026-05-19T21:30:55.962Z" },
+    { url = "https://files.pythonhosted.org/packages/78/87/deb17b7049bbe74ea11a713b86f8f27800cc1c8648b0b797243ebb4830ba/yarl-1.24.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:7b3a85525f6e7eeabcfdd372862b21ee1915db1b498a04e8bf0e389b607ff0bd", size = 103410, upload-time = "2026-05-19T21:30:57.962Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/be/f9f7594e23b5b93affff0318e4593c1920331bcaefda326cabcad94296a1/yarl-1.24.2-cp314-cp314t-win_amd64.whl", hash = "sha256:a7624b1ca46ca5d7b864ef0d2f8efe3091454085ee1855b4e992314529972215", size = 102980, upload-time = "2026-05-19T21:30:59.735Z" },
+    { url = "https://files.pythonhosted.org/packages/65/a4/ba80dccd3593ff1f01051a818694d07b58cb8232677ee9a22a5a1f93a9fc/yarl-1.24.2-cp314-cp314t-win_arm64.whl", hash = "sha256:e434a45ce2e7a947f951fc5a8944c8cc080b7e59f9c50ae80fd39107cf88126d", size = 91219, upload-time = "2026-05-19T21:31:01.934Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/4d/4b880086bd0d3e034d25647be1d830afc3e3f610e98c4ab3490af6b1b6d5/yarl-1.24.2-py3-none-any.whl", hash = "sha256:2783d9226db8797636cd6896e4de81feed252d1db72265686c9558d97a4d94b9", size = 53576, upload-time = "2026-05-19T21:31:03.909Z" },
+]
+
+[[package]]
+name = "zipp"
+version = "4.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b9/d8/eab98a517c14134c0b2eb4e2387bc5f457334293ec5d2dd3857ec2966802/zipp-4.1.0.tar.gz", hash = "sha256:4cb57381f544315db7688e976e922a2b18cdb513d21cc194eb42232ba2a3e602", size = 26214, upload-time = "2026-05-18T20:08:57.967Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3a/13/547360d81e6d88d58492968ffda9f9542854f11310ee556fef14260cc886/zipp-4.1.0-py3-none-any.whl", hash = "sha256:25ad4e16390cd314347dd8f1de67a2ac538ae658ed4ab9db16029c07c188e97f", size = 10238, upload-time = "2026-05-18T20:08:57.045Z" },
 ]
 
 [[package]]
@@ -1924,23 +7251,6 @@ version = "0.25.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/fd/aa/3e0508d5a5dd96529cdc5a97011299056e14c6505b678fd58938792794b1/zstandard-0.25.0.tar.gz", hash = "sha256:7713e1179d162cf5c7906da876ec2ccb9c3a9dcbdffef0cc7f70c3667a205f0b", size = 711513, upload-time = "2025-09-14T22:15:54.002Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2a/83/c3ca27c363d104980f1c9cee1101cc8ba724ac8c28a033ede6aab89585b1/zstandard-0.25.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:933b65d7680ea337180733cf9e87293cc5500cc0eb3fc8769f4d3c88d724ec5c", size = 795254, upload-time = "2025-09-14T22:16:26.137Z" },
-    { url = "https://files.pythonhosted.org/packages/ac/4d/e66465c5411a7cf4866aeadc7d108081d8ceba9bc7abe6b14aa21c671ec3/zstandard-0.25.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:a3f79487c687b1fc69f19e487cd949bf3aae653d181dfb5fde3bf6d18894706f", size = 640559, upload-time = "2025-09-14T22:16:27.973Z" },
-    { url = "https://files.pythonhosted.org/packages/12/56/354fe655905f290d3b147b33fe946b0f27e791e4b50a5f004c802cb3eb7b/zstandard-0.25.0-cp311-cp311-manylinux2010_i686.manylinux2014_i686.manylinux_2_12_i686.manylinux_2_17_i686.whl", hash = "sha256:0bbc9a0c65ce0eea3c34a691e3c4b6889f5f3909ba4822ab385fab9057099431", size = 5348020, upload-time = "2025-09-14T22:16:29.523Z" },
-    { url = "https://files.pythonhosted.org/packages/3b/13/2b7ed68bd85e69a2069bcc72141d378f22cae5a0f3b353a2c8f50ef30c1b/zstandard-0.25.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:01582723b3ccd6939ab7b3a78622c573799d5d8737b534b86d0e06ac18dbde4a", size = 5058126, upload-time = "2025-09-14T22:16:31.811Z" },
-    { url = "https://files.pythonhosted.org/packages/c9/dd/fdaf0674f4b10d92cb120ccff58bbb6626bf8368f00ebfd2a41ba4a0dc99/zstandard-0.25.0-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:5f1ad7bf88535edcf30038f6919abe087f606f62c00a87d7e33e7fc57cb69fcc", size = 5405390, upload-time = "2025-09-14T22:16:33.486Z" },
-    { url = "https://files.pythonhosted.org/packages/0f/67/354d1555575bc2490435f90d67ca4dd65238ff2f119f30f72d5cde09c2ad/zstandard-0.25.0-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:06acb75eebeedb77b69048031282737717a63e71e4ae3f77cc0c3b9508320df6", size = 5452914, upload-time = "2025-09-14T22:16:35.277Z" },
-    { url = "https://files.pythonhosted.org/packages/bb/1f/e9cfd801a3f9190bf3e759c422bbfd2247db9d7f3d54a56ecde70137791a/zstandard-0.25.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:9300d02ea7c6506f00e627e287e0492a5eb0371ec1670ae852fefffa6164b072", size = 5559635, upload-time = "2025-09-14T22:16:37.141Z" },
-    { url = "https://files.pythonhosted.org/packages/21/88/5ba550f797ca953a52d708c8e4f380959e7e3280af029e38fbf47b55916e/zstandard-0.25.0-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:bfd06b1c5584b657a2892a6014c2f4c20e0db0208c159148fa78c65f7e0b0277", size = 5048277, upload-time = "2025-09-14T22:16:38.807Z" },
-    { url = "https://files.pythonhosted.org/packages/46/c0/ca3e533b4fa03112facbe7fbe7779cb1ebec215688e5df576fe5429172e0/zstandard-0.25.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:f373da2c1757bb7f1acaf09369cdc1d51d84131e50d5fa9863982fd626466313", size = 5574377, upload-time = "2025-09-14T22:16:40.523Z" },
-    { url = "https://files.pythonhosted.org/packages/12/9b/3fb626390113f272abd0799fd677ea33d5fc3ec185e62e6be534493c4b60/zstandard-0.25.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:6c0e5a65158a7946e7a7affa6418878ef97ab66636f13353b8502d7ea03c8097", size = 4961493, upload-time = "2025-09-14T22:16:43.3Z" },
-    { url = "https://files.pythonhosted.org/packages/cb/d3/23094a6b6a4b1343b27ae68249daa17ae0651fcfec9ed4de09d14b940285/zstandard-0.25.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:c8e167d5adf59476fa3e37bee730890e389410c354771a62e3c076c86f9f7778", size = 5269018, upload-time = "2025-09-14T22:16:45.292Z" },
-    { url = "https://files.pythonhosted.org/packages/8c/a7/bb5a0c1c0f3f4b5e9d5b55198e39de91e04ba7c205cc46fcb0f95f0383c1/zstandard-0.25.0-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:98750a309eb2f020da61e727de7d7ba3c57c97cf6213f6f6277bb7fb42a8e065", size = 5443672, upload-time = "2025-09-14T22:16:47.076Z" },
-    { url = "https://files.pythonhosted.org/packages/27/22/503347aa08d073993f25109c36c8d9f029c7d5949198050962cb568dfa5e/zstandard-0.25.0-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:22a086cff1b6ceca18a8dd6096ec631e430e93a8e70a9ca5efa7561a00f826fa", size = 5822753, upload-time = "2025-09-14T22:16:49.316Z" },
-    { url = "https://files.pythonhosted.org/packages/e2/be/94267dc6ee64f0f8ba2b2ae7c7a2df934a816baaa7291db9e1aa77394c3c/zstandard-0.25.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:72d35d7aa0bba323965da807a462b0966c91608ef3a48ba761678cb20ce5d8b7", size = 5366047, upload-time = "2025-09-14T22:16:51.328Z" },
-    { url = "https://files.pythonhosted.org/packages/7b/a3/732893eab0a3a7aecff8b99052fecf9f605cf0fb5fb6d0290e36beee47a4/zstandard-0.25.0-cp311-cp311-win32.whl", hash = "sha256:f5aeea11ded7320a84dcdd62a3d95b5186834224a9e55b92ccae35d21a8b63d4", size = 436484, upload-time = "2025-09-14T22:16:55.005Z" },
-    { url = "https://files.pythonhosted.org/packages/43/a3/c6155f5c1cce691cb80dfd38627046e50af3ee9ddc5d0b45b9b063bfb8c9/zstandard-0.25.0-cp311-cp311-win_amd64.whl", hash = "sha256:daab68faadb847063d0c56f361a289c4f268706b598afbf9ad113cbe5c38b6b2", size = 506183, upload-time = "2025-09-14T22:16:52.753Z" },
-    { url = "https://files.pythonhosted.org/packages/8c/3e/8945ab86a0820cc0e0cdbf38086a92868a9172020fdab8a03ac19662b0e5/zstandard-0.25.0-cp311-cp311-win_arm64.whl", hash = "sha256:22a06c5df3751bb7dc67406f5374734ccee8ed37fc5981bf1ad7041831fa1137", size = 462533, upload-time = "2025-09-14T22:16:53.878Z" },
     { url = "https://files.pythonhosted.org/packages/82/fc/f26eb6ef91ae723a03e16eddb198abcfce2bc5a42e224d44cc8b6765e57e/zstandard-0.25.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:7b3c3a3ab9daa3eed242d6ecceead93aebbb8f5f84318d82cee643e019c4b73b", size = 795738, upload-time = "2025-09-14T22:16:56.237Z" },
     { url = "https://files.pythonhosted.org/packages/aa/1c/d920d64b22f8dd028a8b90e2d756e431a5d86194caa78e3819c7bf53b4b3/zstandard-0.25.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:913cbd31a400febff93b564a23e17c3ed2d56c064006f54efec210d586171c00", size = 640436, upload-time = "2025-09-14T22:16:57.774Z" },
     { url = "https://files.pythonhosted.org/packages/53/6c/288c3f0bd9fcfe9ca41e2c2fbfd17b2097f6af57b62a81161941f09afa76/zstandard-0.25.0-cp312-cp312-manylinux2010_i686.manylinux2014_i686.manylinux_2_12_i686.manylinux_2_17_i686.whl", hash = "sha256:011d388c76b11a0c165374ce660ce2c8efa8e5d87f34996aa80f9c0816698b64", size = 5343019, upload-time = "2025-09-14T22:16:59.302Z" },


### PR DESCRIPTION
## Summary

Adds `--worker-type openhands`: a **real OpenHands SDK 1.28 agent loop** runs the inner loop, governed by the harness like any other worker. This completes the worker layer — all four workers (codex · opencode · claude · openhands) now verified working with real edits.

Follows slide-16's **six-step SDK pattern** (workspace → agent+tools → conversation → run → the harness reads the diff) against the **real** API. The slide's illustrative code (`Agent(model=…)`, `conversation.run(prompt)`, `workspace.get_git_diff()`) does **not** match SDK 1.28 — so we follow the structure, not the literal snippet (same illustrative-vs-real gap codex's CLI had).

## What's in it
- `openhands_runner.py` — subprocess entry point (lazy heavy import + timeout-bounded, same pattern as the CLI workers); task on stdin; clear exit codes for auth-missing (3) and sdk-not-installed (4).
- `openhands_worker.py` — shells out with a timeout; maps auth/not-installed to a clear `blocked`, else completed/failed; the harness `collect_diff` reads the edit.
- Wired into the worker dispatch + CLI (`--worker-type openhands`).
- `[openhands]` optional extra (`openhands-sdk`/`openhands-tools`).
- **`requires-python` bumped to `>=3.12`** (OpenHands SDK constraint) — a project-wide change.

## Validation
- **209 tests passing**, ruff clean.
- Verified **live**: a real OpenHands run added a correct `subtract()` function end-to-end through `run_harness` via `--worker-type openhands`. Auth via `ANTHROPIC_API_KEY`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a fourth built-in worker, `--worker-type openhands`, which runs a real OpenHands SDK 1.28 agent loop in a subprocess governed by the harness. It also refreshes the README to describe the governance outer loop and wires the new worker into the CLI, graph dispatch, and `pyproject.toml` optional extras.

- **`openhands_runner.py` / `openhands_worker.py`**: new subprocess entry point + worker wrapper that follow the same lazy-import, timeout-bounded, clear-exit-code pattern used by the other three workers. Auth-missing (exit 3) and SDK-not-installed (exit 4) both surface as `status=\"blocked\"` with actionable diagnostics.
- **`pyproject.toml`**: `requires-python` bumped to `>=3.12` (OpenHands SDK constraint); `[openhands]` optional extra added; `[tool.ruff] target-version` was not updated to match and still reads `py311`.
- **Tests**: non-git, dirty-repo, and empty-stdin paths are covered; exit-code-3 and exit-code-4 → `blocked` mapping paths in `OpenHandsWorker.run()` have no unit test.

<h3>Confidence Score: 4/5</h3>

The new worker is self-contained and follows an established pattern; the main loose end is a ruff target-version that no longer matches the project's Python floor.

The core implementation is clean and consistent with the three existing workers. The only concrete gap is target-version = py311 in ruff config after bumping requires-python to >=3.12, which means py312-specific lint rules won't fire. The double call to detect_auth_failure is harmless but worth cleaning up, and the missing mock tests for exit codes 3 and 4 leave a small verification gap for the new blocked paths.

pyproject.toml (ruff target-version) and tests/test_openhands_worker.py (missing exit-code 3/4 coverage) are the two spots worth a second look before merge.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| app/core/workers/openhands_runner.py | New subprocess entry point for the OpenHands SDK agent loop; clean lazy-import pattern with clear exit codes (2/3/4). Hard-coded default model string uses an OpenRouter-style prefix that may need verification against the SDK. |
| app/core/workers/openhands_worker.py | Worker wrapper that shells out to the runner; mirrors the pattern of other workers. `detect_auth_failure` is called twice when auth text (not exit code 3/4) triggers the blocked branch — the result should be captured once. |
| tests/test_openhands_worker.py | Covers non-git, dirty-repo, and empty-task paths. Missing unit tests for the exit-code-3 and exit-code-4 → blocked paths in OpenHandsWorker.run(). |
| tests/test_worker_auth_errors.py | New tests for detect_auth_failure patterns; clean and sufficient for the helper being tested. |
| pyproject.toml | Adds [openhands] optional extra and bumps requires-python to >=3.12, but [tool.ruff] target-version still says py311, creating a mismatch. |
| app/core/graph.py | Adds openhands branch to the worker dispatch; follows the exact same pattern as claude, codex, and opencode — no issues. |
| app/cli.py | Adds openhands to the --worker-type help text; purely cosmetic change, correct. |

</details>


</details>


<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant CLI as CLI
    participant Graph as run_harness
    participant Worker as OpenHandsWorker
    participant Runner as openhands_runner
    participant SDK as OpenHands SDK 1.28
    participant Repo as Git Repo

    CLI->>Graph: "run_harness(worker_type=openhands)"
    Graph->>Worker: OpenHandsWorker.run(repo_path, task, timeout)
    Worker->>Worker: is_git_repo / is_dirty check
    Worker->>Runner: "subprocess.run stdin=prompt timeout=N"
    Runner->>Runner: check API key exit 3 if missing
    Runner->>Runner: import openhands.sdk exit 4 if missing
    Runner->>SDK: LLM + Agent + Conversation
    SDK->>Repo: file edits via tools
    SDK-->>Runner: run complete
    Runner-->>Worker: exit 0 or 1 or 3 or 4
    Worker-->>Graph: ExternalEditResult
    Graph->>Repo: collect_diff enforce_permissions run_tests
    Graph-->>CLI: RunRecord
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `pyproject.toml`, line 54 ([link](https://github.com/ven-z8/agentops-harness/blob/466243b06ecd9453f307c47c1fb66cd33832a431/pyproject.toml#L54)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> `requires-python` was bumped to `>=3.12` in this PR but ruff's `target-version` is still `py311`. Ruff uses `target-version` to decide which syntax/deprecation rules to apply, so it will silently skip any py312-specific checks (e.g. PEP 695 type-alias syntax warnings). These should stay in sync.

   

   <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20pyproject.toml%0ALine%3A%2054%0A%0AComment%3A%0A%60requires-python%60%20was%20bumped%20to%20%60%3E%3D3.12%60%20in%20this%20PR%20but%20ruff's%20%60target-version%60%20is%20still%20%60py311%60.%20Ruff%20uses%20%60target-version%60%20to%20decide%20which%20syntax%2Fdeprecation%20rules%20to%20apply%2C%20so%20it%20will%20silently%20skip%20any%20py312-specific%20checks%20%28e.g.%20PEP%20695%20type-alias%20syntax%20warnings%29.%20These%20should%20stay%20in%20sync.%0A%0A%60%60%60suggestion%0Atarget-version%20%3D%20%22py312%22%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=11&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3" height="20"></picture></a>


2. `tests/test_openhands_worker.py`, line 1-33 ([link](https://github.com/ven-z8/agentops-harness/blob/466243b06ecd9453f307c47c1fb66cd33832a431/tests/test_openhands_worker.py#L1-L33)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Missing coverage for exit-code-3 and exit-code-4 → `blocked` mapping**

   The test file covers the non-git, dirty-repo, and empty-stdin paths, but there are no tests that simulate the runner returning exit code 3 (auth missing) or exit code 4 (SDK not installed) and assert that `OpenHandsWorker.run()` returns `status="blocked"`. These are the two new code paths added in `openhands_worker.py` (lines 80–94) and are straightforward to test with `unittest.mock.patch("subprocess.run")` returning a `CompletedProcess` with the appropriate return code.

   <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20tests%2Ftest_openhands_worker.py%0ALine%3A%201-33%0A%0AComment%3A%0A**Missing%20coverage%20for%20exit-code-3%20and%20exit-code-4%20%E2%86%92%20%60blocked%60%20mapping**%0A%0AThe%20test%20file%20covers%20the%20non-git%2C%20dirty-repo%2C%20and%20empty-stdin%20paths%2C%20but%20there%20are%20no%20tests%20that%20simulate%20the%20runner%20returning%20exit%20code%203%20%28auth%20missing%29%20or%20exit%20code%204%20%28SDK%20not%20installed%29%20and%20assert%20that%20%60OpenHandsWorker.run%28%29%60%20returns%20%60status%3D%22blocked%22%60.%20These%20are%20the%20two%20new%20code%20paths%20added%20in%20%60openhands_worker.py%60%20%28lines%2080%E2%80%9394%29%20and%20are%20straightforward%20to%20test%20with%20%60unittest.mock.patch%28%22subprocess.run%22%29%60%20returning%20a%20%60CompletedProcess%60%20with%20the%20appropriate%20return%20code.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=11&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3" height="20"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Apyproject.toml%3A54%0A%60requires-python%60%20was%20bumped%20to%20%60%3E%3D3.12%60%20in%20this%20PR%20but%20ruff's%20%60target-version%60%20is%20still%20%60py311%60.%20Ruff%20uses%20%60target-version%60%20to%20decide%20which%20syntax%2Fdeprecation%20rules%20to%20apply%2C%20so%20it%20will%20silently%20skip%20any%20py312-specific%20checks%20%28e.g.%20PEP%20695%20type-alias%20syntax%20warnings%29.%20These%20should%20stay%20in%20sync.%0A%0A%60%60%60suggestion%0Atarget-version%20%3D%20%22py312%22%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%203%0Aapp%2Fcore%2Fworkers%2Fopenhands_worker.py%3A79-86%0A%60detect_auth_failure%60%20is%20evaluated%20once%20in%20the%20%60if%60%20condition%20%28where%20it%20may%20be%20short-circuited%29%20and%20again%20inside%20the%20%60reason%60%20ternary.%20When%20the%20branch%20is%20entered%20because%20auth%20text%20was%20detected%20%28not%20because%20of%20exit%20code%203%2F4%29%2C%20%60detect_auth_failure%60%20is%20called%20a%20second%20time%20unnecessarily.%20Capturing%20the%20result%20before%20the%20branch%20keeps%20the%20logic%20clear%20and%20the%20call%20count%20to%20one.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%23%20Auth%20%28exit%203%29%20and%20missing-SDK%20%28exit%204%29%20are%20setup%20problems%2C%20not%20run%20failures.%0A%20%20%20%20%20%20%20%20auth_reason%20%3D%20detect_auth_failure%28completed.stdout%2C%20completed.stderr%29%0A%20%20%20%20%20%20%20%20if%20code%20in%20%283%2C%204%29%20or%20auth_reason%3A%0A%20%20%20%20%20%20%20%20%20%20%20%20reason%20%3D%20%28%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%22OpenHands%20SDK%20not%20installed.%20Install%3A%20uv%20sync%20--extra%20openhands.%22%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20if%20code%20%3D%3D%204%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20else%20auth_reason%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20or%20%22OpenHands%20authentication%20failed%3B%20set%20ANTHROPIC_API_KEY%20and%20retry.%22%0A%20%20%20%20%20%20%20%20%20%20%20%20%29%0A%60%60%60%0A%0A%23%23%23%20Issue%203%20of%203%0Atests%2Ftest_openhands_worker.py%3A1-33%0A**Missing%20coverage%20for%20exit-code-3%20and%20exit-code-4%20%E2%86%92%20%60blocked%60%20mapping**%0A%0AThe%20test%20file%20covers%20the%20non-git%2C%20dirty-repo%2C%20and%20empty-stdin%20paths%2C%20but%20there%20are%20no%20tests%20that%20simulate%20the%20runner%20returning%20exit%20code%203%20%28auth%20missing%29%20or%20exit%20code%204%20%28SDK%20not%20installed%29%20and%20assert%20that%20%60OpenHandsWorker.run%28%29%60%20returns%20%60status%3D%22blocked%22%60.%20These%20are%20the%20two%20new%20code%20paths%20added%20in%20%60openhands_worker.py%60%20%28lines%2080%E2%80%9394%29%20and%20are%20straightforward%20to%20test%20with%20%60unittest.mock.patch%28%22subprocess.run%22%29%60%20returning%20a%20%60CompletedProcess%60%20with%20the%20appropriate%20return%20code.%0A%0A&pr=11&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["docs: refresh README for governance loop..."](https://github.com/ven-z8/agentops-harness/commit/466243b06ecd9453f307c47c1fb66cd33832a431) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37090753)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->