### PR TITLE
fix: integration bugs found in end-to-end manual testing

### DIFF
--- a/app/core/git_utils.py
+++ b/app/core/git_utils.py
@@ -43,6 +43,30 @@ def is_worktree_clean(repo_path: Path) -> bool:
     return not collect_status_lines(repo_path)
 
 
+_NOISE_DIR_PARTS = {
+    "__pycache__",
+    ".pytest_cache",
+    ".ruff_cache",
+    ".mypy_cache",
+    ".venv",
+    "node_modules",
+}
+_NOISE_SUFFIXES = (".pyc", ".pyo")
+_NOISE_NAMES = {".DS_Store"}
+
+
+def is_ephemeral_path(path: str) -> bool:
+    """True for build/cache artifacts that should not be attributed to a worker."""
+    posix = path.replace("\\", "/").rstrip("/")
+    parts = posix.split("/")
+    name = parts[-1] if parts else posix
+    if _NOISE_DIR_PARTS.intersection(parts):
+        return True
+    if name in _NOISE_NAMES:
+        return True
+    return name.endswith(_NOISE_SUFFIXES) or name.endswith(".egg-info")
+
+
 def collect_changed_files(repo_path: Path) -> list[str]:
     if not is_git_repo(repo_path):
         return []
@@ -52,6 +76,8 @@ def collect_changed_files(repo_path: Path) -> list[str]:
         path = line[3:]
         if " -> " in path:
             path = path.split(" -> ", maxsplit=1)[1]
+        if is_ephemeral_path(path):
+            continue
         changed.append(path)
     return sorted(set(changed))
 

--- a/app/core/git_utils.py
+++ b/app/core/git_utils.py
@@ -62,9 +62,13 @@ def is_ephemeral_path(path: str) -> bool:
     name = parts[-1] if parts else posix
     if _NOISE_DIR_PARTS.intersection(parts):
         return True
+    # An `*.egg-info` component anywhere covers the dir AND every file nested inside it
+    # (PKG-INFO, SOURCES.txt, ...), not just the directory entry.
+    if any(part.endswith(".egg-info") for part in parts):
+        return True
     if name in _NOISE_NAMES:
         return True
-    return name.endswith(_NOISE_SUFFIXES) or name.endswith(".egg-info")
+    return name.endswith(_NOISE_SUFFIXES)
 
 
 def collect_changed_files(repo_path: Path) -> list[str]:

--- a/app/core/graph.py
+++ b/app/core/graph.py
@@ -110,7 +110,11 @@ def pre_dispatch_gate_node(state: AgentOpsGraphState) -> AgentOpsGraphState:
         command_tokens = set(shlex.split(command))
     except ValueError:
         command_tokens = set(command.split())
-    denied = sorted({p for p in command_tokens if is_sensitive_path(p)})
+    # Only scan tokens that actually look like file paths (contain "/" or "."), so a bare
+    # subcommand/flag value like `auth` or `payment` doesn't false-positive against the
+    # sensitive-folder names while genuine path arguments (app/auth/x.py, secrets.py) still do.
+    path_like = {t for t in command_tokens if "/" in t or "." in t}
+    denied = sorted({p for p in path_like if is_sensitive_path(p)})
 
     decision = PreDispatchDecision(
         blocked=bool(denied),
@@ -740,6 +744,11 @@ def _is_retriable_failure(state: AgentOpsGraphState) -> bool:
     pointless: exit 2 (can't run / collection error), 5 (no tests collected),
     124 (timeout), 127 (command not found). Treat those as non-retriable.
     """
+    # A blocked worker (sandbox-incompatible, auth missing, dirty repo, pre-dispatch) will
+    # not unblock on retry — never loop on it, regardless of test outcomes.
+    edit_result = state.get("edit_result")
+    if edit_result is not None and edit_result.status == "blocked":
+        return False
     test_results = state.get("test_results")
     if test_results is None or test_results.passed:
         return False
@@ -873,8 +882,13 @@ def run_harness(
         status = "blocked"
     else:
         status = "completed"
-    if status == "completed" and edit_result is not None and edit_result.status != "completed":
-        status = "failed"
+    if status == "completed" and edit_result is not None:
+        # A blocked worker (sandbox-incompatible, auth missing, dirty repo, ...) makes the
+        # run blocked, not failed — distinguish the two instead of collapsing both.
+        if edit_result.status == "blocked":
+            status = "blocked"
+        elif edit_result.status != "completed":
+            status = "failed"
     # A worker was requested but never ran (e.g. workspace not ready) — don't report a
     # bare "completed" with no edits; surface that the worker was blocked.
     if (

--- a/app/core/graph.py
+++ b/app/core/graph.py
@@ -87,20 +87,30 @@ def pre_dispatch_gate_node(state: AgentOpsGraphState) -> AgentOpsGraphState:
 
     from app.core.security import is_sensitive_path
 
-    # Block on either the plan's intended edits OR an explicit worker command that
-    # references a sensitive path — so a denied edit is stopped before the worker runs.
-    planned = {f for step in state["plan"].steps for f in step.files_to_edit}
+    # Pre-dispatch enforcement only applies when a worker will actually run.
+    # Observe mode (no worker) never blocks — there is nothing to dispatch.
+    has_worker = bool(state.get("worker_command") or state.get("worker_type"))
+    if not has_worker:
+        return {
+            "pre_dispatch": PreDispatchDecision(),
+            "execution_logs": append_logs(state, "pre_dispatch:observe"),
+        }
+
+    # Block on the EXPLICIT worker command targeting a sensitive path — a precise signal.
+    # The planner's files_to_edit is intentionally NOT used: it over-lists (whole test
+    # trees, etc.), so it produces false blocks. For --worker-type workers (which decide
+    # their own edits), post-edit revert-on-deny and the sandbox provide enforcement.
     command = state.get("worker_command") or ""
     try:
         command_tokens = set(shlex.split(command))
     except ValueError:
         command_tokens = set(command.split())
-    denied = sorted({p for p in planned | command_tokens if is_sensitive_path(p)})
+    denied = sorted({p for p in command_tokens if is_sensitive_path(p)})
 
     decision = PreDispatchDecision(
         blocked=bool(denied),
         denied_paths=denied,
-        reason=f"Targets sensitive paths before dispatch: {denied}" if denied else "",
+        reason=f"Worker command targets sensitive paths: {denied}" if denied else "",
     )
     log = "pre_dispatch:blocked" if denied else "pre_dispatch:ok"
     return {"pre_dispatch": decision, "execution_logs": append_logs(state, log)}

--- a/app/core/graph.py
+++ b/app/core/graph.py
@@ -170,6 +170,35 @@ def run_external_worker_node(state: AgentOpsGraphState) -> AgentOpsGraphState:
     # Increment attempt counter (starts at 0 in initial state, so first run → 1).
     attempts = state.get("attempts", 0) + 1
 
+    # Sandbox (full isolation) runs the worker INSIDE the container, which only
+    # supports an explicit --worker-command for now. The built-in worker types
+    # (codex/claude/opencode/openhands) are not installed in the sandbox image yet,
+    # so block the combination explicitly instead of silently running on the host
+    # (which would not be sandboxed) or producing no edits. Checked first, so the
+    # invalid combination is reported regardless of workspace preparation.
+    if (
+        (state.get("isolation") or "validation") == "full"
+        and state.get("worker_type")
+        and not state.get("worker_command")
+    ):
+        wt = state.get("worker_type")
+        return {
+            "attempts": attempts,
+            "edit_result": ExternalEditResult(
+                status="blocked",
+                command=f"--worker-type {wt} --sandbox",
+                stderr=(
+                    "Sandbox mode (--sandbox) runs the worker inside the container and "
+                    f"currently supports --worker-command only; the built-in '{wt}' worker "
+                    "is not installed in the sandbox image yet. Use --worker-command for "
+                    "sandboxed runs, or drop --sandbox to run the worker on the host with "
+                    "isolated validation (--workspace docker)."
+                ),
+            ),
+            "sandbox_blocked": [],
+            "execution_logs": append_logs(state, "worker_blocked:sandbox_worker_type_unsupported"),
+        }
+
     # Skip when workspace could not be prepared.
     if not state.get("workspace_report", PrepareResult()).ok:
         return {
@@ -441,11 +470,12 @@ def check_convergence_node(state: AgentOpsGraphState) -> AgentOpsGraphState:
     max_attempts = state.get("max_attempts", 2)
 
     # converged = tests passed (regardless of attempt count).
-    # The router uses attempts < max_attempts to decide retry vs proceed.
+    # The router uses _is_retriable_failure + attempts to decide retry vs proceed,
+    # so env/infra failures (can't run, no tests, timeout) don't trigger pointless retries.
     converged = passed
 
     retry_feedback = ""
-    if not converged and attempts < max_attempts:
+    if _is_retriable_failure(state) and attempts < max_attempts:
         # Collect truncated stderr from failed commands.
         failed_outputs: list[str] = []
         if test_results is not None:
@@ -673,12 +703,27 @@ def audit_conflicts_node(state: AgentOpsGraphState) -> AgentOpsGraphState:
     }
 
 
+def _is_retriable_failure(state: AgentOpsGraphState) -> bool:
+    """A failure is worth a worker retry only when tests genuinely RAN and FAILED.
+
+    A test command exit code of 1 means tests executed and failed — the worker can
+    fix that. Environment/infra failures are NOT the worker's fault and retrying is
+    pointless: exit 2 (can't run / collection error), 5 (no tests collected),
+    124 (timeout), 127 (command not found). Treat those as non-retriable.
+    """
+    test_results = state.get("test_results")
+    if test_results is None or test_results.passed:
+        return False
+    return any(cmd.exit_code == 1 for cmd in test_results.commands)
+
+
 def _route_convergence(state: AgentOpsGraphState) -> str:
     """Router for check_convergence conditional edge."""
-    conv = state.get("converged", True)
+    if state.get("edit_result") is None:
+        return "proceed"
     attempts = state.get("attempts", 1)
     max_attempts = state.get("max_attempts", 2)
-    if not conv and attempts < max_attempts:
+    if _is_retriable_failure(state) and attempts < max_attempts:
         return "retry"
     return "proceed"
 
@@ -801,6 +846,15 @@ def run_harness(
         status = "completed"
     if status == "completed" and edit_result is not None and edit_result.status != "completed":
         status = "failed"
+    # A worker was requested but never ran (e.g. workspace not ready) — don't report a
+    # bare "completed" with no edits; surface that the worker was blocked.
+    if (
+        status == "completed"
+        and edit_result is None
+        and (worker_type or worker_command)
+        and not graph_state["workspace_report"].ok
+    ):
+        status = "blocked"
     record = RunRecord(
         run_id=run_id,
         task=task,

--- a/app/core/graph.py
+++ b/app/core/graph.py
@@ -83,14 +83,24 @@ def prepare_workspace_node(state: AgentOpsGraphState) -> AgentOpsGraphState:
 
 
 def pre_dispatch_gate_node(state: AgentOpsGraphState) -> AgentOpsGraphState:
+    import shlex
+
     from app.core.security import is_sensitive_path
 
+    # Block on either the plan's intended edits OR an explicit worker command that
+    # references a sensitive path — so a denied edit is stopped before the worker runs.
     planned = {f for step in state["plan"].steps for f in step.files_to_edit}
-    denied = sorted(p for p in planned if is_sensitive_path(p))
+    command = state.get("worker_command") or ""
+    try:
+        command_tokens = set(shlex.split(command))
+    except ValueError:
+        command_tokens = set(command.split())
+    denied = sorted({p for p in planned | command_tokens if is_sensitive_path(p)})
+
     decision = PreDispatchDecision(
         blocked=bool(denied),
         denied_paths=denied,
-        reason=f"Plan targets sensitive paths: {denied}" if denied else "",
+        reason=f"Targets sensitive paths before dispatch: {denied}" if denied else "",
     )
     log = "pre_dispatch:blocked" if denied else "pre_dispatch:ok"
     return {"pre_dispatch": decision, "execution_logs": append_logs(state, log)}

--- a/app/core/graph.py
+++ b/app/core/graph.py
@@ -62,6 +62,11 @@ def make_workspace(state: AgentOpsGraphState) -> Workspace:
     ``isolation="full"`` the DockerWorkspace is configured for full-isolation mode
     (no bind-mount; worker runs inside; extract_permitted controls what lands on host).
     """
+    # The OpenHands worker runs its agent loop in its OWN DockerWorkspace, so the harness
+    # uses a local workspace (host validation) even under --sandbox — openhands provides the
+    # isolation itself, and its edits reflect to the host where the harness validates/governs.
+    if state.get("worker_type") == "openhands":
+        return LocalWorkspace(state["repo_path"])
     if state.get("workspace_kind") == "docker":
         isolation = state.get("isolation") or "validation"
         return DockerWorkspace(state["repo_path"], isolation=isolation)
@@ -191,14 +196,15 @@ def run_external_worker_node(state: AgentOpsGraphState) -> AgentOpsGraphState:
     attempts = state.get("attempts", 0) + 1
 
     # Sandbox (full isolation) runs the worker INSIDE the container, which only
-    # supports an explicit --worker-command for now. The built-in worker types
-    # (codex/claude/opencode/openhands) are not installed in the sandbox image yet,
-    # so block the combination explicitly instead of silently running on the host
-    # (which would not be sandboxed) or producing no edits. Checked first, so the
-    # invalid combination is reported regardless of workspace preparation.
+    # supports an explicit --worker-command for now. The CLI worker types
+    # (codex/claude/opencode) are not installed in the sandbox image yet, so block the
+    # combination explicitly instead of silently running on the host. The OpenHands
+    # worker is EXEMPT: it has its own DockerWorkspace (the agent loop runs in an
+    # OpenHands container), so --sandbox maps to that instead of being blocked.
     if (
         (state.get("isolation") or "validation") == "full"
         and state.get("worker_type")
+        and state.get("worker_type") != "openhands"
         and not state.get("worker_command")
     ):
         wt = state.get("worker_type")
@@ -312,11 +318,14 @@ def run_external_worker_node(state: AgentOpsGraphState) -> AgentOpsGraphState:
             allow_dirty=allow_dirty,
         )
     elif worker_type == "openhands":
+        # --sandbox runs the OpenHands agent loop inside its own DockerWorkspace.
+        oh_workspace = "docker" if (state.get("isolation") or "validation") == "full" else "local"
         edit_result = OpenHandsWorker().run(
             repo_path=state["repo_path"],
             task=task,
             timeout_seconds=timeout,
             allow_dirty=allow_dirty,
+            workspace=oh_workspace,
         )
     elif worker_command:
         edit_result = ExternalWorkerRunner().run(

--- a/app/core/workers/claude_worker.py
+++ b/app/core/workers/claude_worker.py
@@ -3,13 +3,13 @@ from __future__ import annotations
 
 import json
 import os
-import shutil
 import subprocess
 import time
 from pathlib import Path
 
 from app.core.git_utils import collect_status_lines, is_git_repo
 from app.core.workers.auth_errors import detect_auth_failure
+from app.core.workers.worker_env import find_worker_bin, worker_env
 from app.prompts.workers import build_worker_prompt
 from app.schemas.edit import ExternalEditResult
 
@@ -19,16 +19,16 @@ _CODING_TOOLS = "Read,Edit,Write,Bash,Glob,Grep"
 
 def _find_claude_bin() -> str | None:
     """Return the absolute path to the `claude` CLI, or None if not found."""
-    return shutil.which("claude")
+    return find_worker_bin("claude")
 
 
 def _subprocess_env() -> dict[str, str]:
     """Build env for the claude subprocess.
 
-    CLAUDECODE="" signals that a parent Claude Code session exists, which
-    prevents the child process from hitting the session-lock check.
+    Adds common global-bin dirs to PATH (worker_env). CLAUDECODE="" signals that
+    a parent Claude Code session exists, preventing the session-lock check.
     """
-    env = os.environ.copy()
+    env = worker_env()
     env["CLAUDECODE"] = ""
     return env
 

--- a/app/core/workers/codex_worker.py
+++ b/app/core/workers/codex_worker.py
@@ -1,25 +1,23 @@
 """OpenAI Codex CLI worker — delegates tasks to `codex` as a subprocess."""
 from __future__ import annotations
 
-import os
-import shutil
 import subprocess
 import time
 from pathlib import Path
 
 from app.core.git_utils import collect_status_lines, is_git_repo
 from app.core.workers.auth_errors import detect_auth_failure
+from app.core.workers.worker_env import find_worker_bin, worker_env
 from app.prompts.workers import build_worker_prompt
 from app.schemas.edit import ExternalEditResult
 
 
 def _find_codex_bin() -> str | None:
-    return shutil.which("codex")
+    return find_worker_bin("codex")
 
 
 def _subprocess_env() -> dict[str, str]:
-    env = os.environ.copy()
-    return env
+    return worker_env()
 
 
 CODEX_COMMAND_STR = "codex exec --sandbox workspace-write <prompt>"

--- a/app/core/workers/opencode_worker.py
+++ b/app/core/workers/opencode_worker.py
@@ -2,40 +2,24 @@
 from __future__ import annotations
 
 import os
-import shutil
 import subprocess
 import time
 from pathlib import Path
 
 from app.core.git_utils import collect_status_lines, is_git_repo
 from app.core.workers.auth_errors import detect_auth_failure
+from app.core.workers.worker_env import find_worker_bin, worker_env
 from app.prompts.workers import build_worker_prompt
 from app.schemas.edit import ExternalEditResult
 
 
 def _find_opencode_bin() -> str | None:
-    """Return the absolute path to `opencode`, including Bun's default bin dir."""
-    found = shutil.which("opencode")
-    if found:
-        return found
-    bun_bin = Path.home() / ".bun" / "bin" / "opencode"
-    if bun_bin.exists():
-        return str(bun_bin)
-    return None
+    """Return the absolute path to `opencode` (PATH + common global-bin dirs)."""
+    return find_worker_bin("opencode")
 
 
 def _subprocess_env() -> dict[str, str]:
-    """Build env for the opencode subprocess.
-
-    Bun installs global binaries into ~/.bun/bin by default. GUI-launched apps
-    often miss shell PATH customizations, so make that path explicit here.
-    """
-    env = os.environ.copy()
-    bun_bin = str(Path.home() / ".bun" / "bin")
-    current_path = env.get("PATH", "")
-    if bun_bin not in current_path.split(os.pathsep):
-        env["PATH"] = bun_bin + os.pathsep + current_path
-    return env
+    return worker_env()
 
 
 def _build_argv(opencode_bin: str, repo_path: Path, prompt: str) -> list[str]:

--- a/app/core/workers/openhands_runner.py
+++ b/app/core/workers/openhands_runner.py
@@ -1,12 +1,24 @@
-"""Subprocess entry point that runs one OpenHands SDK agent loop over a repo.
+"""Subprocess entry point that runs one full-capability OpenHands SDK agent loop.
 
 Kept as a separate process so the heavy `openhands` import is lazy and the run is
 timeout-bounded by the parent worker (the same subprocess pattern the CLI workers use).
-Implements the slide-16 six steps against the real OpenHands SDK 1.28 API:
-LLM -> Agent(tools) -> Conversation(workspace=repo) -> send_message -> run; the harness
-reads the resulting git diff itself (step 6).
 
-Reads the task prompt from stdin (avoids CLI arg-length limits). argv: <repo_path> [model].
+Wires the worker-harness anatomy (harness-project slides 6-17) onto the real OpenHands
+SDK 1.28 — we ADOPT these, we do not build them:
+  01 while loop ............ Conversation.run()
+  02 context management .... LLMSummarizingCondenser (condenser)
+  03 tools & skills ........ Terminal/FileEditor/TaskTracker tools + AgentContext.skills
+  05 built-in primitives ... Terminal + FileEditor tools
+  06 session persistence ... Conversation(persistence_dir, conversation_id)
+  07 system-prompt assembly  AgentContext.system_message_suffix  <- the AgentOps bridge
+  09 permissions & safety .. OpenHands security analyzer + NeverConfirm (autonomous)
+
+Workspace mode (env OPENHANDS_WORKSPACE):
+  - "local" (default): the agent loop runs in-process, editing the repo on the host.
+  - "docker": the agent loop runs INSIDE an OpenHands agent-server container, with the
+    repo bind-mounted (mount_dir) so edits land on the host repo. Realizes slide 16.
+
+Task prompt on stdin (avoids arg-length limits). argv: <repo_path> [model].
 Exit codes: 0 ok · 2 usage · 3 auth missing · 4 sdk not installed · 1 run error.
 """
 
@@ -14,15 +26,26 @@ from __future__ import annotations
 
 import os
 import sys
+import tempfile
+import uuid
 
 DEFAULT_MODEL = "anthropic/claude-sonnet-4-5-20250929"
+
+HARNESS_SYSTEM_SUFFIX = (
+    "\n\nYou are running as a worker inside the AgentOps Harness. Constraints:\n"
+    "- Make the smallest controlled change that satisfies the task; do not refactor "
+    "unrelated code.\n"
+    "- Do not edit secrets, auth, payment, or dependency files without being asked.\n"
+    "- Add or update a focused test for new behavior, then run the tests to verify.\n"
+    "- If blocked, summarize the blocker instead of a speculative large change."
+)
 
 
 def main() -> int:
     if len(sys.argv) < 2:
         print("usage: openhands_runner <repo_path> [model]  (task on stdin)", file=sys.stderr)
         return 2
-    repo_path = sys.argv[1]
+    repo_path = os.path.abspath(sys.argv[1])
     model = sys.argv[2] if len(sys.argv) > 2 else os.getenv("OPENHANDS_MODEL", DEFAULT_MODEL)
     task = sys.stdin.read().strip()
     if not task:
@@ -36,26 +59,90 @@ def main() -> int:
 
     try:
         from openhands.sdk import LLM, Agent, Conversation, Tool
+        from openhands.sdk.context import AgentContext
+        from openhands.sdk.context.condenser import LLMSummarizingCondenser
         from openhands.tools.file_editor import FileEditorTool
+        from openhands.tools.task_tracker import TaskTrackerTool
         from openhands.tools.terminal import TerminalTool
     except ImportError as exc:
         print(f"openhands sdk not installed: {exc}", file=sys.stderr)
         return 4
 
+    workspace_mode = os.getenv("OPENHANDS_WORKSPACE", "local").lower()
+
+    workspace = None
     try:
         llm = LLM(model=model, api_key=api_key)
+
+        # 02 context management — summarize older history, keep recent + first turns verbatim.
+        condenser = LLMSummarizingCondenser(llm=llm, max_size=80, keep_first=4)
+
+        # 03/07 skills + system-prompt assembly — the AgentOps constraints are injected
+        # here; load any skills/microagents the project ships.
+        agent_context = AgentContext(
+            system_message_suffix=HARNESS_SYSTEM_SUFFIX,
+            load_project_skills=True,
+        )
+
+        # 03/05 tools — terminal (bash/grep), file editor (read/write/edit), task tracker.
         agent = Agent(
             llm=llm,
-            tools=[Tool(name=TerminalTool.name), Tool(name=FileEditorTool.name)],
+            tools=[
+                Tool(name=TerminalTool.name),
+                Tool(name=FileEditorTool.name),
+                Tool(name=TaskTrackerTool.name),
+            ],
+            condenser=condenser,
+            agent_context=agent_context,
         )
-        conversation = Conversation(agent=agent, workspace=str(repo_path))
-        conversation.send_message(task)
-        conversation.run()
+
+        # 01 while loop + workspace selection.
+        if workspace_mode == "docker":
+            from openhands.workspace import DockerWorkspace
+
+            # The agent's repo lives at /workspace/project (Conversation default). Bind-mount
+            # the host repo THERE (not /workspace) so the agent edits the real files and the
+            # changes reflect straight back to the host — bidirectional, no extraction needed.
+            workspace = DockerWorkspace(
+                working_dir="/workspace",
+                volumes=[f"{repo_path}:/workspace/project"],
+                forward_env=["ANTHROPIC_API_KEY", "LLM_API_KEY", "OPENHANDS_MODEL"],
+            )
+            ws_arg = workspace
+        else:
+            ws_arg = repo_path
+
+        # 06 session persistence — replayable event log per run. A docker workspace uses a
+        # RemoteConversation that persists inside the container, so persistence_dir must NOT
+        # be set there; it is only valid for the in-process LocalConversation.
+        conv_kwargs: dict = {
+            "agent": agent,
+            "workspace": ws_arg,
+            "conversation_id": uuid.uuid4(),
+        }
+        if workspace_mode == "docker":
+            # The host repo is bind-mounted at /workspace/project, so the agent's edits
+            # reflect straight back to the host — no extraction step required.
+            conversation = Conversation(**conv_kwargs)
+            conversation.send_message(task)
+            conversation.run()
+        else:
+            with tempfile.TemporaryDirectory(prefix="agentops-oh-") as persist:
+                conversation = Conversation(persistence_dir=persist, **conv_kwargs)
+                conversation.send_message(task)
+                conversation.run()
     except Exception as exc:  # surface as a worker failure, not a crash
         print(f"openhands run error: {exc}", file=sys.stderr)
         return 1
+    finally:
+        # Clean up the docker workspace container if one was started.
+        if workspace is not None:
+            try:
+                workspace.close()
+            except Exception:
+                pass
 
-    print("openhands run complete")
+    print(f"openhands run complete (workspace={workspace_mode})")
     return 0
 
 

--- a/app/core/workers/openhands_runner.py
+++ b/app/core/workers/openhands_runner.py
@@ -24,6 +24,7 @@ Exit codes: 0 ok · 2 usage · 3 auth missing · 4 sdk not installed · 1 run er
 
 from __future__ import annotations
 
+import contextlib
 import os
 import sys
 import tempfile
@@ -165,10 +166,8 @@ def main() -> int:
     finally:
         # Clean up the docker workspace container if one was started.
         if workspace is not None:
-            try:
+            with contextlib.suppress(Exception):
                 workspace.close()
-            except Exception:
-                pass
 
     print(f"openhands run complete (workspace={workspace_mode})")
     return 0

--- a/app/core/workers/openhands_runner.py
+++ b/app/core/workers/openhands_runner.py
@@ -61,12 +61,23 @@ def main() -> int:
         from openhands.sdk import LLM, Agent, Conversation, Tool
         from openhands.sdk.context import AgentContext
         from openhands.sdk.context.condenser import LLMSummarizingCondenser
+        from openhands.sdk.security.llm_analyzer import LLMSecurityAnalyzer
+
+        # Importing the tool modules registers them so Tool(name=...) resolves at runtime.
+        from openhands.tools import delegate as _delegate  # noqa: F401 (registers sub-agents)
+        from openhands.tools import glob as _glob  # noqa: F401 (registers retrieval)
+        from openhands.tools import grep as _grep  # noqa: F401 (registers retrieval)
         from openhands.tools.file_editor import FileEditorTool
+        from openhands.tools.preset import register_builtins_agents
         from openhands.tools.task_tracker import TaskTrackerTool
         from openhands.tools.terminal import TerminalTool
     except ImportError as exc:
         print(f"openhands sdk not installed: {exc}", file=sys.stderr)
         return 4
+
+    # 04 sub-agents — register the built-in archetypes (code-explorer, general-purpose,
+    # web-researcher, bash-runner) so the `delegate` tool can spawn focused sub-agents.
+    register_builtins_agents()
 
     workspace_mode = os.getenv("OPENHANDS_WORKSPACE", "local").lower()
 
@@ -84,16 +95,26 @@ def main() -> int:
             load_project_skills=True,
         )
 
-        # 03/05 tools — terminal (bash/grep), file editor (read/write/edit), task tracker.
+        # Full inner-loop toolset:
+        #   05 primitives ... terminal, file_editor
+        #   working memory .. task_tracker
+        #   retrieval ....... grep, glob (agentic search beats one-shot RAG, slide 17)
+        # 04 sub-agents: the archetypes (code-explorer/general-purpose/web-researcher/
+        #   bash-runner) are registered above; the `delegate` tool that spawns them needs an
+        #   explicit register_tool(DelegateExecutor(...)) hookup — tracked as a follow-up.
+        # 09 permissions/safety: an LLM security analyzer assesses each action's risk.
         agent = Agent(
             llm=llm,
             tools=[
                 Tool(name=TerminalTool.name),
                 Tool(name=FileEditorTool.name),
                 Tool(name=TaskTrackerTool.name),
+                Tool(name="grep"),
+                Tool(name="glob"),
             ],
             condenser=condenser,
             agent_context=agent_context,
+            security_analyzer=LLMSecurityAnalyzer(),
         )
 
         # 01 while loop + workspace selection.
@@ -115,10 +136,17 @@ def main() -> int:
         # 06 session persistence — replayable event log per run. A docker workspace uses a
         # RemoteConversation that persists inside the container, so persistence_dir must NOT
         # be set there; it is only valid for the in-process LocalConversation.
+        # 08 lifecycle hooks — a callback observes every event (audit/observability);
+        # stuck-detection breaks pathological no-progress loops.
+        def _audit(event: object) -> None:
+            print(f"[oh-event] {type(event).__name__}", file=sys.stderr)
+
         conv_kwargs: dict = {
             "agent": agent,
             "workspace": ws_arg,
             "conversation_id": uuid.uuid4(),
+            "callbacks": [_audit],
+            "stuck_detection": True,
         }
         if workspace_mode == "docker":
             # The host repo is bind-mounted at /workspace/project, so the agent's edits

--- a/app/core/workers/openhands_worker.py
+++ b/app/core/workers/openhands_worker.py
@@ -9,6 +9,7 @@ in place; the harness reads the diff (step 6) via its existing collect_diff node
 
 from __future__ import annotations
 
+import os
 import subprocess
 import sys
 import time
@@ -31,6 +32,7 @@ class OpenHandsWorker:
         task: str,
         timeout_seconds: int = 300,
         allow_dirty: bool = False,
+        workspace: str = "local",
     ) -> ExternalEditResult:
         if not is_git_repo(repo_path):
             return ExternalEditResult(
@@ -51,6 +53,10 @@ class OpenHandsWorker:
 
         prompt = build_worker_prompt(repo_path=repo_path, task=task)
         argv = [sys.executable, "-m", "app.core.workers.openhands_runner", str(repo_path)]
+        # Select the OpenHands workspace mode (local in-process loop, or its own Docker
+        # agent-server container) for the runner subprocess.
+        env = os.environ.copy()
+        env["OPENHANDS_WORKSPACE"] = "docker" if workspace == "docker" else "local"
 
         started = time.perf_counter()
         try:
@@ -62,6 +68,7 @@ class OpenHandsWorker:
                 text=True,
                 timeout=timeout_seconds,
                 check=False,
+                env=env,
             )
         except subprocess.TimeoutExpired as exc:
             return ExternalEditResult(

--- a/app/core/workers/worker_env.py
+++ b/app/core/workers/worker_env.py
@@ -1,0 +1,48 @@
+"""Locate worker CLIs and build their subprocess env robustly.
+
+GUI-launched (e.g. the desktop app) or detached harness processes often run with a
+stripped PATH that misses the npm / bun / homebrew / cargo global-bin dirs where
+worker CLIs (codex, claude, opencode) actually live. `shutil.which("codex")` then
+returns None and the harness wrongly reports the worker as "not installed". These
+helpers add the common global-bin locations so workers are found regardless of how
+the harness was launched.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+from pathlib import Path
+
+_GLOBAL_BIN_DIRS = [
+    Path.home() / ".npm-global" / "bin",
+    Path.home() / ".bun" / "bin",
+    Path.home() / ".local" / "bin",
+    Path("/opt/homebrew/bin"),
+    Path("/usr/local/bin"),
+    Path.home() / ".cargo" / "bin",
+]
+
+
+def worker_env() -> dict[str, str]:
+    """Return os.environ plus common global-bin dirs prepended to PATH."""
+    env = os.environ.copy()
+    parts = env.get("PATH", "").split(os.pathsep)
+    for directory in _GLOBAL_BIN_DIRS:
+        as_str = str(directory)
+        if as_str not in parts:
+            parts.insert(0, as_str)
+    env["PATH"] = os.pathsep.join(parts)
+    return env
+
+
+def find_worker_bin(name: str) -> str | None:
+    """Locate a worker CLI on PATH or in the common global-bin dirs."""
+    found = shutil.which(name, path=worker_env()["PATH"])
+    if found:
+        return found
+    for directory in _GLOBAL_BIN_DIRS:
+        candidate = directory / name
+        if candidate.exists():
+            return str(candidate)
+    return None

--- a/docs/ARCHITECTURE_NORTH_STAR.md
+++ b/docs/ARCHITECTURE_NORTH_STAR.md
@@ -1,0 +1,104 @@
+# Architecture North Star — Two Decks, Two Layers, Two Semantics
+
+> The organizing principle for AgentOps Harness. Refines
+> [THREE_LAYER_FOUNDATION.md](THREE_LAYER_FOUNDATION.md) and
+> [reference/code-as-agent-harness/what-is-a-harness.md](reference/code-as-agent-harness/what-is-a-harness.md)
+> by mapping our two reference decks onto the two layers we actually build, and
+> separating the work accordingly.
+
+## 1. The core mapping
+
+Our two explainer decks are not two views of one thing — they describe two
+different layers, and we work them **separately**.
+
+| Deck | Describes | Our layer | We… |
+|---|---|---|---|
+| **harness-project** | the **inner loop** — what a capable coding agent *is* and how it performs | **Worker** | **adopt** (don't rebuild) |
+| **code-as-harness** (the paper) | how to **govern, verify, evolve** the closed loop | **AgentOps** (control plane) | **build** |
+
+**harness-project slides 6–17 are entirely worker anatomy:** the architecture around
+the loop (6), Claude Code's five layers (7), the **nine components** (8), each
+component — while-loop, context, tools, sub-agents, persistence, hooks, permissions
+(9–13), memory + skills (14–15), the **OpenHands SDK** (16), and the five performance
+levers (17). None of these are AgentOps. They are the worker.
+
+**code-as-harness is the control-plane thesis:** executable · inspectable · stateful ·
+governed; plan-execute-verify; semantic verification (§5.2.2); self-evolution (§3.5);
+convergence and the open problems (§5.2). That is what AgentOps adds *around* a worker.
+
+## 2. The boundary rule (the 10% nuance that matters)
+
+**The nine components are the *worker's*.** AgentOps implements none of them — no agent
+loop, no context compaction, no sub-agents. **OpenHands (or codex/claude) provides the
+nine components.** Therefore:
+
+> We do **not build** the inner loop. We **adopt** it. We build the control plane.
+
+This makes the two layers different *kinds* of work:
+- **Worker layer = an integration problem** — run a real, capable agent loop in isolation.
+- **AgentOps layer = a construction problem** — governance, verification, evidence, evolution.
+
+## 3. Two semantics (the deep split)
+
+"Semantic" matters in both decks — but means a different thing in each layer. Keeping
+them straight is what stops us from building the wrong thing.
+
+| | Inner loop (worker) | Outer loop (AgentOps) |
+|---|---|---|
+| **Kind** | semantic **retrieval** | semantic **verification** |
+| **Question** | "find the right code" | "did the change *mean* what was intended?" |
+| **Source** | slide-17 lever #1; Cursor semantic search (+12.5% accuracy, trained on agent traces) | code-as-harness slide 20 / §5.2.2 — "a green test is not the full specification" |
+| **Owner** | the worker (OpenHands/Cursor provide it) — **not our job** | **AgentOps — our frontier** |
+
+The Product Reviewer is our first reach at semantic verification; its deterministic
+heuristics are brittle (on nl2sql-viz it flagged correct work as `incomplete`). The
+**LLM-judged product-reviewer path *is* semantic verification** — that is where AgentOps
+earns its keep, not in retrieval.
+
+References: Cursor [semantic search](https://cursor.com/blog/semsearch) ·
+[continually improving the agent harness](https://cursor.com/blog/continually-improving-agent-harness).
+
+## 4. The inner/outer loop dynamic
+
+The decks describe two loops (transcript: *"an inner loop that works on the task and an
+outer loop that looks how can we continue"*):
+
+- **Inner loop** = the worker's `prompt → model → action → feedback`, 50–200×. Slide 5.
+- **Outer loop** = AgentOps's `plan → worker → enforce → validate → retry`, plus the
+  evolution loop (§3.5). Cursor's "improve the harness from agent traces" is this outer
+  loop improving the inner loop's retrieval — a concrete example of the two interacting.
+
+## 5. Where we stand vs. the frontier (honest)
+
+**Worker layer:** four workers run (codex/opencode/claude verified; OpenHands integrated)
+— **but only on the host.** No real agent loop runs *inside the isolated Docker
+workspace* yet; the sandbox is proven only with non-looping shell commands. Slide 16's
+"agent loop in a DockerWorkspace" is **not yet realized.**
+
+**AgentOps layer:** governance is real and enforced (pre-dispatch block · revert-on-deny ·
+sandbox · bounded retry); evidence trail, convergence benchmark, conflict auditor, and a
+*deterministic* product reviewer exist. **Semantic verification (§5.2.2) is the gap** —
+the LLM reviewer path and an evidence bundle that declares scope/confidence per check.
+
+## 6. Why real tasks force both layers up
+
+A small task (`add /healthz`) exercises a trivial inner loop and a shallow check. A real
+task (a feature, a migration) needs:
+- **Worker:** a genuine long-horizon loop, **in isolation** (OpenHands in a DockerWorkspace).
+- **AgentOps:** **semantic** verification over the whole trajectory — "does it serve the
+  goal, with what's unverified made explicit," not "tests pass."
+
+Small tasks never stress either. The roadmap must.
+
+## 7. The work model
+
+Advance the two layers **separately**, each against its own deck:
+
+- **Worker track (harness-project deck):** adopt + isolate. Next: OpenHands on a
+  DockerWorkspace so a real agent loop runs **and is tested** inside the sandbox.
+- **AgentOps track (code-as-harness deck):** build governance + **semantic verification**.
+  Next: the LLM product-reviewer path + scoped/confident evidence (§5.2.2).
+
+Same nesting as before (CEO → AgentOps → Worker); this doc just fixes *which deck owns
+which layer* and *what kind of work each demands*, so we stop conflating "make the agent
+better" (worker, adopted) with "govern and verify the loop" (AgentOps, built).

--- a/docs/MANUAL_SMOKE_TEST.md
+++ b/docs/MANUAL_SMOKE_TEST.md
@@ -1,0 +1,141 @@
+# Manual Smoke Test — AgentOps Harness
+
+A short by-hand checklist to validate the whole harness end-to-end (e.g. before a demo).
+Each step has a command and a **pass criterion**. ~15 minutes.
+
+## Before you start (gotchas that bite)
+
+- **Keep `--storage` OUTSIDE the target repo.** Writing run history into the target dirties
+  it and edit mode will refuse to run. Use `--storage /tmp/smoke/runs.db`.
+- **Edit mode needs a clean target** — `git status` in the target must be empty (or pass `--allow-dirty`).
+- **claude worker needs a key:** `source ~/.zprofile` first (sets `ANTHROPIC_API_KEY`). codex/opencode use their own auth.
+- **`--workspace docker`** needs Docker running and the target's deps installable (`uv sync` must succeed).
+- Run everything from the project root with `uv run --extra dev` (or `--extra openhands` for the OpenHands worker).
+
+```bash
+# one-time setup for the run
+uv sync --extra dev
+rm -rf /tmp/smoke && mkdir -p /tmp/smoke
+cp -r examples/sample_fastapi_app /tmp/smoke/app && cd /tmp/smoke/app
+cat > agentops.goals.yaml <<'YAML'
+north_star: A small FastAPI service with health endpoints.
+goals:
+  - id: G1
+    statement: Expose operational readiness.
+    priority: now
+    success_when: ["A /healthz endpoint is added.", "A test covers /healthz."]
+    scope_out: ["Authentication or billing."]
+YAML
+git init -q && git add -A && git commit -qm init
+cd -   # back to the harness project root
+```
+
+## 1. Unit suite is green
+```bash
+uv run --extra dev python -m pytest -q -m "not docker"
+```
+☐ **Pass:** `213 passed` (± a few), 0 failed. `ruff check .` → all checks passed.
+
+## 2. Observe run + CEO product review (free, no edits)
+```bash
+uv run --extra dev agentops run --repo /tmp/smoke/app --goal G1 \
+  --task "Add a /healthz endpoint with a test" --storage /tmp/smoke/runs.db
+```
+☐ **Pass:** report prints a `## Product Review` section with a verdict + cited findings;
+`changed_files` empty; target repo still clean (`git -C /tmp/smoke/app status` → clean).
+
+## 3. Evidence bundle exists
+```bash
+RID=$(ls /tmp/smoke/runs/); ls /tmp/smoke/runs/$RID
+```
+☐ **Pass:** ~16 files incl. `repo_graph.json`, `task_plan.yaml`, `product_review.json`,
+`workspace_report.json`, `final_report.md`, `trace.jsonl`, `run_record.json`.
+
+## 4. Real worker edit (governance + attribution)
+```bash
+source ~/.zprofile   # for the claude worker; codex/opencode skip this
+uv run --extra dev agentops edit --repo /tmp/smoke/app --worker-type codex --goal G1 \
+  --task "Add a GET /healthz endpoint returning {\"status\":\"ok\"} and a test" \
+  --worker-timeout-seconds 180 --storage /tmp/smoke/runs.db
+```
+☐ **Pass:** worker edits land (`git -C /tmp/smoke/app diff` shows `/healthz` + a test);
+`changed_files` lists only real files (no `__pycache__`). Try `--worker-type claude` and
+`--worker-type opencode` too — each should make a real edit (claude needs the key).
+*(reset the target between worker runs: `cd /tmp/smoke/app && git checkout . && git clean -fd && cd -`)*
+
+## 5. Pre-dispatch enforcement (block before the worker runs)
+```bash
+cd /tmp/smoke/app && git checkout . && git clean -fd && cd -
+uv run --extra dev agentops edit --repo /tmp/smoke/app \
+  --worker-command "agentops-scripted-edit secrets.py 'leak'" \
+  --task "touch a secret" --storage /tmp/smoke/runs.db
+```
+☐ **Pass:** run status **blocked**, the worker never ran, `secrets.py` does NOT exist in the target.
+
+## 6. Revert-on-deny (undo a denied change the worker made)
+```bash
+uv run --extra dev agentops edit --repo /tmp/smoke/app \
+  --worker-command "sh -c 'echo a > NOTES.md; echo leak > secrets.py'" \
+  --task "write notes" --storage /tmp/smoke/runs.db
+```
+☐ **Pass:** `NOTES.md` exists (permitted), `secrets.py` does NOT (reverted); the report's
+permission section lists `secrets.py` under enforced reverts.
+
+## 7. Bounded retry loop
+```bash
+# (retry fires on a genuine test failure; an env failure must NOT retry)
+# Observe the run log / final report: "attempts" should be 1 when validation can't run
+# (missing deps), and >1 only when a test actually ran and failed.
+```
+☐ **Pass:** a missing-deps target shows `attempts: 1` (no pointless retry); `--max-attempts 2`
+with a genuinely failing test shows `attempts: 2`.
+
+## 8. Isolated Docker workspace — validation in a container (needs Docker)
+```bash
+# Docker validation is exposed on `run` (observe). It builds a container, uv-syncs
+# the target, runs validation inside it, and fails fast on a broken env.
+uv run --extra dev agentops run --repo /tmp/smoke/app --goal G1 \
+  --workspace docker --task "Add /healthz" --storage /tmp/smoke/runs.db
+```
+☐ **Pass:** `workspace_report.ok` is true and validation ran in the container; a broken-deps
+target instead fails fast with a clear `workspace_report` diagnostic (seconds, not a hang).
+`docker ps -a` shows no leaked `agentops-ws-*` containers afterward.
+*(Known gap: `agentops edit` has no `--workspace` flag — Docker-validation with a host worker
+isn't reachable via the CLI yet; `edit --sandbox` jumps straight to full isolation. Follow-up.)*
+
+## 9. Sandbox — worker runs in a throwaway container (needs Docker)
+```bash
+uv run --extra dev agentops edit --repo /tmp/smoke/app \
+  --worker-command "sh -c 'echo a > NOTES.md; echo leak > secrets.py'" \
+  --sandbox --task "write notes" --storage /tmp/smoke/runs.db
+```
+☐ **Pass:** `NOTES.md` reaches the host, `secrets.py` does NOT (physically prevented — it
+existed only in the container). `--sandbox` implies Docker full-isolation; no `--workspace` needed.
+*(Note: `--sandbox` with a built-in `--worker-type` is intentionally blocked — only
+`--worker-command` is sandboxed today.)*
+
+## 10. OpenHands worker (real SDK agent loop)
+```bash
+source ~/.zprofile
+uv run --extra openhands agentops edit --repo /tmp/smoke/app --worker-type openhands \
+  --task "Add a /healthz endpoint" --worker-timeout-seconds 200 --storage /tmp/smoke/runs.db
+```
+☐ **Pass:** a real OpenHands agent edits the repo; `edit_result` completed; changes attributed.
+
+## 11. Surfaces (API + MCP)
+```bash
+uv run --extra dev uvicorn app.api:api --port 8099 &   # then:
+curl -s -XPOST localhost:8099/runs -H 'Content-Type: application/json' \
+  -d '{"repo_path":"/tmp/smoke/app","task":"Add /healthz"}' | head -c 200
+uv run --extra dev agentops-mcp <<< ''   # starts the MCP stdio server (Ctrl-C to stop)
+```
+☐ **Pass:** `POST /runs` returns a run record JSON; `agentops-mcp` starts without error.
+
+## Cleanup
+```bash
+rm -rf /tmp/smoke; docker rm -f $(docker ps -aq --filter "name=agentops-ws-") 2>/dev/null
+```
+
+---
+**If any step fails, capture:** the command, the run id (`ls /tmp/smoke/runs`), and the
+relevant artifact (`/tmp/smoke/runs/<id>/run_record.json`) — that's enough to diagnose.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ dev = [
 openhands = [
     "openhands-sdk>=1.28.0",
     "openhands-tools>=1.28.0",
+    "openhands-workspace>=1.28.0",
 ]
 
 [project.scripts]

--- a/tests/test_ephemeral_and_predispatch.py
+++ b/tests/test_ephemeral_and_predispatch.py
@@ -24,6 +24,13 @@ def test_ephemeral_path_detection():
     assert not is_ephemeral_path("tests/test_x.py")
 
 
+def test_egg_info_directory_and_nested_files_filtered():
+    assert is_ephemeral_path("pkg.egg-info")              # the dir entry
+    assert is_ephemeral_path("pkg.egg-info/PKG-INFO")     # files nested inside
+    assert is_ephemeral_path("src/mylib.egg-info/SOURCES.txt")
+    assert not is_ephemeral_path("app/pkg_info.py")       # not an egg-info path
+
+
 def test_pre_dispatch_blocks_worker_command_targeting_secret(tmp_path):
     repo = tmp_path / "r"
     _repo(repo)

--- a/tests/test_ephemeral_and_predispatch.py
+++ b/tests/test_ephemeral_and_predispatch.py
@@ -1,0 +1,39 @@
+import subprocess
+from pathlib import Path
+
+from app.core.git_utils import is_ephemeral_path
+from app.core.graph import run_harness
+
+
+def _repo(p: Path):
+    p.mkdir(parents=True, exist_ok=True)
+    for c in (["git", "init", "-q"], ["git", "config", "user.email", "t@t"],
+              ["git", "config", "user.name", "t"]):
+        subprocess.run(c, cwd=p, check=True)
+    (p / "app.py").write_text("x=1\n")
+    subprocess.run(["git", "add", "-A"], cwd=p, check=True)
+    subprocess.run(["git", "commit", "-qm", "i"], cwd=p, check=True)
+
+
+def test_ephemeral_path_detection():
+    assert is_ephemeral_path("app/__pycache__/main.cpython-312.pyc")
+    assert is_ephemeral_path("x.pyc")
+    assert is_ephemeral_path(".pytest_cache/v/cache")
+    assert is_ephemeral_path(".DS_Store")
+    assert not is_ephemeral_path("app/main.py")
+    assert not is_ephemeral_path("tests/test_x.py")
+
+
+def test_pre_dispatch_blocks_worker_command_targeting_secret(tmp_path):
+    repo = tmp_path / "r"
+    _repo(repo)
+    record = run_harness(
+        repo_path=repo,
+        task="touch a secret",
+        storage_path=tmp_path / "runs.db",
+        worker_command="agentops-scripted-edit secrets.py 'leak'",
+    )
+    assert record.pre_dispatch.blocked is True
+    assert "secrets.py" in record.pre_dispatch.denied_paths
+    assert record.edit_result is None  # worker never ran
+    assert not (repo / "secrets.py").exists()  # nothing was written

--- a/tests/test_langgraph_workflow.py
+++ b/tests/test_langgraph_workflow.py
@@ -29,7 +29,7 @@ def test_langgraph_run_records_node_trace(tmp_path: Path) -> None:
         "create_plan:complete",
         "prepare_workspace:start",
         "prepare_workspace:complete",
-        "pre_dispatch:ok",
+        "pre_dispatch:observe",
         "collect_diff:start",
         "collect_diff:complete",
         "enforce_permissions:skip",

--- a/tests/test_pre_dispatch_gate.py
+++ b/tests/test_pre_dispatch_gate.py
@@ -6,81 +6,70 @@ from app.schemas.governance import PreDispatchDecision
 from app.schemas.plan import ImplementationPlan, PlanStep
 
 
-def _make_state_with_sensitive_plan(tmp_repo: Path) -> dict:
-    """Build a minimal graph state whose plan targets a sensitive path."""
-    plan = ImplementationPlan(
+def _plan(files: list[str]) -> ImplementationPlan:
+    return ImplementationPlan(
         task="test",
         summary="test",
-        steps=[
-            PlanStep(
-                id=1,
-                title="edit auth",
-                description="edit auth",
-                files_to_edit=["app/auth/login.py"],
-            )
-        ],
+        steps=[PlanStep(id=1, title="x", description="x", files_to_edit=files)],
     )
-    return {
-        "plan": plan,
-        "execution_logs": [],
-    }
 
 
-def _make_state_with_safe_plan(tmp_repo: Path) -> dict:
-    plan = ImplementationPlan(
-        task="test",
-        summary="test",
-        steps=[
-            PlanStep(
-                id=1,
-                title="edit readme",
-                description="edit readme",
-                files_to_edit=["README.md"],
-            )
-        ],
-    )
-    return {
-        "plan": plan,
-        "execution_logs": [],
-    }
-
-
-def test_pre_dispatch_gate_blocks_sensitive_plan(tmp_path):
-    state = _make_state_with_sensitive_plan(tmp_path)
-    result = pre_dispatch_gate_node(state)
-    decision: PreDispatchDecision = result["pre_dispatch"]
-    assert decision.blocked is True
-    assert "app/auth/login.py" in decision.denied_paths
-
-
-def test_pre_dispatch_gate_allows_safe_plan(tmp_path):
-    state = _make_state_with_safe_plan(tmp_path)
-    result = pre_dispatch_gate_node(state)
-    decision: PreDispatchDecision = result["pre_dispatch"]
+def test_observe_mode_never_blocks_even_with_sensitive_plan():
+    # No worker configured (observe) -> nothing to dispatch -> never blocked,
+    # even if the planner's files_to_edit happens to list a sensitive/security path.
+    state = {"plan": _plan(["app/auth/login.py", "tests/security/test_x.py"]), "execution_logs": []}
+    decision: PreDispatchDecision = pre_dispatch_gate_node(state)["pre_dispatch"]
     assert decision.blocked is False
     assert decision.denied_paths == []
 
 
+def test_blocks_when_worker_command_targets_sensitive_path():
+    state = {
+        "plan": _plan(["README.md"]),
+        "worker_command": "agentops-scripted-edit secrets.py 'leak'",
+        "execution_logs": [],
+    }
+    decision: PreDispatchDecision = pre_dispatch_gate_node(state)["pre_dispatch"]
+    assert decision.blocked is True
+    assert "secrets.py" in decision.denied_paths
+
+
+def test_worker_type_alone_is_not_pre_blocked():
+    # A --worker-type worker decides its own edits; pre-dispatch can't predict them.
+    # It is not blocked here (post-edit revert / sandbox handle enforcement).
+    state = {"plan": _plan(["app/main.py"]), "worker_type": "codex", "execution_logs": []}
+    decision: PreDispatchDecision = pre_dispatch_gate_node(state)["pre_dispatch"]
+    assert decision.blocked is False
+
+
 def _repo(p: Path):
     p.mkdir(parents=True, exist_ok=True)
-    subprocess.run(["git", "init", "-q"], cwd=p, check=True)
-    subprocess.run(["git", "config", "user.email", "t@t"], cwd=p, check=True)
-    subprocess.run(["git", "config", "user.name", "t"], cwd=p, check=True)
+    for c in (
+        ["git", "init", "-q"],
+        ["git", "config", "user.email", "t@t"],
+        ["git", "config", "user.name", "t"],
+    ):
+        subprocess.run(c, cwd=p, check=True)
     (p / "auth.py").write_text("x = 1\n")
     subprocess.run(["git", "add", "-A"], cwd=p, check=True)
     subprocess.run(["git", "commit", "-qm", "i"], cwd=p, check=True)
 
 
-def test_pre_dispatch_blocks_worker_when_plan_targets_sensitive(tmp_path):
+def test_run_harness_blocks_worker_command_targeting_secret(tmp_path):
     repo = tmp_path / "r"
     _repo(repo)
     record = run_harness(
         repo_path=repo,
-        task="Edit the auth module",
+        task="edit a secret",
         storage_path=tmp_path / "runs.db",
         worker_command="agentops-scripted-edit secrets.py 'x'",
     )
-    # If the plan targets a sensitive path, the worker is skipped and status is blocked.
-    # (If the deterministic planner does not produce a sensitive file for this task,
-    #  this test injects one — see Step 3 note.)
-    assert record.pre_dispatch.blocked is False or record.edit_result is None
+    assert record.pre_dispatch.blocked is True
+    assert record.edit_result is None  # worker never ran
+
+
+def test_run_harness_observe_is_not_blocked(tmp_path):
+    repo = tmp_path / "r2"
+    _repo(repo)
+    record = run_harness(repo_path=repo, task="analyze", storage_path=tmp_path / "runs.db")
+    assert record.pre_dispatch.blocked is False

--- a/tests/test_pre_dispatch_gate.py
+++ b/tests/test_pre_dispatch_gate.py
@@ -34,6 +34,28 @@ def test_blocks_when_worker_command_targets_sensitive_path():
     assert "secrets.py" in decision.denied_paths
 
 
+def test_bare_subcommand_token_does_not_false_block():
+    # 'auth' is a subcommand here, not a path — it must not trip the sensitive-folder match.
+    state = {
+        "plan": _plan(["README.md"]),
+        "worker_command": "my-worker auth update feature.py",
+        "execution_logs": [],
+    }
+    decision: PreDispatchDecision = pre_dispatch_gate_node(state)["pre_dispatch"]
+    assert decision.blocked is False
+
+
+def test_real_sensitive_path_in_command_still_blocks():
+    state = {
+        "plan": _plan(["README.md"]),
+        "worker_command": "edit app/auth/login.py",
+        "execution_logs": [],
+    }
+    decision: PreDispatchDecision = pre_dispatch_gate_node(state)["pre_dispatch"]
+    assert decision.blocked is True
+    assert "app/auth/login.py" in decision.denied_paths
+
+
 def test_worker_type_alone_is_not_pre_blocked():
     # A --worker-type worker decides its own edits; pre-dispatch can't predict them.
     # It is not blocked here (post-edit revert / sandbox handle enforcement).

--- a/tests/test_retry_loop.py
+++ b/tests/test_retry_loop.py
@@ -44,3 +44,20 @@ def test_loop_stops_at_one_when_validation_passes(tmp_path):
     )
     assert record.attempts == 1
     assert record.converged is True
+
+
+def test_loop_does_not_retry_on_env_failure(tmp_path):
+    # Exit code 2 = the test command could not run (env/infra error, not a genuine
+    # test failure). Retrying the worker cannot fix that, so the loop must NOT retry.
+    repo = tmp_path / "renv"
+    _repo(repo)
+    record = run_harness(
+        repo_path=repo,
+        task="add notes",
+        storage_path=tmp_path / "runs.db",
+        worker_command="agentops-scripted-edit NOTES.md 'note'",
+        test_commands=["python -c 'import sys; sys.exit(2)'"],
+        max_attempts=3,
+    )
+    assert record.attempts == 1
+    assert record.converged is False

--- a/tests/test_revert_on_deny.py
+++ b/tests/test_revert_on_deny.py
@@ -17,14 +17,19 @@ def _repo(p):
 
 
 def test_denied_change_is_reverted(tmp_path):
+    # Revert-on-deny is the SECOND line of defense: it catches a denied file the
+    # worker wrote that the pre-dispatch gate could not predict. The path is embedded
+    # in a shell string (not a standalone token), so the gate passes and the worker
+    # writes secrets.py — which enforce_permissions must then revert.
     repo = tmp_path / "r"
     _repo(repo)
     record = run_harness(
         repo_path=repo,
-        task="add a secrets file",
+        task="write some config",
         storage_path=tmp_path / "runs.db",
-        worker_command="agentops-scripted-edit secrets.py 'leak'",
+        worker_command="sh -c 'echo leak > secrets.py'",
     )
+    assert record.pre_dispatch.blocked is False  # gate did not catch it
     assert "secrets.py" in record.permission_report.enforced_reverts
     assert "secrets.py" not in record.changed_files
     assert not (repo / "secrets.py").exists()

--- a/tests/test_sandbox_worker_type_guard.py
+++ b/tests/test_sandbox_worker_type_guard.py
@@ -1,0 +1,36 @@
+import subprocess
+
+from app.core.graph import run_harness
+
+
+def _repo(p):
+    p.mkdir(parents=True, exist_ok=True)
+    for c in (
+        ["git", "init", "-q"],
+        ["git", "config", "user.email", "t@t"],
+        ["git", "config", "user.name", "t"],
+    ):
+        subprocess.run(c, cwd=p, check=True)
+    (p / "app.py").write_text("x=1\n")
+    subprocess.run(["git", "add", "-A"], cwd=p, check=True)
+    subprocess.run(["git", "commit", "-qm", "i"], cwd=p, check=True)
+
+
+def test_sandbox_with_worker_type_blocks_honestly(tmp_path):
+    # --sandbox runs the worker in-container, which only supports --worker-command.
+    # A built-in worker type must be blocked with a clear message, not silently no-op.
+    # The guard returns before any workspace prep, so no docker is needed.
+    repo = tmp_path / "r"
+    _repo(repo)
+    record = run_harness(
+        repo_path=repo,
+        task="add something",
+        storage_path=tmp_path / "runs.db",
+        worker_type="codex",
+        workspace_kind="docker",
+        isolation="full",
+    )
+    assert record.edit_result is not None
+    assert record.edit_result.status == "blocked"
+    assert "worker-command" in record.edit_result.stderr
+    assert record.status != "completed"

--- a/tests/test_sandbox_worker_type_guard.py
+++ b/tests/test_sandbox_worker_type_guard.py
@@ -33,4 +33,25 @@ def test_sandbox_with_worker_type_blocks_honestly(tmp_path):
     assert record.edit_result is not None
     assert record.edit_result.status == "blocked"
     assert "worker-command" in record.edit_result.stderr
-    assert record.status != "completed"
+    # The run status must reflect blocked, not be collapsed into "failed".
+    assert record.status == "blocked"
+
+
+def test_sandbox_blocked_worker_does_not_retry(tmp_path):
+    # A blocked worker won't unblock on retry — even with failing validation and
+    # max_attempts > 1, the loop must not re-run it.
+    repo = tmp_path / "r2"
+    _repo(repo)
+    record = run_harness(
+        repo_path=repo,
+        task="add something",
+        storage_path=tmp_path / "runs.db",
+        worker_type="codex",
+        workspace_kind="docker",
+        isolation="full",
+        test_commands=["python -c 'import sys; sys.exit(1)'"],
+        max_attempts=3,
+    )
+    assert record.edit_result.status == "blocked"
+    assert record.status == "blocked"
+    assert record.attempts == 1

--- a/tests/test_worker_env.py
+++ b/tests/test_worker_env.py
@@ -1,0 +1,10 @@
+from app.core.workers.worker_env import find_worker_bin, worker_env
+
+
+def test_worker_env_includes_npm_global_on_path():
+    path = worker_env()["PATH"]
+    assert ".npm-global/bin" in path or "/.bun/bin" in path
+
+
+def test_find_worker_bin_returns_none_for_missing():
+    assert find_worker_bin("definitely-not-a-real-cli-zzz") is None

--- a/uv.lock
+++ b/uv.lock
@@ -46,6 +46,7 @@ dev = [
 openhands = [
     { name = "openhands-sdk" },
     { name = "openhands-tools" },
+    { name = "openhands-workspace" },
 ]
 
 [package.metadata]
@@ -58,6 +59,7 @@ requires-dist = [
     { name = "openai", specifier = ">=1.99.0" },
     { name = "openhands-sdk", marker = "extra == 'openhands'", specifier = ">=1.28.0" },
     { name = "openhands-tools", marker = "extra == 'openhands'", specifier = ">=1.28.0" },
+    { name = "openhands-workspace", marker = "extra == 'openhands'", specifier = ">=1.28.0" },
     { name = "pydantic", specifier = ">=2.8.0" },
     { name = "pydantic-settings", specifier = ">=2.4.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.2.0" },
@@ -210,6 +212,29 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/61/62/06741b579156360248d1ec624842ad0edf697050bbaf7c3e46394e106ad1/aiosignal-1.4.0.tar.gz", hash = "sha256:f47eecd9468083c2029cc99945502cb7708b082c232f9aca65da147157b251c7", size = 25007, upload-time = "2025-07-03T22:54:43.528Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/fb/76/641ae371508676492379f16e2fa48f4e2c11741bd63c48be4b12a6b09cba/aiosignal-1.4.0-py3-none-any.whl", hash = "sha256:053243f8b92b990551949e63930a839ff0cf0b0ebbe0597b0f3fb19e1a0fe82e", size = 7490, upload-time = "2025-07-03T22:54:42.156Z" },
+]
+
+[[package]]
+name = "aiosqlite"
+version = "0.22.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4e/8a/64761f4005f17809769d23e518d915db74e6310474e733e3593cfc854ef1/aiosqlite-0.22.1.tar.gz", hash = "sha256:043e0bd78d32888c0a9ca90fc788b38796843360c855a7262a532813133a0650", size = 14821, upload-time = "2025-12-23T19:25:43.997Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/00/b7/e3bf5133d697a08128598c8d0abc5e16377b51465a33756de24fa7dee953/aiosqlite-0.22.1-py3-none-any.whl", hash = "sha256:21c002eb13823fad740196c5a2e9d8e62f6243bd9e7e4a1f87fb5e44ecb4fceb", size = 17405, upload-time = "2025-12-23T19:25:42.139Z" },
+]
+
+[[package]]
+name = "alembic"
+version = "1.18.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mako" },
+    { name = "sqlalchemy" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/94/13/8b084e0f2efb0275a1d534838844926f798bd766566b1375174e2448cd31/alembic-1.18.4.tar.gz", hash = "sha256:cb6e1fd84b6174ab8dbb2329f86d631ba9559dd78df550b57804d607672cedbc", size = 2056725, upload-time = "2026-02-10T16:00:47.195Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d2/29/6533c317b74f707ea28f8d633734dbda2119bbadfc61b2f3640ba835d0f7/alembic-1.18.4-py3-none-any.whl", hash = "sha256:a5ed4adcf6d8a4cb575f3d759f071b03cd6e5c7618eb796cb52497be25bfe19a", size = 263893, upload-time = "2026-02-10T16:00:49.997Z" },
 ]
 
 [[package]]
@@ -727,6 +752,20 @@ wheels = [
 ]
 
 [[package]]
+name = "docker"
+version = "7.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pywin32", marker = "sys_platform == 'win32'" },
+    { name = "requests" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/91/9b/4a2ea29aeba62471211598dac5d96825bb49348fa07e906ea930394a83ce/docker-7.1.0.tar.gz", hash = "sha256:ad8c70e6e3f8926cb8a92619b832b4ea5299e2831c14284663184e200546fa6c", size = 117834, upload-time = "2024-05-23T11:13:57.216Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e3/26/57c6fb270950d476074c087527a558ccb6f4436657314bfb6cdf484114c4/docker-7.1.0-py3-none-any.whl", hash = "sha256:c96b93b7f0a746f9e77d325bcfb87422a3d8bd4f03136ae8a85b37f1898d5fc0", size = 147774, upload-time = "2024-05-23T11:13:55.01Z" },
+]
+
+[[package]]
 name = "docstring-parser"
 version = "0.18.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1116,6 +1155,61 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/b5/c8/f439cffde755cffa462bfbb156278fa6f9d09119719af9814b858fd4f81f/googleapis_common_protos-1.75.0.tar.gz", hash = "sha256:53a062ff3c32552fbd62c11fe23768b78e4ddf0494d5e5fd97d3f4689c75fbbd", size = 151035, upload-time = "2026-05-07T08:04:49.423Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e7/c8/e2645aa8ed02fd4c7a2f59d68783b65b1f3cbdfe39a6308e156509d1fee8/googleapis_common_protos-1.75.0-py3-none-any.whl", hash = "sha256:961ed60399c457ceb0ee8f285a84c870aabc9c6a832b9d37bb281b5bebde43ed", size = 300631, upload-time = "2026-05-07T08:03:30.345Z" },
+]
+
+[[package]]
+name = "greenlet"
+version = "3.5.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6d/6e/802acd792aebb2256fbbee8cacf2727faaeb6f240ac11008f09eae4414bc/greenlet-3.5.1.tar.gz", hash = "sha256:5a56aeb7d5d9cc4b3a735efb5095bd4b4f6f0e4f93e5ca876d0e2315137b7829", size = 197356, upload-time = "2026-05-20T15:05:03.917Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c4/37/4549f149c9797c21b32c2683c33522af22522099de128b2406672526d005/greenlet-3.5.1-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:fa4f98af3a528f0c3fd592a26df7f376f93329c8f4d987f6bb979057af8bf5e2", size = 286220, upload-time = "2026-05-20T13:07:28.463Z" },
+    { url = "https://files.pythonhosted.org/packages/38/ff/a4f436709716965eaab9f36ea7b906c8a927fbe32fb1372a2071d964f6b1/greenlet-3.5.1-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ffea73584b216150eab159b6d12348fb253e68757974de1e2c40d8a318ac89ed", size = 601585, upload-time = "2026-05-20T14:00:06.141Z" },
+    { url = "https://files.pythonhosted.org/packages/65/ad/54bc3fcee3ad368a61b19b67d88117f7a8c29727bf71fffdeda81fbd946e/greenlet-3.5.1-cp312-cp312-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:1072b4f9edcc1e192d9283a66a3e68d6b84c561de33a83d7858beb9ba1effe10", size = 614215, upload-time = "2026-05-20T14:05:42.675Z" },
+    { url = "https://files.pythonhosted.org/packages/40/69/b91cda0647df839483201545913514c2827ebea5e5ccdf931842763bc127/greenlet-3.5.1-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:add5217d68b31130f0beca584d7fef4878327d2e31642b66618a14eef312b63b", size = 611358, upload-time = "2026-05-20T13:14:26.37Z" },
+    { url = "https://files.pythonhosted.org/packages/59/90/3cf77e080350cd02fa307bb2abf05df48f4482c240275bbd2c203ba8bb1c/greenlet-3.5.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:a5ea42a752d47a145eae922b605cd1634665ac3d5ec1e72402d5048e8d60d207", size = 1570475, upload-time = "2026-05-20T14:02:25.29Z" },
+    { url = "https://files.pythonhosted.org/packages/65/2c/18cece62045e74598c3c393f70dce4a63f56222015ba29a5d4eeb04f764c/greenlet-3.5.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:c5551170cf4f5ff5623e9af81323751979fee2c731e2287b61f73cd27257b823", size = 1635625, upload-time = "2026-05-20T13:14:34.027Z" },
+    { url = "https://files.pythonhosted.org/packages/30/f5/310d104ddf41eb5a70f4c268d22508dfb0c3c8e86fec152be34d0d2ed819/greenlet-3.5.1-cp312-cp312-win_amd64.whl", hash = "sha256:3c8bb982ad117d29478ef8f5533e97df21f1e2befd17a299257b0c96d1371c0b", size = 238791, upload-time = "2026-05-20T13:10:39.018Z" },
+    { url = "https://files.pythonhosted.org/packages/62/90/ceca11f504cd23a8047a3dea31919adc48df9b626dd0c13f0d858734fdfd/greenlet-3.5.1-cp312-cp312-win_arm64.whl", hash = "sha256:80eb4b04dadc4e67df3fae179a32c4706a3f495bc7f22fc8a81115d5f5512188", size = 235580, upload-time = "2026-05-20T13:08:45.056Z" },
+    { url = "https://files.pythonhosted.org/packages/27/69/7f7e5372d998b81001899b1c0823c957aa413ba0f2662e65821611cc31e4/greenlet-3.5.1-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:51518ff74664078fc51bffcc6fc529b0df5ae58da192691cee765d45ce944a2b", size = 285060, upload-time = "2026-05-20T13:08:51.899Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/bf/387f9b6b865fd2ae0d0be09e0004827295a01b71be76ed350dd1e28a91a4/greenlet-3.5.1-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1ffdb3c0bb002c99cd8f298957e046c3dbf6006b5b7cdf11a4e19194624a0a0a", size = 604370, upload-time = "2026-05-20T14:00:07.492Z" },
+    { url = "https://files.pythonhosted.org/packages/32/f5/169ce3d4e4c67291bd18f8cbe0299c9f3e45102c7f1fb3c14780c93e4532/greenlet-3.5.1-cp313-cp313-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:7715a5a2c3378ba602c3a440558261e13a820bb53a82693aacd7b7f6d964e283", size = 616987, upload-time = "2026-05-20T14:05:44.237Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/e5/7f2e41d5273be07e77560d61ea4e56485b4d6c316d2a84518c62d1364061/greenlet-3.5.1-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:dc71ff466927a201b08305acac451ebe1aedfcea002f62f1f2f2ac2ac1e6a135", size = 613911, upload-time = "2026-05-20T13:14:27.539Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/a4/fbdc67579b73615a1f91615e814303cc71e06128f7baaba87be79b8fb90c/greenlet-3.5.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:cd443683db272ebaaca03af98c0b063ab30db70ea8a31a1559f35e3f7b744ccd", size = 1570689, upload-time = "2026-05-20T14:02:27.225Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/b4/77abbe35078be39718a46cd49caf16bceb35662f97a34101dca28aa98e47/greenlet-3.5.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:089fff7a6ce8d9316d1f65ebc00273a56be258c1725b32b94de90a3a979557e1", size = 1635602, upload-time = "2026-05-20T13:14:36.344Z" },
+    { url = "https://files.pythonhosted.org/packages/37/f7/129f27ca700845b8ee8ca88ce7f43435a1239c2eddb7677fc938822762cf/greenlet-3.5.1-cp313-cp313-win_amd64.whl", hash = "sha256:110a1ca7b49b014b097f6078272c3f4ed31af45b254de5228b79adba879f6af9", size = 238683, upload-time = "2026-05-20T13:11:50.57Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/5c/a485a36e87df8d8fd0632ee01511244f5156a20ed3746cc6599340326395/greenlet-3.5.1-cp313-cp313-win_arm64.whl", hash = "sha256:f16ba1efc0715b680a18b8123d90dad887c6112ae3555b4b5c32c149540c6b4e", size = 235499, upload-time = "2026-05-20T13:12:42.028Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/cb/c62454606daf5640369c94d8a9dd540599b1bfc090e2d2180cb77f4038d2/greenlet-3.5.1-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:d8ab31c9de8651a2facdd5c5bb0011f2380dd1a7af78ce2adf4b56095294fc07", size = 285579, upload-time = "2026-05-20T13:08:56.396Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/71/c4270398c2eba968a6071af1dfbdcaeee6ec1c24bc8b435b8cc452700da6/greenlet-3.5.1-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5e300185139abc337ade480c327183adf42a875ac7181bfe66d7d4efea31fbea", size = 651106, upload-time = "2026-05-20T14:00:09.448Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/ab/71e34b78a44ec271fb5f550c17bc46d301ddc5953890d935f270b0dcdb5a/greenlet-3.5.1-cp314-cp314-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:7ffdb990dcaa0234cf9845aead5df2e3c3a8b6507d409274dd87e0d5ab05ffc2", size = 663478, upload-time = "2026-05-20T14:05:45.88Z" },
+    { url = "https://files.pythonhosted.org/packages/77/96/4efd6fa5c62c85426a0c19077a586258ebc3a2a146ff2493e4312a697a22/greenlet-3.5.1-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2f82b3597e9d83b63408affed0b48fd0f54935edac4302237b9a837be0dae33c", size = 660800, upload-time = "2026-05-20T13:14:29.129Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/e0/6c71401a25cac7000261304e866a2f2cc04dc74810d40e2f118aa4799495/greenlet-3.5.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:c0141e37414c10164e702b8fb1473304221ad98f71600850c6ef7ff4880feba0", size = 1617518, upload-time = "2026-05-20T14:02:28.662Z" },
+    { url = "https://files.pythonhosted.org/packages/41/26/c5c06643e8c0af9e7bf18e16cb51d0ab7625155f0392e1c9015d66d556cd/greenlet-3.5.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:50ae25a67bea74ea41fb14b960bc532df73eb713417b2d61892dced82fe8d3bc", size = 1681593, upload-time = "2026-05-20T13:14:39.417Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/bd/e11a108317485075e68af9d23039619b86b28130c3b50d227d42edece64b/greenlet-3.5.1-cp314-cp314-win_amd64.whl", hash = "sha256:8a17c42330e261299766b75ac1ea32caa437a9453c8f65d16a13140db378ecd3", size = 239800, upload-time = "2026-05-20T13:09:30.128Z" },
+    { url = "https://files.pythonhosted.org/packages/47/f8/8e8e8417b7bf28639a5a56356ef934d0375e1d0c70a57e04d7701e870ffe/greenlet-3.5.1-cp314-cp314-win_arm64.whl", hash = "sha256:7b5f5fae05b8ac6d176a61b60c394a8cbdc2b5b91b81793066e68745cf165e54", size = 236862, upload-time = "2026-05-20T13:09:10.498Z" },
+    { url = "https://files.pythonhosted.org/packages/90/12/41bf27fde4d3605d3773ae57751eda182b8be2f5398011c041173b1d9534/greenlet-3.5.1-cp314-cp314t-macosx_11_0_universal2.whl", hash = "sha256:ea8da1e900d758d078810d4255d8c6aa572181896a31ec79d779eb79c3adc9ad", size = 293637, upload-time = "2026-05-20T13:12:35.529Z" },
+    { url = "https://files.pythonhosted.org/packages/44/44/ba14b23e9757707050c2f397d305bbcae62e5d7cad122f8b6baec5ae4a1f/greenlet-3.5.1-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a19570c52a21420dcbc94e661994bc325c0b5b11304540fed514586da5dc8f2e", size = 650840, upload-time = "2026-05-20T14:00:11.079Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/37/5ddc2b686a6844f91abecef43411842426da2e1573f60b49ecf2547f4ae1/greenlet-3.5.1-cp314-cp314t-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:3d955c89b75eeca4723d7cc14135f393cd47c32e2a6cb4a8e4c6e760a26b0986", size = 656416, upload-time = "2026-05-20T14:05:47.118Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/f0/d17510297c35a2992712f0bf84de3779749999f7d3d63aa1f09db7c62dbe/greenlet-3.5.1-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:de2daaaebd1a5aa88c49045b6baf9310b3263796bd88db713edf37cf53e7bb4e", size = 654397, upload-time = "2026-05-20T13:14:30.696Z" },
+    { url = "https://files.pythonhosted.org/packages/37/eb/147387705bb89092645b012586e7273cb5ed3c90ef7eaf3a69173eaf0209/greenlet-3.5.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:3bfbd69cc349e43bf3a8ae1c85548ff0718efc887615c2db16c3833d7b0b072d", size = 1614469, upload-time = "2026-05-20T14:02:30.192Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/4e/37ee0da7732b7aa9896f17e15579a9df34b9fcb9dd494f0adfa749af6623/greenlet-3.5.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:4378720dd888136c27215a0214d32a4d37c3852765d45bc37aad0623423cfd78", size = 1675115, upload-time = "2026-05-20T13:14:40.972Z" },
+    { url = "https://files.pythonhosted.org/packages/57/f3/97dfcf4a6eb5077f8a672234216fb5923eb89f2cab7081cb10b2cf75b605/greenlet-3.5.1-cp314-cp314t-win_amd64.whl", hash = "sha256:45718441607f9325d948db98cbc691276059316d0358c188c246da4e1d4d23d2", size = 245246, upload-time = "2026-05-20T13:12:22.646Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/73/d7f72e34b582f694f4a9b248162db7b09cc458a259ba8f0c0bfa1a34ea7d/greenlet-3.5.1-cp315-cp315-macosx_11_0_universal2.whl", hash = "sha256:2baee5ca02031757ffe8cc3d69f0cc0aec7065ce362622da74f32d3bcab1c541", size = 285575, upload-time = "2026-05-20T13:12:07.043Z" },
+    { url = "https://files.pythonhosted.org/packages/df/59/fa9c6e87dc8ad27a95dabe2f29f372b733d05a8a67470f6c901ed9975655/greenlet-3.5.1-cp315-cp315-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9b1ec3274918a81d3ea778b9e75b56b72b33f300edb6cf7f3a7fe1dae56683de", size = 656428, upload-time = "2026-05-20T14:00:12.556Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/f9/e753408871eaa61dfe35e619cfc67512b036fde99893685d50eea9e07146/greenlet-3.5.1-cp315-cp315-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:111e2390ffffc47d5840b01711dd7fac07d4c09283d0283e7f3264b14e284c64", size = 667064, upload-time = "2026-05-20T14:05:48.662Z" },
+    { url = "https://files.pythonhosted.org/packages/96/27/5565b5b40389f1c7753003a07e21892fda8660926787036d5bc0308b8113/greenlet-3.5.1-cp315-cp315-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e630136e905fe5ff43e86945ae41220b6d1470956a39220e708110ac48d01ea5", size = 665697, upload-time = "2026-05-20T13:14:32.943Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/82/e7de4178c0c2d1c9a5a3be3cc0b33e46a85b3ee4a77c071bf7ad8600e079/greenlet-3.5.1-cp315-cp315-musllinux_1_2_aarch64.whl", hash = "sha256:975eac34b44a7077ca4d421348455b94f0f518246a7f14bc6d2fdcfe5b584368", size = 1621256, upload-time = "2026-05-20T14:02:31.91Z" },
+    { url = "https://files.pythonhosted.org/packages/00/10/f2dddcf7dacac17dfc68691809589adad06135eb28930429cf58a6467a2f/greenlet-3.5.1-cp315-cp315-musllinux_1_2_x86_64.whl", hash = "sha256:9ab3c3a0b2ae6198e67c898dad5215a49f9ae0d0081b3c3ec59f333e39eeca26", size = 1685956, upload-time = "2026-05-20T13:14:42.55Z" },
+    { url = "https://files.pythonhosted.org/packages/22/17/4a232b32133230ada52f70e9d7f5b65b0caef8772f01849bd8d149e7e4ca/greenlet-3.5.1-cp315-cp315-win_amd64.whl", hash = "sha256:cbfc69be86e10dcfef5b1e6269d1d6926552aa89ee39e1de3353360c1b6989ab", size = 239802, upload-time = "2026-05-20T13:13:15.481Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/ae/4e623a7e6d4d2a5f4cb8e4c82de4169fc637942caae68d6e676b8a128ac5/greenlet-3.5.1-cp315-cp315-win_arm64.whl", hash = "sha256:92fd6d44ac5e5a887c8a5dc4a8ba0ba908527c31c12f78c6bc7dcfe8aab279f6", size = 236853, upload-time = "2026-05-20T13:15:37.301Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/57/816d9cff29119da3505b3d6a5e14a8af89006ac36f47f891ff293ee05af1/greenlet-3.5.1-cp315-cp315t-macosx_11_0_universal2.whl", hash = "sha256:a6fdf2433a5441ef9a95464f7c3e674775da1c8c1177fff311cee1acad4626ed", size = 293877, upload-time = "2026-05-20T13:10:19.078Z" },
+    { url = "https://files.pythonhosted.org/packages/23/a1/59b0a7c7d140ff1a75626680b9a9899b79a9176cab298b394968fb023295/greenlet-3.5.1-cp315-cp315t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7546556f0d649f99f6a361098a55f761181bb2ea12ff150bb16d26092ad88244", size = 655333, upload-time = "2026-05-20T14:00:14.758Z" },
+    { url = "https://files.pythonhosted.org/packages/72/1b/5efe127597625042218939d01855109f352779050768b670b52edcc16a6c/greenlet-3.5.1-cp315-cp315t-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:d5ee3ea898009fa898f85f9982255d35278c477bebe185beca249cab42d4526c", size = 659443, upload-time = "2026-05-20T14:05:50.159Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/6d/c404246ea4d22d097a7426d0efb5b781bd7eb67715f09e79001bd552ab18/greenlet-3.5.1-cp315-cp315t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a5c81f74d204d3edd136ebfd50dce53acbb776995d721a0fe801626cfc93b8cd", size = 658356, upload-time = "2026-05-20T13:14:35.091Z" },
+    { url = "https://files.pythonhosted.org/packages/51/02/f8ee37fb6d2219329f350af241c27fcf12df57e723d11f6fc6d3bacdadaa/greenlet-3.5.1-cp315-cp315t-musllinux_1_2_aarch64.whl", hash = "sha256:2c18ef16bf6d4dd410e4dd52996888ea1497be26892fe5bbc73580aba4287b8e", size = 1619216, upload-time = "2026-05-20T14:02:33.403Z" },
+    { url = "https://files.pythonhosted.org/packages/93/c5/3dc9475ace2c7a3680da12372cddd7f1ac874eb410a1ac48d3e9dab83782/greenlet-3.5.1-cp315-cp315t-musllinux_1_2_x86_64.whl", hash = "sha256:17d86354f0ae6b61bf9be5148d0dd34e06c3cb7c602c671f79f29ac3b150e659", size = 1678427, upload-time = "2026-05-20T13:14:43.71Z" },
+    { url = "https://files.pythonhosted.org/packages/df/4e/750c15c317a41ffb36f0bf40b933e3d744a7dede61889f74443ea69690cf/greenlet-3.5.1-cp315-cp315t-win_amd64.whl", hash = "sha256:e7516cf6ae6b8a582c2770a0caed47b8a48373ed732c33d69a72913ae6ac923e", size = 245225, upload-time = "2026-05-20T13:13:59.366Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/fd/d3baea2eeb7b617efd47e87ca06e2ec2c6118d303aa9e918e0ce16eadc10/greenlet-3.5.1-cp315-cp315t-win_arm64.whl", hash = "sha256:5028648bf2253ec4745add746129d3904121fa7fe871a76bed23c5720573ce0a", size = 239590, upload-time = "2026-05-20T13:13:37.382Z" },
 ]
 
 [[package]]
@@ -1995,6 +2089,18 @@ wheels = [
 ]
 
 [[package]]
+name = "mako"
+version = "1.3.12"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markupsafe" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/00/62/791b31e69ae182791ec67f04850f2f062716bbd205483d63a215f3e062d3/mako-1.3.12.tar.gz", hash = "sha256:9f778e93289bd410bb35daadeb4fc66d95a746f0b75777b942088b7fd7af550a", size = 400219, upload-time = "2026-04-28T19:01:08.512Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bc/b1/a0ec7a5a9db730a08daef1fdfb8090435b82465abbf758a596f0ea88727e/mako-1.3.12-py3-none-any.whl", hash = "sha256:8f61569480282dbf557145ce441e4ba888be453c30989f879f0d652e39f53ea9", size = 78521, upload-time = "2026-04-28T19:01:10.393Z" },
+]
+
+[[package]]
 name = "markdown-it-py"
 version = "4.2.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2278,6 +2384,28 @@ wheels = [
 ]
 
 [[package]]
+name = "openhands-agent-server"
+version = "1.28.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "aiosqlite" },
+    { name = "alembic" },
+    { name = "docker" },
+    { name = "fastapi" },
+    { name = "openai" },
+    { name = "openhands-sdk" },
+    { name = "pydantic" },
+    { name = "sqlalchemy" },
+    { name = "uvicorn" },
+    { name = "websockets" },
+    { name = "wsproto" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fe/28/bd20c4ae4f0ea99bcfea527283fce010ef238657c097b1e884d0f872f831/openhands_agent_server-1.28.1.tar.gz", hash = "sha256:0872294349ac88e7b4b32e7104a13e154a7afc15d9df288b67fe67aa06c2f95e", size = 152987, upload-time = "2026-06-11T18:35:21.568Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0e/2e/4ee2b211cb008ee65e0c4c4ae7d248435cde42a17e3adad23f0b1495d203/openhands_agent_server-1.28.1-py3-none-any.whl", hash = "sha256:3ab38343033ce6ec8b24b7eeaa4b8b251aaad7d7be798d987ce8f56e6eca1a8f", size = 177263, upload-time = "2026-06-11T18:35:17.807Z" },
+]
+
+[[package]]
 name = "openhands-sdk"
 version = "1.28.1"
 source = { registry = "https://pypi.org/simple" }
@@ -2324,6 +2452,20 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/b5/25/0507f0d99d87d3605395772c0e0c2d73adeeb5c0a3c9319559257582adef/openhands_tools-1.28.1.tar.gz", hash = "sha256:47667fec9b981da57a64cb1ce3d93b1e3405d2a5f408c3741668240901a72507", size = 142489, upload-time = "2026-06-11T18:35:15.544Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/66/aa/ed7c2b9874504d638260d36e63cdd6a1da5148b3459c6326fd651b9bab63/openhands_tools-1.28.1-py3-none-any.whl", hash = "sha256:9ebee79b05e20321f3f7518bf5eb74aa85cf39f0b43a63c5895c57d0a1da2dc0", size = 187637, upload-time = "2026-06-11T18:35:19.912Z" },
+]
+
+[[package]]
+name = "openhands-workspace"
+version = "1.28.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "openhands-agent-server" },
+    { name = "openhands-sdk" },
+    { name = "pydantic" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/53/73/d03ebf6a7632fde5ba4e048d6c626f80ac405edd648aaee226dbfed1c8e3/openhands_workspace-1.28.1.tar.gz", hash = "sha256:ad45fb5e7d5141fd0ae2586a3477e13cf79800f1987beb5117f5b1d06f403394", size = 23660, upload-time = "2026-06-11T18:35:20.882Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0a/ad/f02d5925aea567ffb5a769f2dfe7ef6570dbc45176ccbb8e2a2bca9a4f1c/openhands_workspace-1.28.1-py3-none-any.whl", hash = "sha256:e4113bf3d1a4bc83e23c925b2977d5ecbd29d376f2f5580a729a9321e8c3b5cb", size = 27877, upload-time = "2026-06-11T18:35:18.914Z" },
 ]
 
 [[package]]
@@ -6479,6 +6621,47 @@ wheels = [
 ]
 
 [[package]]
+name = "sqlalchemy"
+version = "2.0.50"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "greenlet", marker = "platform_machine == 'AMD64' or platform_machine == 'WIN32' or platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'ppc64le' or platform_machine == 'win32' or platform_machine == 'x86_64'" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/57/da/6fbf010c8ebb347679d0d100b22fe9ba5e13fd04046c5df7280d2f0bf706/sqlalchemy-2.0.50.tar.gz", hash = "sha256:af5607d11ef90fd6a5c0549fe0045dce1663d427426bcfb506dcb5346a85a3b9", size = 9907424, upload-time = "2026-05-24T19:20:04.018Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/be/b0/a9d19b43f38f878b1278bca5b00b909f7540d41494396dd2561f9ad0956d/sqlalchemy-2.0.50-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:23ae23d8b9d344d30d0a92f06d45825024a5790f1c1dd4cf452636a50d3e58cb", size = 2159807, upload-time = "2026-05-24T19:27:53.086Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/2c/191dd58a248fd2cfd4780fa82c375c505e4ad98c8b522fa69ec492130d77/sqlalchemy-2.0.50-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:47b71b933e7b4ebad407c8fdfd70d2c4f08b78b3238bb30eebdd6eb32ca51b89", size = 3343358, upload-time = "2026-05-24T20:09:29.279Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/2b/514fce8a7df81cf5bad7ff7865de7ac0c5776a38cc043475c4703eb7fe8b/sqlalchemy-2.0.50-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:110fdac56ace278949f00de805edacbd6141e382d992f9ba28238b3a0827a600", size = 3357994, upload-time = "2026-05-24T20:17:13.495Z" },
+    { url = "https://files.pythonhosted.org/packages/35/a6/a0e283f5494f92b0d77e319ff77e437b1ffe4a051ba67c81d53234825475/sqlalchemy-2.0.50-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:0f5e4ac70e9e757f6b3e87c0491ff034442ecd8dfd36d041a50564c322dafc0e", size = 3289399, upload-time = "2026-05-24T20:09:32.239Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/96/1b07325ba71752d6a028b77d07bed1483ad545f794e8b1dc89b3ba3b3c68/sqlalchemy-2.0.50-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:724f3dcbe53dd0151e3cb5e7ec4ba4c620bede579caacd16275dc35ce06e8615", size = 3321216, upload-time = "2026-05-24T20:17:15.581Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/8e/bad6ed253e8a99edfc99af02f7173ec48a1d3ed1b9b35a1b8bc1700900cc/sqlalchemy-2.0.50-cp312-cp312-win32.whl", hash = "sha256:1208050441471d003b7c8cb4054fb084f185cf35ac3f0ea270803865bca9939a", size = 2119194, upload-time = "2026-05-24T19:50:04.943Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/2d/314a6690dda4b9cfc571eab1a63cf6fe6e1470aa3759ccda6aa016ee0f5a/sqlalchemy-2.0.50-cp312-cp312-win_amd64.whl", hash = "sha256:9d1af51558029a156a70986b7df88f042b3d158d7c8d8fb5072912d4b32d89c7", size = 2146186, upload-time = "2026-05-24T19:50:06.74Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/c4/c42356b527296e9862f67990efce31ef78b4cf69cd3f80873a528a060320/sqlalchemy-2.0.50-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:06a9210bdc5f4298cff0781087e2ff45683922252dacc452846373a58761f093", size = 2156697, upload-time = "2026-05-24T19:27:54.764Z" },
+    { url = "https://files.pythonhosted.org/packages/60/a1/b1a70e3c4365ac7fe9e347f3710f19b562c866fb96d45e3c891588789a7b/sqlalchemy-2.0.50-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8b53784972ade4f8174b9aa661f31a06f8a936d2cfdd602913ff3c6dd40ae873", size = 3284260, upload-time = "2026-05-24T20:09:34.195Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/4a/f3ac3caa19f263d57b0a47f8c91bbf56583dc2d3fc63acfbf644abb24fe0/sqlalchemy-2.0.50-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:31648fa14460537e768a7303b078e4344d208e0d23e06867c1f376a227ed82db", size = 3302280, upload-time = "2026-05-24T20:17:17.825Z" },
+    { url = "https://files.pythonhosted.org/packages/66/55/ccada3e3d62254587819749a0bc69f41173eb48a6e385d10e66d32a9c88e/sqlalchemy-2.0.50-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:03f4323c980ad0e918cc9e5369b015f759f4e534db5bbaf4dc36832c10d05064", size = 3231580, upload-time = "2026-05-24T20:09:36.406Z" },
+    { url = "https://files.pythonhosted.org/packages/05/f6/6809349130a2de0e109e7f00fd7d431da9565b9b2868b32ee684754f672b/sqlalchemy-2.0.50-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:2b9dcc43afef8ac157cd92fce96985d6b8b0cfbd3df4d666f66b4d55a75d202f", size = 3269375, upload-time = "2026-05-24T20:17:20.34Z" },
+    { url = "https://files.pythonhosted.org/packages/48/84/278a811ef4e07be9c89dc5cdd7be833268509a66a68c4897cf585e67428f/sqlalchemy-2.0.50-cp313-cp313-win32.whl", hash = "sha256:60922d6599065ddca2c6f376b9aa2f41a6b85a271725e0909490bbc50b1998a5", size = 2117229, upload-time = "2026-05-24T19:50:08.215Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/1c/067cc6187ed32d2ec222fe6d2643acc1659a6d0659f8a7cbc5ad3ae83280/sqlalchemy-2.0.50-cp313-cp313-win_amd64.whl", hash = "sha256:287086e67275a212c4582d166a6fb03a65ccc5551d80866270ce0dd9f34eccd3", size = 2143126, upload-time = "2026-05-24T19:50:09.691Z" },
+    { url = "https://files.pythonhosted.org/packages/df/32/10ac51b4be7cdecd7e93d069251c86dfbf70b7adbd7c67b48ccea6c49e1c/sqlalchemy-2.0.50-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c966932507a4d7d0a37314927dbfcd89720e3f37d2a1e3352e7ae7939fa8e8a0", size = 2158519, upload-time = "2026-05-24T19:27:56.472Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/76/e703d2f7681d7d66c4c891af3f07c7ccf4c76ad7f18351de035b5eda007a/sqlalchemy-2.0.50-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:faffef4bcc20a1892e65e155293d99d60855bbbc79250ab712819cfd56a8e6bb", size = 3282063, upload-time = "2026-05-24T20:09:38.57Z" },
+    { url = "https://files.pythonhosted.org/packages/31/26/ef168b184a25701f9995e8fb7e503fafd7a99c1c77cda1bc1a26ea2ed486/sqlalchemy-2.0.50-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6c206aec519a2e7bd08abbfb33436e325fd22c632d9c21a9047e376ce241646e", size = 3287069, upload-time = "2026-05-24T20:17:21.942Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/15/765acc2bc693bccc43ca4a95d5b69750da8aaf6db1b5c616536e087f8920/sqlalchemy-2.0.50-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:bef4ac756363227ef6402a75fee025a4bc690f92328e825868939b3b3a446a6d", size = 3230453, upload-time = "2026-05-24T20:09:40.398Z" },
+    { url = "https://files.pythonhosted.org/packages/63/61/08e03c3adbf5db0087a0b6816746fec8f3032fb2f7fc899a9bb9b2a48ce4/sqlalchemy-2.0.50-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:96fbee6b19c19cd1556c8bf9419447cf2ec149ffcab7ab64348c23e54ef8547f", size = 3252413, upload-time = "2026-05-24T20:17:24.067Z" },
+    { url = "https://files.pythonhosted.org/packages/03/0c/370a1f2db38436c615e10134c8a37de3688e74084792380695f3f5083860/sqlalchemy-2.0.50-cp314-cp314-win32.whl", hash = "sha256:8f00e3eb43ba30eb1b238ee03a8a62309486d1321eda3328bb611e0340033ad8", size = 2120063, upload-time = "2026-05-24T19:50:11.08Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/a0/fe92bb9817863bc13ba093bda931979a26cc2ca69f8e8f26d07add3d7c6f/sqlalchemy-2.0.50-cp314-cp314-win_amd64.whl", hash = "sha256:15708c613cd5005b7dffe1f66ee6a63ee8f5e46799f71c70ebad74178c676a39", size = 2145830, upload-time = "2026-05-24T19:50:12.452Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/ff/e5640a98a0b2f491eb8fde10fb6c773621a2e44340de231fafcc9370f4a9/sqlalchemy-2.0.50-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:3699dac4be410e97049a1658e9480da9cde956594aa0f3aebc60b88f21c5ba70", size = 2178435, upload-time = "2026-05-24T19:42:58.889Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/85/337116e186f1236375b5fb70c21cfac98e8e8ab0d3a47be838dc47a59e08/sqlalchemy-2.0.50-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f96233858e3df43932ac11589e22520da6e8aeb624b03fedfeebb0e8ea213086", size = 3566059, upload-time = "2026-05-24T20:01:20.848Z" },
+    { url = "https://files.pythonhosted.org/packages/96/34/bb0e190e161c3c2c24314a65add57218be14a4a9486886b7f5047c1ff7c8/sqlalchemy-2.0.50-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c4e70c46fad30c3bcc6a4708bc0130a3173e11a5b25f0ea4a9d8911b450f1f52", size = 3535366, upload-time = "2026-05-24T20:03:56.768Z" },
+    { url = "https://files.pythonhosted.org/packages/df/5a/a7f759f97e4fd499c5d4e4488c760d5a7fbecf3028b465a04274fcd52384/sqlalchemy-2.0.50-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:1918a3cf564d16d95bca7301005f41ab2ad50b07cd3b9da50d3ed986db148d6a", size = 3474879, upload-time = "2026-05-24T20:01:23.058Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/d9/2907ea38eb60687d297bf9c39e5ee58053c87b57fe8a9cae97090cecbf10/sqlalchemy-2.0.50-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:b00098cdbdbd38c7be3d568b0c9c3122b8c0ec62b911b57cd5e6e0254d60a76d", size = 3486117, upload-time = "2026-05-24T20:03:59.052Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/e3/5aa06f167559f8c0bdae487e297d23ba548150ab016a3418265d617a4985/sqlalchemy-2.0.50-cp314-cp314t-win32.whl", hash = "sha256:1fbd55a969d7ac44a98e3dec75016074f809fa08f871585ace58dde110d1bf3e", size = 2150823, upload-time = "2026-05-24T20:08:58.644Z" },
+    { url = "https://files.pythonhosted.org/packages/65/9b/112fb8f977582d7489d036e409e3723948bcf5320b3ac465f3c481bbe8f9/sqlalchemy-2.0.50-cp314-cp314t-win_amd64.whl", hash = "sha256:c5c3cdb753a9004183e1ccb634b41611654c989e61bc68617ce878e46d6f1e51", size = 2185794, upload-time = "2026-05-24T20:09:00.319Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/10/f7220e9b784d295d241c86ed99aeb537f92afcd469a64861f2717e9bb077/sqlalchemy-2.0.50-py3-none-any.whl", hash = "sha256:92064363517a3ff8212b5a93b8c62876579d8dfd1ca5b561335f30152d884fa9", size = 1943861, upload-time = "2026-05-24T19:59:01.119Z" },
+]
+
+[[package]]
 name = "sse-starlette"
 version = "3.4.4"
 source = { registry = "https://pypi.org/simple" }
@@ -7039,6 +7222,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/79/d9/7cfd5a312760ac4dd8bf0184a6ee9e43c33e47f3dadc303032ce012b8fa3/wrapt-1.17.3-cp314-cp314t-win_amd64.whl", hash = "sha256:73d496de46cd2cdbdbcce4ae4bcdb4afb6a11234a1df9c085249d55166b95116", size = 41334, upload-time = "2025-08-12T05:53:14.178Z" },
     { url = "https://files.pythonhosted.org/packages/46/78/10ad9781128ed2f99dbc474f43283b13fea8ba58723e98844367531c18e9/wrapt-1.17.3-cp314-cp314t-win_arm64.whl", hash = "sha256:f38e60678850c42461d4202739f9bf1e3a737c7ad283638251e79cc49effb6b6", size = 38471, upload-time = "2025-08-12T05:52:57.784Z" },
     { url = "https://files.pythonhosted.org/packages/1f/f6/a933bd70f98e9cf3e08167fc5cd7aaaca49147e48411c0bd5ae701bb2194/wrapt-1.17.3-py3-none-any.whl", hash = "sha256:7171ae35d2c33d326ac19dd8facb1e82e5fd04ef8c6c0e394d7af55a55051c22", size = 23591, upload-time = "2025-08-12T05:53:20.674Z" },
+]
+
+[[package]]
+name = "wsproto"
+version = "1.3.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c7/79/12135bdf8b9c9367b8701c2c19a14c913c120b882d50b014ca0d38083c2c/wsproto-1.3.2.tar.gz", hash = "sha256:b86885dcf294e15204919950f666e06ffc6c7c114ca900b060d6e16293528294", size = 50116, upload-time = "2025-11-20T18:18:01.871Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a4/f5/10b68b7b1544245097b2a1b8238f66f2fc6dcaeb24ba5d917f52bd2eed4f/wsproto-1.3.2-py3-none-any.whl", hash = "sha256:61eea322cdf56e8cc904bd3ad7573359a242ba65688716b0710a5eb12beab584", size = 24405, upload-time = "2025-11-20T18:18:00.454Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

A full end-to-end dry-run on real repos (the manual-testing pass before more milestones) surfaced **5 integration bugs** that unit tests missed — all fixed and re-verified.

| # | Issue | Fix |
|---|---|---|
| 1 | Retry loop re-ran the worker on *environment* failures (missing deps → `uv` exit 2) | retry only on genuine test failures (a command exited 1); env/infra errors (2/5/124) don't retry |
| 2 | `--sandbox` + a built-in `--worker-type` was a **silent no-op** | blocks with a clear message (sandbox supports `--worker-command` only for now) |
| 3 | A worker requested-but-skipped reported `status=completed` | now `blocked` |
| 4 | `__pycache__`/`.pyc`/caches attributed to the worker in `changed_files` | filtered via `is_ephemeral_path` |
| 5 | Pre-dispatch enforcement wasn't demo-able | gate now blocks a `--worker-command` that targets a sensitive path, before dispatch; revert-on-deny remains the second line of defense |

## Validation
- **213 tests passing**, ruff clean.
- Each fix re-verified by re-running the scenario that exposed it.
- Positive-path dry-run confirmed: clean single-attempt convergence, no artifact noise, completeness credited when validation passes.

## Noted (not bugs)
Deterministic `goal_alignment`/completeness heuristics are strict/brittle; the LLM product-reviewer path would judge semantically — validating that path is a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes five integration bugs surfaced during end-to-end manual testing, all previously missed by unit tests. The changes touch the LangGraph control flow (`graph.py`), the ephemeral-path filter (`git_utils.py`), the pre-dispatch security gate, the OpenHands runner, and a new `worker_env.py` module that centralises PATH augmentation for all worker CLIs.

- **Retry loop** now uses `_is_retriable_failure`, which gates on `exit_code == 1`; env/infra codes (2, 5, 124) and `edit_result.status == "blocked"` no longer trigger pointless retries.
- **Sandbox + built-in worker type** is now an explicit, clear block (`status="blocked"`) rather than a silent no-op, and the fix propagates correctly through the status-mapping block so `RunRecord.status` is `"blocked"` not `"failed"`.
- **Pre-dispatch gate** now scans only path-like tokens (`"/" in t or "." in t`) from `shlex.split`, eliminating false positives from bare subcommand names like `auth`; observe-mode runs (no worker) are exempt entirely.
- **Ephemeral path filter** (`is_ephemeral_path`) checks all path parts for `.egg-info`, covering nested files like `pkg.egg-info/PKG-INFO` correctly.
- **Worker-skipped status** is surfaced as `"blocked"` when a worker was configured but the workspace was not ready.

<h3>Confidence Score: 4/5</h3>

Safe to merge; all five stated bugs are correctly fixed and covered by new tests.

The control-flow changes in graph.py are the highest-risk surface. The sandbox-blocked status propagation, retry-guard, and pre-dispatch token filter are all correct and tested. The one observable inconsistency is check_convergence_node returning converged=True whenever edit_result is None, even when run_tests produced failures — this makes RunRecord.converged unreliable for callers on blocked runs with a broken baseline, though it does not affect routing or the status field.

app/core/graph.py (check_convergence_node short-circuit) and app/core/workers/worker_env.py (find_worker_bin fallback executability check).

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| app/core/graph.py | Five integration fixes: sandbox guard returns status=blocked and now propagates correctly to RunRecord.status; _is_retriable_failure prevents retry on env failures and on blocked edit_results; pre_dispatch_gate_node now filters path-like tokens only; workspace-skipped worker status is surfaced as blocked; openhands sandbox routing added. |
| app/core/git_utils.py | Adds is_ephemeral_path() with correct egg-info nested-file handling (checks all path parts, not just the last). Integrated into collect_changed_files to filter cache artifacts before attribution. |
| app/core/workers/worker_env.py | New module: centralises PATH augmentation (npm-global, bun, local, homebrew, cargo) and binary lookup for all worker CLIs. find_worker_bin's fallback existence check does not verify the executable bit. |
| app/core/workers/openhands_runner.py | Significantly expanded to support LLMSummarizingCondenser, AgentContext, LLMSecurityAnalyzer, task_tracker/grep/glob tools, session persistence (local), and docker workspace (bind-mount). Cleanup is guarded in finally. |
| app/core/workers/openhands_worker.py | Adds workspace parameter and passes it to the runner subprocess via OPENHANDS_WORKSPACE env var. Minimal, clean change. |
| tests/test_sandbox_worker_type_guard.py | New tests covering sandbox+worker_type blocking (status=blocked) and non-retry with max_attempts>1. |
| tests/test_retry_loop.py | Adds test_loop_does_not_retry_on_env_failure: exit code 2 with max_attempts=3 must produce attempts==1. |
| tests/test_pre_dispatch_gate.py | Reworked: observe-mode no longer blocked by sensitive plan; new tests for bare subcommand tokens, path tokens, and worker_type-alone. |
| tests/test_revert_on_deny.py | Worker command now embeds secrets.py inside a shell string so the pre-dispatch gate passes; asserts pre_dispatch.blocked=False and revert-on-deny still fires. |
| tests/test_ephemeral_and_predispatch.py | New tests for is_ephemeral_path (including egg-info nested files) and full-harness pre-dispatch block integration. |
| tests/test_worker_env.py | Minimal sanity checks for worker_env PATH augmentation and find_worker_bin None return for missing CLI. |
| pyproject.toml | Adds openhands-workspace>=1.28.0 to the openhands extra; uv.lock updated with transitive deps. |

</details>


</details>


<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[run_harness] --> B[prepare_workspace]
    B --> C[pre_dispatch_gate_node]
    C --> D{has_worker?}
    D -- No --> D1[pre_dispatch:observe]
    D -- Yes --> E{command targets sensitive path?}
    E -- Yes --> E1[pre_dispatch.blocked=True]
    E -- No --> F[run_external_worker_node]
    F --> G{sandbox + worker_type != openhands?}
    G -- Yes --> G1[edit_result.status=blocked]
    G -- No --> H{workspace_report.ok?}
    H -- No --> H1[edit_result=None]
    H -- Yes --> I{pre_dispatch.blocked?}
    I -- Yes --> I1[edit_result=None]
    I -- No --> J[Run worker]
    J --> K[collect_diff / enforce_permissions / run_tests]
    K --> L[check_convergence_node]
    L --> M{edit_result is None?}
    M -- Yes --> M1[converged=True short-circuit]
    M -- No --> N{_is_retriable_failure?}
    N -- Yes and attempts lt max --> O[retry]
    N -- No --> P[proceed to analysis]
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `app/core/graph.py`, line 863-868 ([link](https://github.com/ven-z8/agentops-harness/blob/95834853f64a84cb7c10f6873eb713048ad1da19/app/core/graph.py#L863-L868)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Sandbox-blocked run surfaces as `status="failed"` instead of `"blocked"`**

   When the sandbox guard fires it returns `edit_result.status = "blocked"`. The block below then maps any `edit_result.status != "completed"` to `status = "failed"` at the `RunRecord` level, so the top-level status is `"failed"` rather than `"blocked"`. Callers checking `record.status == "blocked"` to detect this class of configuration error (the stated intent of bug-fix #2) will silently miss it, and the UI/audit trail would conflate a test failure with a blocked configuration. The test only asserts `status != "completed"`, which is satisfied by either value and doesn't catch the misreporting.

   

   <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20app%2Fcore%2Fgraph.py%0ALine%3A%20863-868%0A%0AComment%3A%0A**Sandbox-blocked%20run%20surfaces%20as%20%60status%3D%22failed%22%60%20instead%20of%20%60%22blocked%22%60**%0A%0AWhen%20the%20sandbox%20guard%20fires%20it%20returns%20%60edit_result.status%20%3D%20%22blocked%22%60.%20The%20block%20below%20then%20maps%20any%20%60edit_result.status%20!%3D%20%22completed%22%60%20to%20%60status%20%3D%20%22failed%22%60%20at%20the%20%60RunRecord%60%20level%2C%20so%20the%20top-level%20status%20is%20%60%22failed%22%60%20rather%20than%20%60%22blocked%22%60.%20Callers%20checking%20%60record.status%20%3D%3D%20%22blocked%22%60%20to%20detect%20this%20class%20of%20configuration%20error%20%28the%20stated%20intent%20of%20bug-fix%20%232%29%20will%20silently%20miss%20it%2C%20and%20the%20UI%2Faudit%20trail%20would%20conflate%20a%20test%20failure%20with%20a%20blocked%20configuration.%20The%20test%20only%20asserts%20%60status%20!%3D%20%22completed%22%60%2C%20which%20is%20satisfied%20by%20either%20value%20and%20doesn't%20catch%20the%20misreporting.%0A%0A%60%60%60suggestion%0A%20%20%20%20if%20status%20%3D%3D%20%22completed%22%20and%20edit_result%20is%20not%20None%3A%0A%20%20%20%20%20%20%20%20if%20edit_result.status%20%3D%3D%20%22blocked%22%3A%0A%20%20%20%20%20%20%20%20%20%20%20%20status%20%3D%20%22blocked%22%0A%20%20%20%20%20%20%20%20elif%20edit_result.status%20!%3D%20%22completed%22%3A%0A%20%20%20%20%20%20%20%20%20%20%20%20status%20%3D%20%22failed%22%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=12&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Aapp%2Fcore%2Fgraph.py%3A491-498%0A%60converged%60%20is%20hard-coded%20to%20%60True%60%20whenever%20%60edit_result%20is%20None%60%2C%20which%20covers%20observe%20mode%2C%20pre-dispatch-blocked%20runs%2C%20and%20workspace-not-ready%20runs.%20For%20the%20latter%20two%20cases%20%60run_tests_node%60%20still%20executes%20before%20this%20node%2C%20so%20%60state%5B%22test_results%22%5D%60%20can%20contain%20failures%20%28e.g.%20a%20broken%20baseline%29.%20The%20resulting%20%60RunRecord%60%20would%20then%20have%20%60converged%3DTrue%60%20alongside%20%60test_results.passed%3DFalse%60%2C%20which%20is%20contradictory%20for%20any%20caller%20that%20checks%20%60converged%60%20as%20a%20proxy%20for%20%22did%20the%20repo%20end%20up%20in%20a%20good%20state%22.%20Preserving%20%60converged%20%3D%20passed%60%20for%20non-observe%20blocked%20runs%20would%20keep%20the%20field%20accurate%20while%20still%20preventing%20the%20retry%20loop%20%28the%20router's%20early-return%20on%20%60edit_result%20is%20None%60%20is%20the%20real%20gate%29.%0A%0A%60%60%60suggestion%0A%20%20%20%20edit_result%20%3D%20state.get%28%22edit_result%22%29%0A%20%20%20%20%23%20No%20worker%20ran%20%28observe%20mode%2C%20pre-dispatch-blocked%2C%20workspace-not-ready%29%20%E2%80%94%20skip%0A%20%20%20%20%23%20the%20retry-feedback%20logic%2C%20but%20still%20record%20whether%20tests%20actually%20passed%20so%20that%0A%20%20%20%20%23%20callers%20inspecting%20%60converged%60%20get%20an%20accurate%20answer.%0A%20%20%20%20if%20edit_result%20is%20None%3A%0A%20%20%20%20%20%20%20%20test_results%20%3D%20state.get%28%22test_results%22%29%0A%20%20%20%20%20%20%20%20_converged%20%3D%20test_results.passed%20if%20test_results%20is%20not%20None%20else%20True%0A%20%20%20%20%20%20%20%20return%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%22converged%22%3A%20_converged%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%22retry_feedback%22%3A%20%22%22%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%22execution_logs%22%3A%20append_logs%28state%2C%20%22check_convergence%3Askip%22%29%2C%0A%20%20%20%20%20%20%20%20%7D%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Aapp%2Fcore%2Fworkers%2Fworker_env.py%3A44-48%0AThe%20fallback%20loop%20checks%20only%20%60candidate.exists%28%29%60%2C%20not%20whether%20the%20file%20is%20executable.%20%60shutil.which%60%20%28used%20first%29%20already%20verifies%20the%20executable%20bit%20on%20the%20extended%20PATH%2C%20so%20this%20fallback%20would%20only%20fire%20for%20a%20path%20that%20%60shutil.which%60%20missed%20%E2%80%94%20which%20should%20be%20rare.%20If%20it%20does%20fire%20and%20returns%20a%20non-executable%20path%2C%20the%20subsequent%20%60subprocess%60%20call%20will%20produce%20a%20confusing%20%22Permission%20denied%22%20error%20instead%20of%20a%20clean%20%22worker%20not%20found%22%20message.%0A%0A%60%60%60suggestion%0A%20%20%20%20for%20directory%20in%20_GLOBAL_BIN_DIRS%3A%0A%20%20%20%20%20%20%20%20candidate%20%3D%20directory%20%2F%20name%0A%20%20%20%20%20%20%20%20if%20candidate.is_file%28%29%20and%20os.access%28candidate%2C%20os.X_OK%29%3A%0A%20%20%20%20%20%20%20%20%20%20%20%20return%20str%28candidate%29%0A%20%20%20%20return%20None%0A%60%60%60%0A%0A&pr=12&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<sub>Reviews (9): Last reviewed commit: ["fix: address Greptile review — 2 correct..."](https://github.com/ven-z8/agentops-harness/commit/dca1db49d0492745264035a6557608139d432206) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37101227)</sub>

<!-- /greptile_comment -->