### PR TITLE
Add OpenHands inner worker

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,8 @@ The target repo must be clean unless `--allow-dirty` is passed, so every changed
 
 The OpenHands worker runs a genuine programmable agent loop (OpenHands SDK 1.28) under the harness — the slide-16 six-step SDK pattern, governed like any other worker.
 
+OpenHands-specific setup, artifact, and manual test details live in [docs/OPENHANDS_INNER_WORKER.md](docs/OPENHANDS_INNER_WORKER.md).
+
 ## Governance: enforced, not just reported
 
 AgentOps doesn't only *audit* the worker — it **enforces**, three ways, and **loops**:

--- a/app/core/graph.py
+++ b/app/core/graph.py
@@ -268,6 +268,11 @@ def run_external_worker_node(state: AgentOpsGraphState) -> AgentOpsGraphState:
             task=task,
             timeout_seconds=timeout,
             allow_dirty=allow_dirty,
+            run_dir=artifact_dir_for_run(state["storage_path"], state["run_id"]),
+            run_id=state["run_id"],
+            plan=state.get("plan"),
+            repo_profile=state.get("repo_profile"),
+            tests_to_run=state.get("test_commands"),
         )
     elif worker_command:
         edit_result = ExternalWorkerRunner().run(
@@ -799,7 +804,13 @@ def run_harness(
         status = "blocked"
     else:
         status = "completed"
-    if status == "completed" and edit_result is not None and edit_result.status != "completed":
+    if (
+        status == "completed"
+        and edit_result is not None
+        and edit_result.status in {"blocked", "setup_missing", "auth_missing"}
+    ):
+        status = "blocked"
+    elif status == "completed" and edit_result is not None and edit_result.status != "completed":
         status = "failed"
     record = RunRecord(
         run_id=run_id,

--- a/app/core/workers/openhands_artifacts.py
+++ b/app/core/workers/openhands_artifacts.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from app.schemas.edit import ExternalEditResult
+from app.schemas.worker_loop import WorkerArtifactPaths, WorkerLoopSummary, WorkerScorecard
+
+
+def _ensure_run_dir(run_dir: Path) -> Path:
+    run_dir.mkdir(parents=True, exist_ok=True)
+    return run_dir
+
+
+def _write_text(path: Path, text: str) -> Path:
+    path.write_text(text, encoding="utf-8")
+    return path
+
+
+def _write_json(path: Path, value: Any) -> Path:
+    payload = value.model_dump(mode="json") if hasattr(value, "model_dump") else value
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return path
+
+
+def write_worker_prompt(run_dir: Path, prompt: str) -> Path:
+    return _write_text(_ensure_run_dir(run_dir) / "worker_prompt.md", prompt.rstrip() + "\n")
+
+
+def write_worker_logs(run_dir: Path, stdout: str, stderr: str) -> tuple[Path, Path]:
+    root = _ensure_run_dir(run_dir)
+    return (
+        _write_text(root / "worker_stdout.log", stdout),
+        _write_text(root / "worker_stderr.log", stderr),
+    )
+
+
+def write_worker_summary(run_dir: Path, summary: WorkerLoopSummary) -> Path:
+    return _write_json(_ensure_run_dir(run_dir) / "worker_loop_summary.json", summary)
+
+
+def write_worker_result(run_dir: Path, result: ExternalEditResult) -> Path:
+    return _write_json(_ensure_run_dir(run_dir) / "worker_result.json", result)
+
+
+def write_worker_events(run_dir: Path, events: list[dict[str, Any]]) -> Path | None:
+    if not events:
+        return None
+    path = _ensure_run_dir(run_dir) / "openhands_events.jsonl"
+    lines = [json.dumps(event, sort_keys=True) for event in events]
+    return _write_text(path, "\n".join(lines) + "\n")
+
+
+def write_worker_scorecard(run_dir: Path, scorecard: WorkerScorecard) -> Path:
+    return _write_json(_ensure_run_dir(run_dir) / "worker_scorecard.json", scorecard)
+
+
+def collect_worker_artifact_paths(
+    *,
+    prompt: Path,
+    stdout: Path,
+    stderr: Path,
+    summary: Path,
+    result: Path,
+    events: Path | None = None,
+    scorecard: Path | None = None,
+) -> WorkerArtifactPaths:
+    return WorkerArtifactPaths(
+        prompt=str(prompt),
+        stdout=str(stdout),
+        stderr=str(stderr),
+        summary=str(summary),
+        result=str(result),
+        events=str(events) if events else None,
+        scorecard=str(scorecard) if scorecard else None,
+    )

--- a/app/core/workers/openhands_config.py
+++ b/app/core/workers/openhands_config.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+import importlib.util
+import os
+
+from pydantic import BaseModel, Field
+
+DEFAULT_OPENHANDS_MODEL = "anthropic/claude-sonnet-4-5-20250929"
+DEFAULT_OPENHANDS_TIMEOUT_SECONDS = 300
+OPENHANDS_TOOL_NAMES = ("terminal", "file_editor")
+AUTH_ENV_NAMES = ("LLM_API_KEY", "ANTHROPIC_API_KEY", "OPENAI_API_KEY")
+
+
+class OpenHandsConfig(BaseModel):
+    model: str = DEFAULT_OPENHANDS_MODEL
+    api_key_env: str | None = None
+    max_iterations: int | None = None
+    timeout_seconds: int = DEFAULT_OPENHANDS_TIMEOUT_SECONDS
+    tools: list[str] = Field(default_factory=lambda: list(OPENHANDS_TOOL_NAMES))
+    config_error: str | None = None
+
+    @property
+    def missing_auth(self) -> bool:
+        return self.api_key_env is None
+
+
+def _positive_int_env(name: str) -> tuple[int | None, str | None]:
+    raw = os.getenv(name)
+    if raw is None or raw.strip() == "":
+        return None, None
+    try:
+        value = int(raw)
+    except ValueError:
+        return None, f"{name} must be a positive integer."
+    if value <= 0:
+        return None, f"{name} must be a positive integer."
+    return value, None
+
+
+def _first_auth_env() -> str | None:
+    for name in AUTH_ENV_NAMES:
+        if os.getenv(name):
+            return name
+    return None
+
+
+def load_openhands_config() -> OpenHandsConfig:
+    max_iterations, config_error = _positive_int_env("OPENHANDS_MAX_ITERATIONS")
+    return OpenHandsConfig(
+        model=os.getenv("OPENHANDS_MODEL", DEFAULT_OPENHANDS_MODEL),
+        api_key_env=_first_auth_env(),
+        max_iterations=max_iterations,
+        tools=list(OPENHANDS_TOOL_NAMES),
+        config_error=config_error,
+    )
+
+
+def openhands_sdk_available() -> bool:
+    try:
+        return (
+            importlib.util.find_spec("openhands.sdk") is not None
+            and importlib.util.find_spec("openhands.tools.terminal") is not None
+        )
+    except ModuleNotFoundError:
+        return False

--- a/app/core/workers/openhands_runner.py
+++ b/app/core/workers/openhands_runner.py
@@ -1,46 +1,178 @@
-"""Subprocess entry point that runs one OpenHands SDK agent loop over a repo.
+"""Subprocess entry point for the OpenHands inner-loop worker.
 
-Kept as a separate process so the heavy `openhands` import is lazy and the run is
-timeout-bounded by the parent worker (the same subprocess pattern the CLI workers use).
-Implements the slide-16 six steps against the real OpenHands SDK 1.28 API:
-LLM -> Agent(tools) -> Conversation(workspace=repo) -> send_message -> run; the harness
-reads the resulting git diff itself (step 6).
-
-Reads the task prompt from stdin (avoids CLI arg-length limits). argv: <repo_path> [model].
-Exit codes: 0 ok · 2 usage · 3 auth missing · 4 sdk not installed · 1 run error.
+The parent AgentOps worker owns repo attribution, timeout, artifact persistence,
+and post-worker governance. This subprocess owns only SDK setup and the
+OpenHands conversation loop. Keeping the SDK import here makes OpenHands an
+optional dependency for normal AgentOps runs and tests.
 """
 
 from __future__ import annotations
 
+import json
 import os
 import sys
+import time
+from pathlib import Path
+from typing import Any
 
-DEFAULT_MODEL = "anthropic/claude-sonnet-4-5-20250929"
+from app.core.workers.openhands_config import (
+    OPENHANDS_TOOL_NAMES,
+    load_openhands_config,
+    openhands_sdk_available,
+)
+from app.schemas.worker_loop import WorkerLoopSummary
+
+EXIT_RUN_ERROR = 1
+EXIT_USAGE_ERROR = 2
+EXIT_AUTH_MISSING = 3
+EXIT_SDK_MISSING = 4
+EXIT_CONFIGURATION_ERROR = 6
+SUMMARY_PREFIX = "OPENHANDS_WORKER_SUMMARY_JSON="
+
+
+class _OpenHandsEventRecorder:
+    def __init__(self, event_log_path: str | None) -> None:
+        self.event_log_path = event_log_path
+        self.observable_event_count = 0
+        self.write_error: str | None = None
+        if event_log_path:
+            path = Path(event_log_path)
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.touch(exist_ok=True)
+
+    def __call__(self, event: Any) -> None:
+        self.observable_event_count += 1
+        if not self.event_log_path:
+            return
+        payload = {
+            "event_type": event.__class__.__name__,
+            "event": _serialize_event(event),
+        }
+        try:
+            with Path(self.event_log_path).open("a", encoding="utf-8") as handle:
+                handle.write(json.dumps(payload, sort_keys=True, default=str) + "\n")
+        except OSError as exc:
+            self.write_error = str(exc)
+
+
+def _serialize_event(event: Any) -> dict[str, Any] | str:
+    if hasattr(event, "model_dump"):
+        return event.model_dump(mode="json")
+    if hasattr(event, "dict"):
+        return event.dict()
+    return repr(event)
+
+
+def _emit_summary(summary: WorkerLoopSummary) -> None:
+    print(SUMMARY_PREFIX + json.dumps(summary.model_dump(mode="json"), sort_keys=True))
+
+
+def _summary(
+    *,
+    status: str,
+    model: str | None,
+    started: float,
+    exit_code: int | None = None,
+    event_log_path: str | None = None,
+    observable_event_count: int = 0,
+    termination_reason: str | None = None,
+    setup_error: str | None = None,
+    notes: list[str] | None = None,
+) -> WorkerLoopSummary:
+    return WorkerLoopSummary(
+        model=model,
+        status=status,
+        exit_code=exit_code,
+        duration_seconds=round(time.perf_counter() - started, 3),
+        tools_requested=list(OPENHANDS_TOOL_NAMES),
+        event_log_path=event_log_path,
+        observable_event_count=observable_event_count,
+        termination_reason=termination_reason,
+        setup_error=setup_error,
+        notes=notes
+        or ["Inner tool trajectory may be partially observable depending on SDK support."],
+    )
 
 
 def main() -> int:
+    started = time.perf_counter()
     if len(sys.argv) < 2:
         print("usage: openhands_runner <repo_path> [model]  (task on stdin)", file=sys.stderr)
-        return 2
+        return EXIT_USAGE_ERROR
     repo_path = sys.argv[1]
-    model = sys.argv[2] if len(sys.argv) > 2 else os.getenv("OPENHANDS_MODEL", DEFAULT_MODEL)
     task = sys.stdin.read().strip()
     if not task:
         print("usage: task prompt must be provided on stdin", file=sys.stderr)
-        return 2
+        return EXIT_USAGE_ERROR
 
-    api_key = os.getenv("LLM_API_KEY") or os.getenv("ANTHROPIC_API_KEY")
-    if not api_key:
-        print("authentication_error: set ANTHROPIC_API_KEY or LLM_API_KEY", file=sys.stderr)
-        return 3
+    config = load_openhands_config()
+    model = sys.argv[2] if len(sys.argv) > 2 else config.model
+    if config.config_error:
+        print(f"configuration_error: {config.config_error}", file=sys.stderr)
+        _emit_summary(
+            _summary(
+                status="failed",
+                model=model,
+                started=started,
+                exit_code=EXIT_CONFIGURATION_ERROR,
+                termination_reason="configuration_error",
+                setup_error=config.config_error,
+            )
+        )
+        return EXIT_CONFIGURATION_ERROR
+
+    if not openhands_sdk_available():
+        message = "OpenHands SDK not installed. Install with: uv sync --extra openhands"
+        print(f"setup_missing: {message}", file=sys.stderr)
+        _emit_summary(
+            _summary(
+                status="setup_missing",
+                model=model,
+                started=started,
+                exit_code=EXIT_SDK_MISSING,
+                termination_reason="sdk_missing",
+                setup_error=message,
+            )
+        )
+        return EXIT_SDK_MISSING
+
+    if config.missing_auth:
+        message = "set LLM_API_KEY, ANTHROPIC_API_KEY, or OPENAI_API_KEY"
+        print(f"authentication_error: {message}", file=sys.stderr)
+        _emit_summary(
+            _summary(
+                status="auth_missing",
+                model=model,
+                started=started,
+                exit_code=EXIT_AUTH_MISSING,
+                termination_reason="auth_missing",
+                setup_error=message,
+            )
+        )
+        return EXIT_AUTH_MISSING
+
+    api_key = os.getenv(config.api_key_env or "")
+    event_recorder = _OpenHandsEventRecorder(os.getenv("OPENHANDS_EVENTS_PATH"))
+    persistence_dir = os.getenv("OPENHANDS_PERSISTENCE_DIR") or None
 
     try:
         from openhands.sdk import LLM, Agent, Conversation, Tool
         from openhands.tools.file_editor import FileEditorTool
         from openhands.tools.terminal import TerminalTool
     except ImportError as exc:
-        print(f"openhands sdk not installed: {exc}", file=sys.stderr)
-        return 4
+        message = f"OpenHands SDK not installed or incomplete: {exc}"
+        print(f"setup_missing: {message}", file=sys.stderr)
+        _emit_summary(
+            _summary(
+                status="setup_missing",
+                model=model,
+                started=started,
+                exit_code=EXIT_SDK_MISSING,
+                termination_reason="sdk_missing",
+                setup_error=message,
+            )
+        )
+        return EXIT_SDK_MISSING
 
     try:
         llm = LLM(model=model, api_key=api_key)
@@ -48,13 +180,56 @@ def main() -> int:
             llm=llm,
             tools=[Tool(name=TerminalTool.name), Tool(name=FileEditorTool.name)],
         )
-        conversation = Conversation(agent=agent, workspace=str(repo_path))
+        conversation_kwargs = {
+            "agent": agent,
+            "workspace": str(repo_path),
+            "callbacks": [event_recorder],
+        }
+        notes = [
+            "OpenHands SDK controls the inner prompt-model-tool-observe loop.",
+            "Observable SDK events are captured through Conversation callbacks.",
+        ]
+        if persistence_dir:
+            conversation_kwargs["persistence_dir"] = persistence_dir
+            notes.append("OpenHands conversation persistence directory was configured.")
+        if config.max_iterations is not None:
+            conversation_kwargs["max_iteration_per_run"] = config.max_iterations
+        conversation = Conversation(**conversation_kwargs)
         conversation.send_message(task)
         conversation.run()
     except Exception as exc:  # surface as a worker failure, not a crash
         print(f"openhands run error: {exc}", file=sys.stderr)
-        return 1
+        notes = ["OpenHands SDK run failed before completion."]
+        if event_recorder.write_error:
+            notes.append(f"OpenHands event log write failed: {event_recorder.write_error}")
+        _emit_summary(
+            _summary(
+                status="failed",
+                model=model,
+                started=started,
+                exit_code=EXIT_RUN_ERROR,
+                event_log_path=event_recorder.event_log_path,
+                observable_event_count=event_recorder.observable_event_count,
+                termination_reason="run_error",
+                notes=notes,
+            )
+        )
+        return EXIT_RUN_ERROR
 
+    if event_recorder.write_error:
+        notes.append(f"OpenHands event log write failed: {event_recorder.write_error}")
+    _emit_summary(
+        _summary(
+            status="completed",
+            model=model,
+            started=started,
+            exit_code=0,
+            event_log_path=event_recorder.event_log_path,
+            observable_event_count=event_recorder.observable_event_count,
+            termination_reason="completed",
+            notes=notes,
+        )
+    )
     print("openhands run complete")
     return 0
 

--- a/app/core/workers/openhands_worker.py
+++ b/app/core/workers/openhands_worker.py
@@ -9,17 +9,30 @@ in place; the harness reads the diff (step 6) via its existing collect_diff node
 
 from __future__ import annotations
 
+import json
+import os
 import subprocess
 import sys
 import time
 from pathlib import Path
+from typing import Any
 
 from app.core.git_utils import collect_status_lines, is_git_repo
 from app.core.workers.auth_errors import detect_auth_failure
+from app.core.workers.openhands_artifacts import (
+    write_worker_logs,
+    write_worker_prompt,
+    write_worker_result,
+    write_worker_scorecard,
+    write_worker_summary,
+)
+from app.core.workers.openhands_runner import SUMMARY_PREFIX
 from app.prompts.workers import build_worker_prompt
 from app.schemas.edit import ExternalEditResult
+from app.schemas.worker_loop import WorkerLoopSummary, WorkerScorecard
 
 COMMAND_STR = "python -m app.core.workers.openhands_runner <repo> (task on stdin)"
+HARNESS_ROOT = Path(__file__).resolve().parents[3]
 
 
 class OpenHandsWorker:
@@ -31,73 +44,273 @@ class OpenHandsWorker:
         task: str,
         timeout_seconds: int = 300,
         allow_dirty: bool = False,
+        run_dir: Path | None = None,
+        run_id: str | None = None,
+        plan: Any = None,
+        repo_profile: Any = None,
+        tests_to_run: list[str] | None = None,
+        forbidden_paths: list[str] | None = None,
+        permission_tier: str = "standard",
     ) -> ExternalEditResult:
+        command = f"{sys.executable} -m app.core.workers.openhands_runner {repo_path}"
         if not is_git_repo(repo_path):
             return ExternalEditResult(
                 status="blocked",
-                command=COMMAND_STR,
+                command=command,
                 stderr="Target path must be a git repository for edit attribution.",
+                termination_reason="not_git_repo",
+                worker_type="openhands",
             )
 
         if collect_status_lines(repo_path) and not allow_dirty:
             return ExternalEditResult(
                 status="blocked",
-                command=COMMAND_STR,
+                command=command,
                 stderr=(
                     "Target repository is dirty. Commit, stash, or pass allow_dirty=True "
                     "before running an OpenHands worker."
                 ),
+                termination_reason="dirty_repo",
+                worker_type="openhands",
             )
 
-        prompt = build_worker_prompt(repo_path=repo_path, task=task)
+        prompt = build_worker_prompt(
+            repo_path=repo_path,
+            task=task,
+            plan=plan,
+            repo_profile=repo_profile,
+            forbidden_paths=forbidden_paths,
+            tests_to_run=tests_to_run,
+            permission_tier=permission_tier,
+        )
         argv = [sys.executable, "-m", "app.core.workers.openhands_runner", str(repo_path)]
+        prompt_path = write_worker_prompt(run_dir, prompt) if run_dir else None
 
         started = time.perf_counter()
         try:
             completed = subprocess.run(
                 argv,
                 input=prompt,
-                cwd=repo_path,
+                cwd=HARNESS_ROOT,
                 capture_output=True,
                 text=True,
                 timeout=timeout_seconds,
                 check=False,
+                env=_runner_env(run_dir),
             )
         except subprocess.TimeoutExpired as exc:
-            return ExternalEditResult(
-                status="failed",
-                command=COMMAND_STR,
-                exit_code=None,
-                stdout=exc.stdout or "",
-                stderr=exc.stderr or f"OpenHands worker timed out after {timeout_seconds}s.",
-                duration_seconds=round(time.perf_counter() - started, 3),
+            stdout = _coerce_text(exc.stdout or exc.output or "")
+            stderr = _coerce_text(
+                exc.stderr or f"OpenHands worker timed out after {timeout_seconds}s."
             )
+            duration = round(time.perf_counter() - started, 3)
+            result = ExternalEditResult(
+                status="timeout",
+                command=command,
+                exit_code=None,
+                stdout=stdout,
+                stderr=stderr,
+                duration_seconds=duration,
+                termination_reason="timeout",
+                worker_type="openhands",
+            )
+            summary = WorkerLoopSummary(
+                status="timeout",
+                exit_code=None,
+                duration_seconds=duration,
+                tools_requested=["terminal", "file_editor"],
+                termination_reason="timeout",
+                prompt_path=str(prompt_path) if prompt_path else None,
+            )
+            _persist_worker_artifacts(
+                run_dir=run_dir,
+                run_id=run_id,
+                prompt_path=prompt_path,
+                prompt=prompt,
+                result=result,
+                summary=summary,
+            )
+            return result
 
         duration = round(time.perf_counter() - started, 3)
         code = completed.returncode
+        summary = _summary_from_stdout(completed.stdout) or WorkerLoopSummary(
+            status=_status_from_exit_code(code, completed.stdout, completed.stderr),
+            exit_code=code,
+            duration_seconds=duration,
+            tools_requested=["terminal", "file_editor"],
+            termination_reason=_termination_from_exit_code(
+                code,
+                completed.stdout,
+                completed.stderr,
+            ),
+        )
+        summary.exit_code = code
+        summary.duration_seconds = duration
+        summary.prompt_path = str(prompt_path) if prompt_path else None
 
-        # Auth (exit 3) and missing-SDK (exit 4) are setup problems, not run failures.
-        if code in (3, 4) or detect_auth_failure(completed.stdout, completed.stderr):
-            reason = (
-                "OpenHands SDK not installed. Install: uv sync --extra openhands."
-                if code == 4
-                else detect_auth_failure(completed.stdout, completed.stderr)
-                or "OpenHands authentication failed; set ANTHROPIC_API_KEY and retry."
-            )
-            return ExternalEditResult(
-                status="blocked",
-                command=COMMAND_STR,
-                exit_code=code,
-                stdout=completed.stdout,
-                stderr=f"{reason}\n{completed.stderr}".strip(),
-                duration_seconds=duration,
-            )
-
-        return ExternalEditResult(
-            status="completed" if code == 0 else "failed",
-            command=COMMAND_STR,
+        status = _status_from_exit_code(code, completed.stdout, completed.stderr)
+        termination_reason = _termination_from_exit_code(code, completed.stdout, completed.stderr)
+        stderr = _stderr_with_setup_hint(status, completed.stdout, completed.stderr)
+        result = ExternalEditResult(
+            status=status,
+            command=command,
             exit_code=code,
             stdout=completed.stdout,
-            stderr=completed.stderr,
+            stderr=stderr,
             duration_seconds=duration,
+            termination_reason=termination_reason,
+            worker_type="openhands",
         )
+        summary.status = status
+        summary.termination_reason = termination_reason
+        _persist_worker_artifacts(
+            run_dir=run_dir,
+            run_id=run_id,
+            prompt_path=prompt_path,
+            prompt=prompt,
+            result=result,
+            summary=summary,
+        )
+        return result
+
+
+def _coerce_text(value: str | bytes) -> str:
+    if isinstance(value, bytes):
+        return value.decode("utf-8", errors="replace")
+    return value
+
+
+def _runner_env(run_dir: Path | None = None) -> dict[str, str]:
+    env = os.environ.copy()
+    existing = env.get("PYTHONPATH")
+    env["PYTHONPATH"] = (
+        str(HARNESS_ROOT) if not existing else f"{HARNESS_ROOT}{os.pathsep}{existing}"
+    )
+    if run_dir is not None:
+        run_dir.mkdir(parents=True, exist_ok=True)
+        events_path = run_dir / "openhands_events.jsonl"
+        persistence_dir = run_dir / "openhands_state"
+        events_path.touch(exist_ok=True)
+        persistence_dir.mkdir(parents=True, exist_ok=True)
+        env["OPENHANDS_EVENTS_PATH"] = str(events_path)
+        env["OPENHANDS_PERSISTENCE_DIR"] = str(persistence_dir)
+    return env
+
+
+def _summary_from_stdout(stdout: str) -> WorkerLoopSummary | None:
+    for line in stdout.splitlines():
+        if not line.startswith(SUMMARY_PREFIX):
+            continue
+        try:
+            return WorkerLoopSummary.model_validate_json(line.split("=", maxsplit=1)[1])
+        except (json.JSONDecodeError, ValueError):
+            return WorkerLoopSummary(
+                status="failed",
+                termination_reason="malformed_worker_summary",
+                notes=["OpenHands runner emitted malformed summary JSON."],
+            )
+    return None
+
+
+def _status_from_exit_code(code: int, stdout: str, stderr: str) -> str:
+    if code == 0:
+        return "completed"
+    if code == 3 or detect_auth_failure(stdout, stderr):
+        return "auth_missing"
+    if code in (4, 6):
+        return "setup_missing"
+    return "failed"
+
+
+def _termination_from_exit_code(code: int, stdout: str, stderr: str) -> str:
+    if code == 0:
+        return "completed"
+    if code == 2:
+        return "usage_error"
+    if code == 3 or detect_auth_failure(stdout, stderr):
+        return "auth_missing"
+    if code == 4:
+        return "sdk_missing"
+    if code == 6:
+        return "configuration_error"
+    return "run_error"
+
+
+def _stderr_with_setup_hint(status: str, stdout: str, stderr: str) -> str:
+    if status == "setup_missing":
+        hint = "OpenHands SDK not installed. Install with: uv sync --extra openhands."
+        return f"{hint}\n{stderr}".strip()
+    if status == "auth_missing":
+        hint = detect_auth_failure(stdout, stderr) or (
+            "OpenHands authentication missing. Set LLM_API_KEY, ANTHROPIC_API_KEY, "
+            "or OPENAI_API_KEY and retry."
+        )
+        return f"{hint}\n{stderr}".strip()
+    return stderr
+
+
+def _persist_worker_artifacts(
+    *,
+    run_dir: Path | None,
+    run_id: str | None,
+    prompt_path: Path | None,
+    prompt: str,
+    result: ExternalEditResult,
+    summary: WorkerLoopSummary,
+) -> None:
+    if run_dir is None:
+        return
+
+    if prompt_path is None:
+        prompt_path = write_worker_prompt(run_dir, prompt)
+    stdout_path, stderr_path = write_worker_logs(run_dir, result.stdout, result.stderr)
+    events_path = _existing_event_log_path(run_dir, summary)
+    summary.prompt_path = str(prompt_path)
+    summary.stdout_path = str(stdout_path)
+    summary.stderr_path = str(stderr_path)
+    if events_path:
+        summary.event_log_path = str(events_path)
+    summary_path = write_worker_summary(run_dir, summary)
+    scorecard_path = write_worker_scorecard(
+        run_dir,
+        WorkerScorecard(
+            task_id=run_id,
+            status=result.status,
+            duration_seconds=result.duration_seconds,
+            tests_attempted_by_worker=_worker_attempted_tests(result.stdout, result.stderr),
+            notes=[
+                "AgentOps owns final diff collection, permission enforcement, tests, "
+                "risk, and evidence."
+            ],
+        ),
+    )
+    result_path = run_dir / "worker_result.json"
+    result.artifact_paths = {
+        "prompt": str(prompt_path),
+        "stdout": str(stdout_path),
+        "stderr": str(stderr_path),
+        "summary": str(summary_path),
+        "result": str(result_path),
+        "events": str(events_path) if events_path else None,
+        "scorecard": str(scorecard_path),
+    }
+    write_worker_result(run_dir, result)
+
+
+def _existing_event_log_path(run_dir: Path, summary: WorkerLoopSummary) -> Path | None:
+    candidates = []
+    if summary.event_log_path:
+        candidates.append(Path(summary.event_log_path))
+    candidates.append(run_dir / "openhands_events.jsonl")
+    for path in candidates:
+        if path.exists():
+            return path
+    return None
+
+
+def _worker_attempted_tests(stdout: str, stderr: str) -> bool | None:
+    blob = f"{stdout}\n{stderr}".lower()
+    if any(marker in blob for marker in ("pytest", "unittest", "npm test", "uv run")):
+        return True
+    return None

--- a/app/prompts/workers.py
+++ b/app/prompts/workers.py
@@ -1,15 +1,178 @@
 from __future__ import annotations
 
 from pathlib import Path
+from typing import Any
 
 
-def build_worker_prompt(*, repo_path: Path, task: str) -> str:
+def _as_lines(values: list[str] | tuple[str, ...] | None, *, empty: str) -> str:
+    if not values:
+        return f"- {empty}"
+    return "\n".join(f"- {value}" for value in values)
+
+
+def _model_dict(value: Any) -> dict[str, Any]:
+    if value is None:
+        return {}
+    if hasattr(value, "model_dump"):
+        return value.model_dump(mode="json")
+    if isinstance(value, dict):
+        return value
+    return {}
+
+
+def _format_plan(plan: Any) -> str:
+    payload = _model_dict(plan)
+    if not payload:
+        return (
+            "- No formal AgentOps plan was provided. Inspect the repo and make the "
+            "smallest safe implementation that satisfies the task."
+        )
+
+    lines = []
+    summary = payload.get("summary")
+    if summary:
+        lines.append(f"- Summary: {summary}")
+    for step in payload.get("steps") or []:
+        title = step.get("title", "Plan step")
+        description = step.get("description", "")
+        lines.append(f"- Step {step.get('id', '?')}: {title} - {description}".rstrip())
+        files_to_inspect = step.get("files_to_inspect") or []
+        files_to_edit = step.get("files_to_edit") or []
+        tests = step.get("tests") or []
+        if files_to_inspect:
+            lines.append(f"  - Inspect: {', '.join(files_to_inspect)}")
+        if files_to_edit:
+            lines.append(f"  - Edit: {', '.join(files_to_edit)}")
+        if tests:
+            lines.append(f"  - Tests: {', '.join(tests)}")
+    criteria = payload.get("acceptance_criteria") or []
+    if criteria:
+        lines.append("- Acceptance criteria:")
+        lines.extend(f"  - {item}" for item in criteria)
+    risk_notes = payload.get("risk_notes") or []
+    if risk_notes:
+        lines.append("- Risk notes:")
+        lines.extend(f"  - {item}" for item in risk_notes)
+    return "\n".join(lines) if lines else "- AgentOps provided an empty plan."
+
+
+def _format_repo_context(repo_path: Path, repo_profile: Any) -> str:
+    payload = _model_dict(repo_profile)
+    lines = [f"- Repo path: {repo_path}"]
+    for key, label in (
+        ("language", "Language"),
+        ("framework", "Framework"),
+        ("package_manager", "Package manager"),
+        ("test_framework", "Test framework"),
+    ):
+        if payload.get(key):
+            lines.append(f"- {label}: {payload[key]}")
+    for key, label in (
+        ("entrypoints", "Entrypoints"),
+        ("important_folders", "Important folders"),
+        ("config_files", "Config files"),
+    ):
+        values = payload.get(key) or []
+        if values:
+            lines.append(f"- {label}: {', '.join(values)}")
+    return "\n".join(lines)
+
+
+def _plan_files(plan: Any) -> list[str]:
+    payload = _model_dict(plan)
+    files: list[str] = []
+    for step in payload.get("steps") or []:
+        files.extend(step.get("files_to_inspect") or [])
+        files.extend(step.get("files_to_edit") or [])
+    return sorted(set(files))
+
+
+def _plan_tests(plan: Any) -> list[str]:
+    payload = _model_dict(plan)
+    tests = list(payload.get("tests_to_run") or [])
+    for step in payload.get("steps") or []:
+        tests.extend(step.get("tests") or [])
+    return sorted(set(tests))
+
+
+def build_worker_prompt(
+    *,
+    repo_path: Path,
+    task: str,
+    plan: Any = None,
+    repo_profile: Any = None,
+    files_to_edit: list[str] | None = None,
+    forbidden_paths: list[str] | None = None,
+    tests_to_run: list[str] | None = None,
+    permission_tier: str = "standard",
+) -> str:
+    likely_files = files_to_edit or _plan_files(plan)
+    verification_commands = tests_to_run or _plan_tests(plan)
+    no_likely_files = (
+        "No likely files were provided. Discover the minimal relevant files before editing."
+    )
+    default_forbidden_paths = (
+        ".env, .env.*, **/*secret*, **/*token*, private keys, credential stores"
+    )
+    default_verification = (
+        "Run the smallest relevant test or validation command you can identify."
+    )
     return f"""\
-You are a coding agent working inside the repository at {repo_path}.
+# Worker Packet
+You are a coding worker running inside AgentOps Harness.
+AgentOps is the outer governance harness.
+You are the inner implementation worker.
 
-Task: {task}
+## Task
+{task}
 
-Implement the task. Edit files as needed, run tests to verify your work, then
-stop. Do not explain what you did — just make the changes and confirm with a
-one-sentence summary of what changed.
+## Plan as Contract
+{_format_plan(plan)}
+Follow this plan unless repo inspection proves it is wrong.
+If the plan is wrong, make the smallest safe correction and explain it.
+
+## Repo Context
+{_format_repo_context(repo_path, repo_profile)}
+
+## Likely Impacted Files
+{_as_lines(likely_files, empty=no_likely_files)}
+
+## Constraints
+- Keep the diff minimal.
+- Do not edit unrelated files.
+- Do not touch sensitive paths.
+- Do not modify tests just to make them pass unless explicitly required.
+- Prefer implementation changes over test weakening.
+- If you cannot proceed safely, stop and explain why.
+
+## Forbidden Actions
+- Do not add secrets, credentials, tokens, private keys, or real API keys.
+- Do not modify lockfiles, generated files, or CI configuration unless the plan requires it.
+- Do not change public behavior outside the task scope.
+- Do not claim tests passed unless you actually ran them and saw success.
+
+## Forbidden Paths
+{_as_lines(forbidden_paths, empty=default_forbidden_paths)}
+
+## Permission Tier
+{permission_tier}
+
+## Verification Obligations
+Run these if possible:
+{_as_lines(verification_commands, empty=default_verification)}
+If you cannot run them, explain why.
+
+## Definition of Done
+The task is done only when:
+- required implementation is complete
+- diff is minimal
+- validation has been attempted
+- no forbidden paths are touched
+- final message summarizes exactly what changed
+
+## Reporting Rules
+Do not claim tests passed unless you actually ran them and saw success.
+Do not claim files changed unless you changed them.
+Do not claim routes/endpoints were added unless they exist in the diff.
+If blocked, explain the blocker and stop.
 """

--- a/app/schemas/edit.py
+++ b/app/schemas/edit.py
@@ -1,9 +1,16 @@
 from typing import Literal
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 EditMode = Literal["observe", "external_worker"]
-ExternalEditStatus = Literal["completed", "failed", "blocked"]
+ExternalEditStatus = Literal[
+    "completed",
+    "failed",
+    "blocked",
+    "timeout",
+    "setup_missing",
+    "auth_missing",
+]
 
 
 class ExternalEditResult(BaseModel):
@@ -14,3 +21,6 @@ class ExternalEditResult(BaseModel):
     stdout: str = ""
     stderr: str = ""
     duration_seconds: float = 0.0
+    termination_reason: str | None = None
+    worker_type: str | None = None
+    artifact_paths: dict[str, str | None] = Field(default_factory=dict)

--- a/app/schemas/worker_loop.py
+++ b/app/schemas/worker_loop.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from pydantic import BaseModel, Field
+
+
+class WorkerLoopSummary(BaseModel):
+    worker_type: str = "openhands"
+    loop_owner: str = "openhands_sdk"
+    agentops_role: str = "outer_governor"
+    model: str | None = None
+    status: str
+    exit_code: int | None = None
+    duration_seconds: float | None = None
+    tools_requested: list[str] = Field(default_factory=list)
+    prompt_path: str | None = None
+    stdout_path: str | None = None
+    stderr_path: str | None = None
+    event_log_path: str | None = None
+    observable_event_count: int = 0
+    termination_reason: str | None = None
+    setup_error: str | None = None
+    notes: list[str] = Field(default_factory=list)
+
+
+class WorkerArtifactPaths(BaseModel):
+    prompt: str
+    stdout: str
+    stderr: str
+    summary: str
+    result: str
+    events: str | None = None
+    scorecard: str | None = None
+
+
+class WorkerScorecard(BaseModel):
+    worker_type: str = "openhands"
+    task_id: str | None = None
+    status: str
+    duration_seconds: float | None = None
+    changed_file_count: int | None = None
+    tests_attempted_by_worker: bool | None = None
+    agentops_tests_passed: bool | None = None
+    permission_violations: int | None = None
+    unsupported_claims: int | None = None
+    risk_level: str | None = None
+    convergence_type: str | None = None
+    notes: list[str] = Field(default_factory=list)

--- a/docs/OPENHANDS_INNER_WORKER.md
+++ b/docs/OPENHANDS_INNER_WORKER.md
@@ -1,0 +1,196 @@
+# OpenHands Inner Worker
+
+AgentOps Harness is the outer governance harness. OpenHands is the inner worker
+harness. The integration lets AgentOps give OpenHands a structured worker packet,
+let OpenHands run its own implementation loop, then let AgentOps collect the diff
+and enforce the normal governance pipeline.
+
+## Boundary
+
+AgentOps owns:
+
+- scan, recall, plan, and workspace preparation
+- pre-dispatch permission checks
+- worker prompt contract
+- target repository and timeout
+- stdout, stderr, exit code, duration, and worker artifacts
+- final diff collection
+- permission enforcement, tests, risk, evidence, product review, and verification
+
+OpenHands owns:
+
+- prompt to model loop
+- file reads and edits inside the target repo
+- terminal commands inside the worker loop
+- local implementation attempts
+- stopping once it completes, blocks, errors, or reaches SDK limits
+
+AgentOps does not trust the worker's self-report. OpenHands may attempt tests, but
+AgentOps reruns configured validation after the worker returns.
+
+## Setup
+
+OpenHands remains optional. Normal AgentOps tests and demos do not install it and
+do not require provider credentials.
+
+Install the optional worker dependencies:
+
+```bash
+uv sync --extra dev --extra openhands
+```
+
+Configure a model and one API key:
+
+```bash
+export OPENHANDS_MODEL=anthropic/claude-sonnet-4-5-20250929
+export ANTHROPIC_API_KEY=...
+```
+
+The worker checks these environment variables:
+
+- `OPENHANDS_MODEL`
+- `OPENHANDS_MAX_ITERATIONS`
+- `LLM_API_KEY`
+- `ANTHROPIC_API_KEY`
+- `OPENAI_API_KEY`
+
+## Artifacts
+
+When invoked from an AgentOps run, OpenHands worker artifacts are written under
+the run directory:
+
+```text
+.agentops/runs/<run_id>/
+|-- worker_prompt.md
+|-- worker_stdout.log
+|-- worker_stderr.log
+|-- worker_loop_summary.json
+|-- worker_result.json
+|-- worker_scorecard.json
+|-- openhands_events.jsonl
+|-- openhands_state/
+|-- diff.patch
+|-- test_results.json
+|-- risk_report.json
+|-- permission_report.json
+|-- evidence_report.json
+|-- product_review.json
+|-- verification_bundle.json
+`-- run_record.json
+```
+
+`worker_loop_summary.json` records the observable inner-loop lifecycle:
+
+```json
+{
+  "worker_type": "openhands",
+  "loop_owner": "openhands_sdk",
+  "agentops_role": "outer_governor",
+  "status": "completed",
+  "model": "anthropic/claude-sonnet-4-5-20250929",
+  "tools_requested": ["terminal", "file_editor"],
+  "event_log_path": ".agentops/runs/<run_id>/openhands_events.jsonl",
+  "observable_event_count": 12,
+  "termination_reason": "completed"
+}
+```
+
+The runner uses OpenHands SDK `Conversation` callbacks to persist observable
+events as JSONL. It also configures a conversation persistence directory under
+the run directory, so SDK-managed state can be inspected separately from
+AgentOps-owned diff, test, risk, permission, evidence, and verification
+artifacts.
+
+## Status Mapping
+
+The subprocess runner uses stable exit codes:
+
+- `0`: completed
+- `1`: run error
+- `2`: usage error
+- `3`: authentication missing
+- `4`: SDK missing
+- `5`: timeout handled by parent
+- `6`: configuration error
+
+The parent worker maps those to `ExternalEditResult.status`:
+
+- `completed`
+- `failed`
+- `blocked`
+- `timeout`
+- `setup_missing`
+- `auth_missing`
+
+Missing SDK and missing auth are classified cleanly so CI can run without
+OpenHands installed and without provider keys.
+
+## Manual Tests
+
+The target repo must be a git root so AgentOps can attribute the worker diff.
+For the bundled sample app, prepare a temporary git repo first:
+
+```bash
+tmp_repo="$(mktemp -d)/sample_fastapi_app"
+cp -R examples/sample_fastapi_app "$tmp_repo"
+git -C "$tmp_repo" init -q
+git -C "$tmp_repo" add .
+git -C "$tmp_repo" commit -qm "initial sample app"
+```
+
+Setup missing:
+
+```bash
+uv run --extra dev agentops edit \
+  --repo "$tmp_repo" \
+  --task "Add request logging middleware" \
+  --worker-type openhands
+```
+
+Expected without OpenHands extras: `setup_missing`, with a diagnostic explaining
+that the OpenHands SDK is not installed.
+
+Auth missing:
+
+```bash
+uv run --extra dev --extra openhands agentops edit \
+  --repo "$tmp_repo" \
+  --task "Add request logging middleware" \
+  --worker-type openhands
+```
+
+Expected without an API key: `auth_missing`.
+
+Successful run:
+
+```bash
+OPENHANDS_MODEL=anthropic/claude-sonnet-4-5-20250929 \
+ANTHROPIC_API_KEY=... \
+uv run --extra dev --extra openhands agentops edit \
+  --repo "$tmp_repo" \
+  --task "Add request logging middleware" \
+  --worker-type openhands \
+  --max-attempts 1
+```
+
+Expected: OpenHands edits the repo, AgentOps collects the diff, reruns tests,
+classifies permissions and risk, checks evidence, runs product review, and writes
+the verification bundle.
+
+Sensitive path:
+
+```bash
+uv run --extra dev agentops edit \
+  --repo "$tmp_repo" \
+  --task "Add API key to .env for the app" \
+  --worker-type openhands
+```
+
+Expected: pre-dispatch governance blocks the worker before OpenHands runs.
+
+## Limitations
+
+- This integration does not add browser tools or network tools to OpenHands.
+- Event capture is limited to events surfaced through OpenHands SDK callbacks.
+- AgentOps does not use OpenHands as a replacement for governance.
+- AgentOps still performs final validation after every worker run.

--- a/docs/handoffs/2026-06-12-openhands-inner-worker-claude-code.md
+++ b/docs/handoffs/2026-06-12-openhands-inner-worker-claude-code.md
@@ -1,0 +1,121 @@
+# Claude Code Handoff: OpenHands Inner Worker Follow-Up
+
+Date: 2026-06-12
+Branch target: `codex/openhands-inner-worker`
+Repo: `Ven-Z8/agentops-harness`
+
+## Current State
+
+AgentOps now has a production-shaped OpenHands inner worker integration. The
+implementation keeps AgentOps as the outer governance harness and OpenHands as
+the governed inner implementation loop.
+
+Implemented surfaces:
+
+- `app/schemas/worker_loop.py`
+- `app/core/workers/openhands_config.py`
+- `app/core/workers/openhands_artifacts.py`
+- `app/core/workers/openhands_runner.py`
+- `app/core/workers/openhands_worker.py`
+- `app/prompts/workers.py`
+- `app/core/graph.py`
+- `docs/OPENHANDS_INNER_WORKER.md`
+- `examples/workloads/openhands_request_logging.yaml`
+- OpenHands worker/config/artifact/runner/prompt tests
+
+The worker remains optional. Default dev tests do not require the OpenHands SDK
+or provider API keys.
+
+## SDK Documentation Findings
+
+Official docs and source were mirrored locally during the implementation pass:
+
+- Docs index: `https://docs.openhands.dev/llms.txt`
+- Downloaded docs: 194 Markdown pages, 45,586 lines
+- `OpenHands/OpenHands` commit inspected:
+  `b240031d27a3dbb0f005c13b05171b1ca7b363c9`
+- `OpenHands/software-agent-sdk` commit inspected:
+  `e3a2a4a2b1b85cd544ec9bc9b7a1d1e5e587a3c8`
+
+Important SDK-specific correction already applied:
+
+- `Conversation.run()` takes no max-iteration keyword in SDK v1.28.x.
+- Max iterations belong on `Conversation(..., max_iteration_per_run=...)`.
+- SDK-visible events are available through `Conversation(..., callbacks=[...])`.
+- SDK persistence is configured through `Conversation(..., persistence_dir=...)`.
+
+## Verification Already Run
+
+These passed before this handoff file was added:
+
+```bash
+uv run --extra dev ruff check .
+uv run --extra dev python -m pytest -q
+env -u LLM_API_KEY -u ANTHROPIC_API_KEY -u OPENAI_API_KEY \
+  UV_PROJECT_ENVIRONMENT=/tmp/agentops-harness-dev-no-openhands \
+  uv run --extra dev python -m pytest \
+  tests/test_openhands_runner_contract.py tests/test_openhands_worker.py -q
+```
+
+Observed results:
+
+- `ruff`: all checks passed
+- full pytest: `228 passed`
+- clean dev-only OpenHands slice: `15 passed`
+
+## What Claude Code Should Do Next
+
+1. Review the OpenHands worker diff as a strict implementation reviewer.
+   Focus on optional dependency boundaries, subprocess behavior, artifact
+   persistence, status mapping, and prompt contract clarity.
+
+2. Run a permanent real-worker smoke, not a temporary-directory smoke:
+
+   ```bash
+   tmp_repo="$(mktemp -d)/sample_fastapi_app"
+   cp -R examples/sample_fastapi_app "$tmp_repo"
+   git -C "$tmp_repo" init -q
+   git -C "$tmp_repo" add .
+   git -C "$tmp_repo" commit -qm "initial sample app"
+
+   OPENHANDS_MODEL=anthropic/claude-sonnet-4-5-20250929 \
+   ANTHROPIC_API_KEY=... \
+   uv run --extra dev --extra openhands agentops edit \
+     --repo "$tmp_repo" \
+     --task "Add request logging middleware" \
+     --worker-type openhands \
+     --worker-timeout-seconds 600 \
+     --max-attempts 1
+   ```
+
+3. Inspect the generated run directory and confirm these OpenHands artifacts are
+   present:
+
+   - `worker_prompt.md`
+   - `worker_stdout.log`
+   - `worker_stderr.log`
+   - `worker_loop_summary.json`
+   - `worker_result.json`
+   - `worker_scorecard.json`
+   - `openhands_events.jsonl`
+   - `openhands_state/`
+
+4. Verify AgentOps still owns final truth after the worker returns:
+
+   - final `diff.patch` collected by AgentOps
+   - permission report generated
+   - tests rerun by AgentOps
+   - risk report generated
+   - evidence report generated
+   - verification bundle generated
+
+5. If the real run exposes SDK event payload issues, improve only the event
+   serializer and tests. Do not make OpenHands a required dependency.
+
+## Non-Negotiables
+
+- Do not import OpenHands in the parent worker.
+- Do not require provider keys in normal CI tests.
+- Do not add browser/network tools to the OpenHands worker.
+- Do not trust the worker self-report as final validation.
+- Preserve AgentOps as the outer harness and OpenHands as the inner worker.

--- a/examples/workloads/openhands_request_logging.yaml
+++ b/examples/workloads/openhands_request_logging.yaml
@@ -1,0 +1,8 @@
+name: OpenHands Request Logging
+repo: examples/sample_fastapi_app
+task: Add structured HTTP request logging middleware with accompanying pytest coverage.
+worker_type: openhands
+expected:
+  max_risk_score: 65
+  required_commands:
+    - python -m pytest -q

--- a/tests/test_openhands_artifacts.py
+++ b/tests/test_openhands_artifacts.py
@@ -1,0 +1,56 @@
+import json
+from pathlib import Path
+
+from app.core.workers.openhands_artifacts import (
+    write_worker_events,
+    write_worker_logs,
+    write_worker_prompt,
+    write_worker_result,
+    write_worker_scorecard,
+    write_worker_summary,
+)
+from app.schemas.edit import ExternalEditResult
+from app.schemas.worker_loop import WorkerLoopSummary, WorkerScorecard
+
+
+def test_openhands_artifact_writer_persists_worker_files(tmp_path: Path) -> None:
+    prompt_path = write_worker_prompt(tmp_path, "# Worker Packet\nDo work")
+    stdout_path, stderr_path = write_worker_logs(tmp_path, "out", "err")
+    summary_path = write_worker_summary(
+        tmp_path,
+        WorkerLoopSummary(
+            status="completed",
+            model="anthropic/test",
+            tools_requested=["terminal", "file_editor"],
+        ),
+    )
+    result_path = write_worker_result(
+        tmp_path,
+        ExternalEditResult(
+            status="completed",
+            command="python -m app.core.workers.openhands_runner",
+            exit_code=0,
+            stdout="out",
+            stderr="",
+            duration_seconds=1.25,
+        ),
+    )
+    scorecard_path = write_worker_scorecard(
+        tmp_path,
+        WorkerScorecard(
+            task_id="run-1",
+            status="completed",
+            duration_seconds=1.25,
+        ),
+    )
+    events_path = write_worker_events(tmp_path, [{"event": "start"}, {"event": "complete"}])
+
+    assert prompt_path.name == "worker_prompt.md"
+    assert prompt_path.read_text(encoding="utf-8").startswith("# Worker Packet")
+    assert stdout_path.read_text(encoding="utf-8") == "out"
+    assert stderr_path.read_text(encoding="utf-8") == "err"
+    assert json.loads(summary_path.read_text(encoding="utf-8"))["loop_owner"] == "openhands_sdk"
+    assert json.loads(result_path.read_text(encoding="utf-8"))["exit_code"] == 0
+    assert json.loads(scorecard_path.read_text(encoding="utf-8"))["worker_type"] == "openhands"
+    assert events_path is not None
+    assert events_path.read_text(encoding="utf-8").count("\n") == 2

--- a/tests/test_openhands_config.py
+++ b/tests/test_openhands_config.py
@@ -1,0 +1,55 @@
+import importlib.util
+
+from app.core.workers.openhands_config import (
+    DEFAULT_OPENHANDS_MODEL,
+    OPENHANDS_TOOL_NAMES,
+    load_openhands_config,
+    openhands_sdk_available,
+)
+
+
+def test_openhands_config_prefers_model_and_auth_env(monkeypatch) -> None:
+    monkeypatch.setenv("OPENHANDS_MODEL", "openai/gpt-test")
+    monkeypatch.setenv("OPENHANDS_MAX_ITERATIONS", "12")
+    monkeypatch.setenv("OPENAI_API_KEY", "secret")
+    monkeypatch.delenv("LLM_API_KEY", raising=False)
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+
+    config = load_openhands_config()
+
+    assert config.model == "openai/gpt-test"
+    assert config.api_key_env == "OPENAI_API_KEY"
+    assert config.max_iterations == 12
+    assert config.tools == list(OPENHANDS_TOOL_NAMES)
+
+
+def test_openhands_config_uses_safe_default_without_auth(monkeypatch) -> None:
+    monkeypatch.delenv("OPENHANDS_MODEL", raising=False)
+    monkeypatch.delenv("OPENHANDS_MAX_ITERATIONS", raising=False)
+    monkeypatch.delenv("LLM_API_KEY", raising=False)
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+
+    config = load_openhands_config()
+
+    assert config.model == DEFAULT_OPENHANDS_MODEL
+    assert config.api_key_env is None
+    assert config.max_iterations is None
+    assert config.missing_auth
+
+
+def test_openhands_config_rejects_invalid_max_iterations(monkeypatch) -> None:
+    monkeypatch.setenv("OPENHANDS_MAX_ITERATIONS", "not-an-int")
+
+    config = load_openhands_config()
+
+    assert config.config_error == "OPENHANDS_MAX_ITERATIONS must be a positive integer."
+
+
+def test_openhands_sdk_available_uses_importlib_spec(monkeypatch) -> None:
+    def fake_find_spec(name: str):
+        return object() if name in {"openhands.sdk", "openhands.tools.terminal"} else None
+
+    monkeypatch.setattr(importlib.util, "find_spec", fake_find_spec)
+
+    assert openhands_sdk_available()

--- a/tests/test_openhands_runner_contract.py
+++ b/tests/test_openhands_runner_contract.py
@@ -1,0 +1,173 @@
+import json
+import subprocess
+import sys
+from types import ModuleType
+
+
+def _run_runner(repo: str = ".", task: str = "Do work", env: dict[str, str] | None = None):
+    return subprocess.run(
+        [sys.executable, "-m", "app.core.workers.openhands_runner", repo],
+        input=task,
+        capture_output=True,
+        text=True,
+        timeout=30,
+        env=env,
+        check=False,
+    )
+
+
+def _summary_from_stdout(stdout: str) -> dict:
+    for line in stdout.splitlines():
+        if line.startswith("OPENHANDS_WORKER_SUMMARY_JSON="):
+            return json.loads(line.split("=", maxsplit=1)[1])
+    raise AssertionError(f"summary line missing from stdout: {stdout}")
+
+
+def test_runner_returns_usage_error_if_repo_path_missing() -> None:
+    completed = subprocess.run(
+        [sys.executable, "-m", "app.core.workers.openhands_runner"],
+        input="Do work",
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+
+    assert completed.returncode == 2
+    assert "usage:" in completed.stderr
+
+
+def test_runner_returns_usage_error_if_stdin_task_missing() -> None:
+    completed = _run_runner(task="")
+
+    assert completed.returncode == 2
+    assert "task prompt" in completed.stderr
+
+
+def test_runner_returns_sdk_missing_before_auth_when_openhands_not_installed(monkeypatch) -> None:
+    monkeypatch.setattr(
+        "app.core.workers.openhands_runner.openhands_sdk_available",
+        lambda: False,
+    )
+
+    from app.core.workers.openhands_runner import main
+
+    monkeypatch.setattr(sys, "argv", ["openhands_runner", "."])
+    monkeypatch.setattr(sys, "stdin", type("FakeStdin", (), {"read": lambda self: "Do work"})())
+
+    assert main() == 4
+
+
+def test_runner_returns_auth_error_when_sdk_present_but_no_key(monkeypatch) -> None:
+    monkeypatch.setattr(
+        "app.core.workers.openhands_runner.openhands_sdk_available",
+        lambda: True,
+    )
+    monkeypatch.delenv("LLM_API_KEY", raising=False)
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+
+    from app.core.workers.openhands_runner import main
+
+    monkeypatch.setattr(sys, "argv", ["openhands_runner", "."])
+    monkeypatch.setattr(sys, "stdin", type("FakeStdin", (), {"read": lambda self: "Do work"})())
+
+    assert main() == 3
+
+
+def test_runner_returns_config_error_for_malformed_env(monkeypatch) -> None:
+    monkeypatch.setenv("OPENHANDS_MAX_ITERATIONS", "bad")
+
+    completed = _run_runner(task="Do work", env={"OPENHANDS_MAX_ITERATIONS": "bad"})
+
+    assert completed.returncode == 6
+    assert "OPENHANDS_MAX_ITERATIONS" in completed.stderr
+
+
+def test_runner_configures_sdk_loop_controls_and_event_capture(
+    monkeypatch, tmp_path, capsys
+) -> None:
+    calls: dict[str, object] = {}
+
+    class FakeEvent:
+        def model_dump(self, *, mode: str):
+            return {"id": "event-1", "source": "agent", "mode": mode}
+
+    class FakeLLM:
+        def __init__(self, **kwargs):
+            calls["llm"] = kwargs
+
+    class FakeTool:
+        def __init__(self, **kwargs):
+            calls.setdefault("tools", []).append(kwargs)
+
+    class FakeAgent:
+        def __init__(self, **kwargs):
+            calls["agent"] = kwargs
+
+    class FakeConversation:
+        def __init__(self, **kwargs):
+            calls["conversation"] = kwargs
+
+        def send_message(self, task: str) -> None:
+            calls["task"] = task
+
+        def run(self) -> None:
+            calls["run_kwargs"] = {}
+            for callback in calls["conversation"]["callbacks"]:
+                callback(FakeEvent())
+
+    sdk = ModuleType("openhands.sdk")
+    sdk.LLM = FakeLLM
+    sdk.Agent = FakeAgent
+    sdk.Conversation = FakeConversation
+    sdk.Tool = FakeTool
+
+    terminal = ModuleType("openhands.tools.terminal")
+    terminal.TerminalTool = type("TerminalTool", (), {"name": "terminal"})
+    file_editor = ModuleType("openhands.tools.file_editor")
+    file_editor.FileEditorTool = type("FileEditorTool", (), {"name": "file_editor"})
+
+    monkeypatch.setitem(sys.modules, "openhands", ModuleType("openhands"))
+    monkeypatch.setitem(sys.modules, "openhands.sdk", sdk)
+    monkeypatch.setitem(sys.modules, "openhands.tools", ModuleType("openhands.tools"))
+    monkeypatch.setitem(sys.modules, "openhands.tools.terminal", terminal)
+    monkeypatch.setitem(sys.modules, "openhands.tools.file_editor", file_editor)
+    monkeypatch.setattr(
+        "app.core.workers.openhands_runner.openhands_sdk_available",
+        lambda: True,
+    )
+    monkeypatch.setenv("LLM_API_KEY", "test-key")
+    monkeypatch.setenv("OPENHANDS_MODEL", "test/model")
+    monkeypatch.setenv("OPENHANDS_MAX_ITERATIONS", "7")
+    events_path = tmp_path / "openhands_events.jsonl"
+    persistence_dir = tmp_path / "openhands_state"
+    monkeypatch.setenv("OPENHANDS_EVENTS_PATH", str(events_path))
+    monkeypatch.setenv("OPENHANDS_PERSISTENCE_DIR", str(persistence_dir))
+
+    from app.core.workers.openhands_runner import main
+
+    monkeypatch.setattr(sys, "argv", ["openhands_runner", str(tmp_path)])
+    monkeypatch.setattr(
+        sys,
+        "stdin",
+        type("FakeStdin", (), {"read": lambda self: "Structured worker packet"})(),
+    )
+
+    assert main() == 0
+
+    output = capsys.readouterr()
+    summary = _summary_from_stdout(output.out)
+    assert calls["llm"] == {"model": "test/model", "api_key": "test-key"}
+    assert calls["task"] == "Structured worker packet"
+    assert calls["conversation"]["workspace"] == str(tmp_path)
+    assert calls["conversation"]["max_iteration_per_run"] == 7
+    assert calls["conversation"]["persistence_dir"] == str(persistence_dir)
+    assert len(calls["conversation"]["callbacks"]) == 1
+    assert events_path.exists()
+    assert json.loads(events_path.read_text(encoding="utf-8")) == {
+        "event": {"id": "event-1", "mode": "json", "source": "agent"},
+        "event_type": "FakeEvent",
+    }
+    assert summary["event_log_path"] == str(events_path)
+    assert summary["observable_event_count"] == 1

--- a/tests/test_openhands_worker.py
+++ b/tests/test_openhands_worker.py
@@ -1,6 +1,7 @@
 import subprocess
 import sys
 from pathlib import Path
+from types import SimpleNamespace
 
 from app.core.workers.openhands_worker import OpenHandsWorker
 
@@ -19,6 +20,39 @@ def test_blocks_on_dirty_repo(tmp_path: Path):
     assert "dirty" in result.stderr.lower()
 
 
+def test_allows_dirty_repo_when_requested_and_passes_prompt_on_stdin(tmp_path: Path, monkeypatch):
+    subprocess.run(["git", "init", "-q"], cwd=tmp_path, check=True)
+    (tmp_path / "f.py").write_text("x=1\n")
+    seen = {}
+
+    def fake_run(argv, *args, **kwargs):
+        if argv[:2] == ["git", "rev-parse"]:
+            return SimpleNamespace(returncode=0, stdout=str(tmp_path), stderr="")
+        if argv[:3] == ["git", "status", "--porcelain"]:
+            return SimpleNamespace(returncode=0, stdout="?? f.py\n", stderr="")
+        seen["argv"] = argv
+        seen["input"] = kwargs["input"]
+        seen["cwd"] = kwargs["cwd"]
+        seen["env"] = kwargs["env"]
+        return SimpleNamespace(returncode=0, stdout="done", stderr="")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    result = OpenHandsWorker().run(
+        repo_path=tmp_path,
+        task="Add logging",
+        timeout_seconds=5,
+        allow_dirty=True,
+    )
+
+    assert result.status == "completed"
+    assert "agentops-harness" in str(seen["cwd"])
+    assert "PYTHONPATH" in seen["env"]
+    assert "agentops-harness" in seen["env"]["PYTHONPATH"]
+    assert seen["input"].startswith("# Worker Packet")
+    assert "## Task\nAdd logging" in seen["input"]
+
+
 def test_runner_exits_2_without_a_task():
     # The runner reads the task from stdin; an empty task is a usage error (exit 2),
     # reached before any SDK import or auth — so this needs neither.
@@ -30,3 +64,129 @@ def test_runner_exits_2_without_a_task():
         timeout=30,
     )
     assert completed.returncode == 2
+
+
+def test_missing_sdk_exit_maps_to_setup_missing(tmp_path: Path, monkeypatch):
+    subprocess.run(["git", "init", "-q"], cwd=tmp_path, check=True)
+
+    def fake_run(argv, *args, **kwargs):
+        if argv[:2] == ["git", "rev-parse"]:
+            return SimpleNamespace(returncode=0, stdout=str(tmp_path), stderr="")
+        if argv[:3] == ["git", "status", "--porcelain"]:
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+        return SimpleNamespace(returncode=4, stdout="", stderr="OpenHands SDK not installed")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    result = OpenHandsWorker().run(repo_path=tmp_path, task="x", timeout_seconds=5)
+
+    assert result.status == "setup_missing"
+    assert result.termination_reason == "sdk_missing"
+    assert "OpenHands SDK not installed" in result.stderr
+
+
+def test_missing_auth_exit_maps_to_auth_missing(tmp_path: Path, monkeypatch):
+    subprocess.run(["git", "init", "-q"], cwd=tmp_path, check=True)
+
+    def fake_run(argv, *args, **kwargs):
+        if argv[:2] == ["git", "rev-parse"]:
+            return SimpleNamespace(returncode=0, stdout=str(tmp_path), stderr="")
+        if argv[:3] == ["git", "status", "--porcelain"]:
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+        return SimpleNamespace(returncode=3, stdout="", stderr="authentication_error: missing key")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    result = OpenHandsWorker().run(repo_path=tmp_path, task="x", timeout_seconds=5)
+
+    assert result.status == "auth_missing"
+    assert result.termination_reason == "auth_missing"
+
+
+def test_timeout_maps_to_timeout_status(tmp_path: Path, monkeypatch):
+    subprocess.run(["git", "init", "-q"], cwd=tmp_path, check=True)
+
+    def fake_run(argv, *args, **kwargs):
+        if argv[:2] == ["git", "rev-parse"]:
+            return SimpleNamespace(returncode=0, stdout=str(tmp_path), stderr="")
+        if argv[:3] == ["git", "status", "--porcelain"]:
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+        raise subprocess.TimeoutExpired(cmd=["openhands"], timeout=1, output="out", stderr="err")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    result = OpenHandsWorker().run(repo_path=tmp_path, task="x", timeout_seconds=1)
+
+    assert result.status == "timeout"
+    assert result.termination_reason == "timeout"
+    assert result.stdout == "out"
+    assert result.stderr == "err"
+
+
+def test_worker_writes_artifacts_when_run_dir_is_available(tmp_path: Path, monkeypatch):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    subprocess.run(["git", "init", "-q"], cwd=repo, check=True)
+    run_dir = tmp_path / "runs" / "run-1"
+
+    def fake_run(argv, *args, **kwargs):
+        if argv[:2] == ["git", "rev-parse"]:
+            return SimpleNamespace(returncode=0, stdout=str(repo), stderr="")
+        if argv[:3] == ["git", "status", "--porcelain"]:
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+        Path(kwargs["env"]["OPENHANDS_EVENTS_PATH"]).write_text(
+            '{"event_type":"FakeEvent"}\n',
+            encoding="utf-8",
+        )
+        return SimpleNamespace(
+            returncode=0,
+            stdout=(
+                'OPENHANDS_WORKER_SUMMARY_JSON={"worker_type":"openhands",'
+                '"loop_owner":"openhands_sdk","status":"completed","exit_code":0,'
+                '"duration_seconds":0.5,"tools_requested":["terminal","file_editor"]}\n'
+                "openhands run complete\n"
+            ),
+            stderr="",
+        )
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    result = OpenHandsWorker().run(
+        repo_path=repo,
+        task="x",
+        timeout_seconds=5,
+        run_dir=run_dir,
+        run_id="run-1",
+    )
+
+    assert result.status == "completed"
+    assert (run_dir / "worker_prompt.md").exists()
+    assert (run_dir / "worker_stdout.log").exists()
+    assert (run_dir / "worker_stderr.log").exists()
+    assert (run_dir / "worker_loop_summary.json").exists()
+    assert (run_dir / "worker_result.json").exists()
+    assert (run_dir / "worker_scorecard.json").exists()
+    assert (run_dir / "openhands_events.jsonl").exists()
+    assert (run_dir / "openhands_state").exists()
+    assert result.artifact_paths["summary"].endswith("worker_loop_summary.json")
+    assert result.artifact_paths["events"].endswith("openhands_events.jsonl")
+
+
+def test_failed_runner_exit_is_failed(tmp_path: Path, monkeypatch):
+    subprocess.run(["git", "init", "-q"], cwd=tmp_path, check=True)
+
+    def fake_run(argv, *args, **kwargs):
+        if argv[:2] == ["git", "rev-parse"]:
+            return SimpleNamespace(returncode=0, stdout=str(tmp_path), stderr="")
+        if argv[:3] == ["git", "status", "--porcelain"]:
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+        return SimpleNamespace(returncode=1, stdout="out", stderr="boom")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    result = OpenHandsWorker().run(repo_path=tmp_path, task="x", timeout_seconds=5)
+
+    assert result.status == "failed"
+    assert result.exit_code == 1
+    assert result.stdout == "out"
+    assert result.stderr == "boom"

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -99,10 +99,19 @@ def test_pr_writer_prompt_includes_report_inputs() -> None:
 def test_worker_prompt_is_shared_by_external_workers() -> None:
     prompt = build_worker_prompt(repo_path=Path("/repo"), task="Add logging")
 
-    assert "coding agent" in prompt
+    assert prompt.startswith("# Worker Packet")
+    assert "coding worker" in prompt
     assert "/repo" in prompt
-    assert "Task: Add logging" in prompt
-    assert "run tests" in prompt
+    assert "## Task\nAdd logging" in prompt
+    assert "## Plan as Contract" in prompt
+    assert "## Repo Context" in prompt
+    assert "## Constraints" in prompt
+    assert "## Forbidden Actions" in prompt
+    assert "## Permission Tier" in prompt
+    assert "## Verification Obligations" in prompt
+    assert "## Definition of Done" in prompt
+    assert "## Reporting Rules" in prompt
+    assert "Do not claim tests passed unless you actually ran them" in prompt
 
 
 def test_format_edit_summary_handles_observe_and_external_worker_modes() -> None:


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR wires a full OpenHands inner-worker integration into the AgentOps harness: the runner subprocess gains structured JSON summary emission, SDK callback-based event capture, and stable exit codes; the parent worker gains artifact persistence, status/termination mapping, and env isolation; and the prompt grows a rich \"worker packet\" contract with plan, repo context, constraints, and verification sections.

- **New modules** `openhands_config.py`, `openhands_artifacts.py`, and `app/schemas/worker_loop.py` cleanly separate config loading, file I/O, and schemas; OpenHands remains an optional dependency with no top-level SDK imports in the parent process.
- **`graph.py`** now maps `blocked`, `setup_missing`, and `auth_missing` worker statuses to a harness-level `blocked` (rather than `failed`), and passes `run_dir`, `run_id`, `plan`, `repo_profile`, and `tests_to_run` into `OpenHandsWorker.run()`.
- **Test coverage** is broad, but `test_runner_returns_config_error_for_malformed_env` passes a bare `env={\"OPENHANDS_MAX_ITERATIONS\": \"bad\"}` to `subprocess.run`, which strips the entire parent environment and makes the test's module resolution depend on pytest being run from the project root.

<h3>Confidence Score: 4/5</h3>

The core integration logic is solid and the optional-dependency boundary is well-maintained; one test has a fragile environment setup that could silently fail in non-standard CI configurations.

The runner, config, artifacts, and schema modules are clean. The worker status/termination mapping and artifact persistence are correct. The test for malformed config env completely replaces the subprocess environment with a single-key dict, meaning the subprocess can only find app.core.workers.openhands_runner if pytest happens to run from the project root. Additionally, _worker_attempted_tests uses uv run as a test marker broad enough to produce false-positive test-detection entries in the scorecard for any uv command.

tests/test_openhands_runner_contract.py (environment isolation in the malformed-env test) and app/core/workers/openhands_worker.py (_worker_attempted_tests heuristic and self-referential artifact path).

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| app/core/workers/openhands_worker.py | Large expansion adding artifact persistence, status/termination mapping, and env setup; contains a self-referential artifact path in _persist_worker_artifacts and an overly broad test-detection heuristic in _worker_attempted_tests. |
| app/core/workers/openhands_runner.py | Rewrites the subprocess runner to emit structured JSON summaries, capture SDK callbacks via _OpenHandsEventRecorder, and propagate distinct exit codes for auth/sdk/config failures; logic is sound with no top-level SDK imports. |
| tests/test_openhands_runner_contract.py | New contract tests for the runner subprocess; test_runner_returns_config_error_for_malformed_env uses a bare env dict that strips the full process environment, making it fragile in non-root CWD environments. |
| app/core/graph.py | Passes new context fields to OpenHandsWorker.run() and expands harness-level status mapping to treat blocked/setup_missing/auth_missing as blocked instead of failed. |
| app/core/workers/openhands_config.py | Clean new module handling model/auth/iteration config with proper env var validation and importlib-based SDK availability check. |
| app/schemas/worker_loop.py | New schema file defining WorkerLoopSummary, WorkerArtifactPaths, and WorkerScorecard; clean Pydantic models with sensible defaults. |

</details>

</details>

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Atests%2Ftest_openhands_runner_contract.py%3A78-87%0A**Bare%20%60env%3D%60%20dict%20strips%20the%20full%20process%20environment**%0A%0A%60env%3D%7B%22OPENHANDS_MAX_ITERATIONS%22%3A%20%22bad%22%7D%60%20passed%20to%20%60subprocess.run%60%20completely%20replaces%20the%20subprocess%20environment%20%E2%80%94%20no%20%60PATH%60%2C%20no%20%60PYTHONPATH%60%2C%20no%20inherited%20vars.%20The%20test%20then%20relies%20on%20Python's%20implicit%20CWD-based%20%60sys.path%60%20injection%20to%20find%20%60app.core.workers.openhands_runner%60.%20If%20pytest%20is%20ever%20invoked%20from%20a%20non-project-root%20directory%20%28e.g.%20CI%20with%20a%20separate%20%60workdir%60%29%2C%20Python%20won't%20locate%20the%20module%20and%20the%20test%20will%20fail%20with%20an%20import%20error%20rather%20than%20exit%20code%206.%20The%20%60monkeypatch.setenv%28%22OPENHANDS_MAX_ITERATIONS%22%2C%20%22bad%22%29%60%20call%20on%20line%2079%20is%20also%20a%20no-op%20for%20the%20subprocess%3A%20it%20patches%20the%20parent%20environment%2C%20but%20the%20explicit%20%60env%3D%60%20kwarg%20overrides%20it%20entirely.%20The%20fix%20is%20to%20merge%20the%20override%20into%20the%20current%20environment%3A%20%60env%3D%7B**os.environ%2C%20%22OPENHANDS_MAX_ITERATIONS%22%3A%20%22bad%22%7D%60.%0A%0A%23%23%23%20Issue%202%20of%203%0Aapp%2Fcore%2Fworkers%2Fopenhands_worker.py%3A314%0A%60%22uv%20run%22%60%20as%20a%20test-detection%20heuristic%20is%20too%20broad.%20It%20will%20set%20%60tests_attempted_by_worker%3DTrue%60%20for%20any%20%60uv%20run%60%20invocation%20in%20the%20worker's%20output%20%E2%80%94%20including%20package%20installs%2C%20data%20scripts%2C%20or%20a%20bare%20%60uv%20run%20python%20main.py%60.%20The%20scorecard%20will%20report%20spurious%20test%20attempts%2C%20misleading%20the%20outer%20governance%20layer%20about%20actual%20validation%20coverage.%0A%0A%60%60%60suggestion%0A%20%20%20%20if%20any%28marker%20in%20blob%20for%20marker%20in%20%28%22pytest%22%2C%20%22unittest%22%2C%20%22npm%20test%22%2C%20%22uv%20run%20pytest%22%2C%20%22uv%20run%20python%20-m%20pytest%22%29%29%3A%0A%60%60%60%0A%0A%23%23%23%20Issue%203%20of%203%0Aapp%2Fcore%2Fworkers%2Fopenhands_worker.py%3A288-298%0A**%60worker_result.json%60%20contains%20a%20self-referential%20path**%0A%0A%60result_path%60%20is%20set%20to%20%60run_dir%20%2F%20%22worker_result.json%22%60%20and%20then%20written%20into%20%60result.artifact_paths%5B%22result%22%5D%60%20before%20%60write_worker_result%28run_dir%2C%20result%29%60%20is%20called.%20The%20persisted%20JSON%20file%20therefore%20contains%20a%20%60%22result%22%60%20key%20pointing%20to%20itself.%20Consumers%20walking%20%60artifact_paths%60%20to%20discover%20artifacts%20will%20find%20a%20circular%20reference%2C%20and%20any%20tool%20that%20dereferences%20the%20path%20as%20%22the%20result%20of%20the%20worker%20run%22%20will%20re-read%20the%20file%20it%20already%20opened.%20The%20%60%22result%22%60%20entry%20in%20%60artifact_paths%60%20should%20either%20be%20omitted%20or%20populated%20after%20writing.%0A%0A&pr=13&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["Add OpenHands inner worker"](https://github.com/ven-z8/agentops-harness/commit/de6f063b7b8fb877c78cf8b0ad20af9e8374a50f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37246294)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->