### PR TITLE
Harvest Codex observability onto full-component OpenHands worker

### DIFF
--- a/app/core/graph.py
+++ b/app/core/graph.py
@@ -330,6 +330,11 @@ def run_external_worker_node(state: AgentOpsGraphState) -> AgentOpsGraphState:
             timeout_seconds=timeout,
             allow_dirty=allow_dirty,
             workspace=oh_workspace,
+            run_dir=artifact_dir_for_run(state["storage_path"], state["run_id"]),
+            run_id=state["run_id"],
+            plan=state.get("plan"),
+            repo_profile=state.get("repo_profile"),
+            tests_to_run=state.get("test_commands"),
         )
     elif worker_command:
         edit_result = ExternalWorkerRunner().run(

--- a/app/core/workers/openhands_artifacts.py
+++ b/app/core/workers/openhands_artifacts.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from app.schemas.edit import ExternalEditResult
+from app.schemas.worker_loop import WorkerArtifactPaths, WorkerLoopSummary, WorkerScorecard
+
+
+def _ensure_run_dir(run_dir: Path) -> Path:
+    run_dir.mkdir(parents=True, exist_ok=True)
+    return run_dir
+
+
+def _write_text(path: Path, text: str) -> Path:
+    path.write_text(text, encoding="utf-8")
+    return path
+
+
+def _write_json(path: Path, value: Any) -> Path:
+    payload = value.model_dump(mode="json") if hasattr(value, "model_dump") else value
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return path
+
+
+def write_worker_prompt(run_dir: Path, prompt: str) -> Path:
+    return _write_text(_ensure_run_dir(run_dir) / "worker_prompt.md", prompt.rstrip() + "\n")
+
+
+def write_worker_logs(run_dir: Path, stdout: str, stderr: str) -> tuple[Path, Path]:
+    root = _ensure_run_dir(run_dir)
+    return (
+        _write_text(root / "worker_stdout.log", stdout),
+        _write_text(root / "worker_stderr.log", stderr),
+    )
+
+
+def write_worker_summary(run_dir: Path, summary: WorkerLoopSummary) -> Path:
+    return _write_json(_ensure_run_dir(run_dir) / "worker_loop_summary.json", summary)
+
+
+def write_worker_result(run_dir: Path, result: ExternalEditResult) -> Path:
+    return _write_json(_ensure_run_dir(run_dir) / "worker_result.json", result)
+
+
+def write_worker_events(run_dir: Path, events: list[dict[str, Any]]) -> Path | None:
+    if not events:
+        return None
+    path = _ensure_run_dir(run_dir) / "openhands_events.jsonl"
+    lines = [json.dumps(event, sort_keys=True) for event in events]
+    return _write_text(path, "\n".join(lines) + "\n")
+
+
+def write_worker_scorecard(run_dir: Path, scorecard: WorkerScorecard) -> Path:
+    return _write_json(_ensure_run_dir(run_dir) / "worker_scorecard.json", scorecard)
+
+
+def collect_worker_artifact_paths(
+    *,
+    prompt: Path,
+    stdout: Path,
+    stderr: Path,
+    summary: Path,
+    result: Path,
+    events: Path | None = None,
+    scorecard: Path | None = None,
+) -> WorkerArtifactPaths:
+    return WorkerArtifactPaths(
+        prompt=str(prompt),
+        stdout=str(stdout),
+        stderr=str(stderr),
+        summary=str(summary),
+        result=str(result),
+        events=str(events) if events else None,
+        scorecard=str(scorecard) if scorecard else None,
+    )

--- a/app/core/workers/openhands_config.py
+++ b/app/core/workers/openhands_config.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+import importlib.util
+import os
+
+from pydantic import BaseModel, Field
+
+DEFAULT_OPENHANDS_MODEL = "anthropic/claude-sonnet-4-5-20250929"
+DEFAULT_OPENHANDS_TIMEOUT_SECONDS = 300
+OPENHANDS_TOOL_NAMES = ("terminal", "file_editor", "task_tracker", "grep", "glob")
+AUTH_ENV_NAMES = ("LLM_API_KEY", "ANTHROPIC_API_KEY", "OPENAI_API_KEY")
+
+
+class OpenHandsConfig(BaseModel):
+    model: str = DEFAULT_OPENHANDS_MODEL
+    api_key_env: str | None = None
+    max_iterations: int | None = None
+    timeout_seconds: int = DEFAULT_OPENHANDS_TIMEOUT_SECONDS
+    tools: list[str] = Field(default_factory=lambda: list(OPENHANDS_TOOL_NAMES))
+    config_error: str | None = None
+
+    @property
+    def missing_auth(self) -> bool:
+        return self.api_key_env is None
+
+
+def _positive_int_env(name: str) -> tuple[int | None, str | None]:
+    raw = os.getenv(name)
+    if raw is None or raw.strip() == "":
+        return None, None
+    try:
+        value = int(raw)
+    except ValueError:
+        return None, f"{name} must be a positive integer."
+    if value <= 0:
+        return None, f"{name} must be a positive integer."
+    return value, None
+
+
+def _first_auth_env() -> str | None:
+    for name in AUTH_ENV_NAMES:
+        if os.getenv(name):
+            return name
+    return None
+
+
+def load_openhands_config() -> OpenHandsConfig:
+    max_iterations, config_error = _positive_int_env("OPENHANDS_MAX_ITERATIONS")
+    return OpenHandsConfig(
+        model=os.getenv("OPENHANDS_MODEL", DEFAULT_OPENHANDS_MODEL),
+        api_key_env=_first_auth_env(),
+        max_iterations=max_iterations,
+        tools=list(OPENHANDS_TOOL_NAMES),
+        config_error=config_error,
+    )
+
+
+def openhands_sdk_available() -> bool:
+    try:
+        return (
+            importlib.util.find_spec("openhands.sdk") is not None
+            and importlib.util.find_spec("openhands.tools.terminal") is not None
+        )
+    except ModuleNotFoundError:
+        return False

--- a/app/core/workers/openhands_runner.py
+++ b/app/core/workers/openhands_runner.py
@@ -1,37 +1,37 @@
-"""Subprocess entry point that runs one full-capability OpenHands SDK agent loop.
+"""Subprocess entry point for the OpenHands inner-loop worker.
 
-Kept as a separate process so the heavy `openhands` import is lazy and the run is
-timeout-bounded by the parent worker (the same subprocess pattern the CLI workers use).
-
-Wires the worker-harness anatomy (harness-project slides 6-17) onto the real OpenHands
-SDK 1.28 — we ADOPT these, we do not build them:
-  01 while loop ............ Conversation.run()
-  02 context management .... LLMSummarizingCondenser (condenser)
-  03 tools & skills ........ Terminal/FileEditor/TaskTracker tools + AgentContext.skills
-  05 built-in primitives ... Terminal + FileEditor tools
-  06 session persistence ... Conversation(persistence_dir, conversation_id)
-  07 system-prompt assembly  AgentContext.system_message_suffix  <- the AgentOps bridge
-  09 permissions & safety .. OpenHands security analyzer + NeverConfirm (autonomous)
-
-Workspace mode (env OPENHANDS_WORKSPACE):
-  - "local" (default): the agent loop runs in-process, editing the repo on the host.
-  - "docker": the agent loop runs INSIDE an OpenHands agent-server container, with the
-    repo bind-mounted (mount_dir) so edits land on the host repo. Realizes slide 16.
-
-Task prompt on stdin (avoids arg-length limits). argv: <repo_path> [model].
-Exit codes: 0 ok · 2 usage · 3 auth missing · 4 sdk not installed · 1 run error.
+The parent AgentOps worker owns repo attribution, timeout, artifact persistence,
+and post-worker governance. This subprocess owns only SDK setup and the
+OpenHands conversation loop. Keeping the SDK import here makes OpenHands an
+optional dependency for normal AgentOps runs and tests.
 """
 
 from __future__ import annotations
 
 import contextlib
+import json
 import os
 import sys
-import tempfile
-import uuid
+import time
+from pathlib import Path
+from typing import Any
 
-DEFAULT_MODEL = "anthropic/claude-sonnet-4-5-20250929"
+from app.core.workers.openhands_config import (
+    OPENHANDS_TOOL_NAMES,
+    load_openhands_config,
+    openhands_sdk_available,
+)
+from app.schemas.worker_loop import WorkerLoopSummary
 
+EXIT_RUN_ERROR = 1
+EXIT_USAGE_ERROR = 2
+EXIT_AUTH_MISSING = 3
+EXIT_SDK_MISSING = 4
+EXIT_CONFIGURATION_ERROR = 6
+SUMMARY_PREFIX = "OPENHANDS_WORKER_SUMMARY_JSON="
+
+# Injected as the agent's system-prompt suffix — the AgentOps-harness constraints
+# (the bridge between the outer governor and the inner OpenHands loop).
 HARNESS_SYSTEM_SUFFIX = (
     "\n\nYou are running as a worker inside the AgentOps Harness. Constraints:\n"
     "- Make the smallest controlled change that satisfies the task; do not refactor "
@@ -42,21 +42,131 @@ HARNESS_SYSTEM_SUFFIX = (
 )
 
 
+class _OpenHandsEventRecorder:
+    def __init__(self, event_log_path: str | None) -> None:
+        self.event_log_path = event_log_path
+        self.observable_event_count = 0
+        self.write_error: str | None = None
+        if event_log_path:
+            path = Path(event_log_path)
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.touch(exist_ok=True)
+
+    def __call__(self, event: Any) -> None:
+        self.observable_event_count += 1
+        if not self.event_log_path:
+            return
+        payload = {
+            "event_type": event.__class__.__name__,
+            "event": _serialize_event(event),
+        }
+        try:
+            with Path(self.event_log_path).open("a", encoding="utf-8") as handle:
+                handle.write(json.dumps(payload, sort_keys=True, default=str) + "\n")
+        except OSError as exc:
+            self.write_error = str(exc)
+
+
+def _serialize_event(event: Any) -> dict[str, Any] | str:
+    if hasattr(event, "model_dump"):
+        return event.model_dump(mode="json")
+    if hasattr(event, "dict"):
+        return event.dict()
+    return repr(event)
+
+
+def _emit_summary(summary: WorkerLoopSummary) -> None:
+    print(SUMMARY_PREFIX + json.dumps(summary.model_dump(mode="json"), sort_keys=True))
+
+
+def _summary(
+    *,
+    status: str,
+    model: str | None,
+    started: float,
+    exit_code: int | None = None,
+    event_log_path: str | None = None,
+    observable_event_count: int = 0,
+    termination_reason: str | None = None,
+    setup_error: str | None = None,
+    notes: list[str] | None = None,
+) -> WorkerLoopSummary:
+    return WorkerLoopSummary(
+        model=model,
+        status=status,
+        exit_code=exit_code,
+        duration_seconds=round(time.perf_counter() - started, 3),
+        tools_requested=list(OPENHANDS_TOOL_NAMES),
+        event_log_path=event_log_path,
+        observable_event_count=observable_event_count,
+        termination_reason=termination_reason,
+        setup_error=setup_error,
+        notes=notes
+        or ["Inner tool trajectory may be partially observable depending on SDK support."],
+    )
+
+
 def main() -> int:
+    started = time.perf_counter()
     if len(sys.argv) < 2:
         print("usage: openhands_runner <repo_path> [model]  (task on stdin)", file=sys.stderr)
-        return 2
-    repo_path = os.path.abspath(sys.argv[1])
-    model = sys.argv[2] if len(sys.argv) > 2 else os.getenv("OPENHANDS_MODEL", DEFAULT_MODEL)
+        return EXIT_USAGE_ERROR
+    repo_path = sys.argv[1]
     task = sys.stdin.read().strip()
     if not task:
         print("usage: task prompt must be provided on stdin", file=sys.stderr)
-        return 2
+        return EXIT_USAGE_ERROR
 
-    api_key = os.getenv("LLM_API_KEY") or os.getenv("ANTHROPIC_API_KEY")
-    if not api_key:
-        print("authentication_error: set ANTHROPIC_API_KEY or LLM_API_KEY", file=sys.stderr)
-        return 3
+    config = load_openhands_config()
+    model = sys.argv[2] if len(sys.argv) > 2 else config.model
+    if config.config_error:
+        print(f"configuration_error: {config.config_error}", file=sys.stderr)
+        _emit_summary(
+            _summary(
+                status="failed",
+                model=model,
+                started=started,
+                exit_code=EXIT_CONFIGURATION_ERROR,
+                termination_reason="configuration_error",
+                setup_error=config.config_error,
+            )
+        )
+        return EXIT_CONFIGURATION_ERROR
+
+    if not openhands_sdk_available():
+        message = "OpenHands SDK not installed. Install with: uv sync --extra openhands"
+        print(f"setup_missing: {message}", file=sys.stderr)
+        _emit_summary(
+            _summary(
+                status="setup_missing",
+                model=model,
+                started=started,
+                exit_code=EXIT_SDK_MISSING,
+                termination_reason="sdk_missing",
+                setup_error=message,
+            )
+        )
+        return EXIT_SDK_MISSING
+
+    if config.missing_auth:
+        message = "set LLM_API_KEY, ANTHROPIC_API_KEY, or OPENAI_API_KEY"
+        print(f"authentication_error: {message}", file=sys.stderr)
+        _emit_summary(
+            _summary(
+                status="auth_missing",
+                model=model,
+                started=started,
+                exit_code=EXIT_AUTH_MISSING,
+                termination_reason="auth_missing",
+                setup_error=message,
+            )
+        )
+        return EXIT_AUTH_MISSING
+
+    api_key = os.getenv(config.api_key_env or "")
+    event_recorder = _OpenHandsEventRecorder(os.getenv("OPENHANDS_EVENTS_PATH"))
+    persistence_dir = os.getenv("OPENHANDS_PERSISTENCE_DIR") or None
+    workspace_mode = os.getenv("OPENHANDS_WORKSPACE", "local").lower()
 
     try:
         from openhands.sdk import LLM, Agent, Conversation, Tool
@@ -65,7 +175,6 @@ def main() -> int:
         from openhands.sdk.security.llm_analyzer import LLMSecurityAnalyzer
 
         # Importing the tool modules registers them so Tool(name=...) resolves at runtime.
-        from openhands.tools import delegate as _delegate  # noqa: F401 (registers sub-agents)
         from openhands.tools import glob as _glob  # noqa: F401 (registers retrieval)
         from openhands.tools import grep as _grep  # noqa: F401 (registers retrieval)
         from openhands.tools.file_editor import FileEditorTool
@@ -73,37 +182,35 @@ def main() -> int:
         from openhands.tools.task_tracker import TaskTrackerTool
         from openhands.tools.terminal import TerminalTool
     except ImportError as exc:
-        print(f"openhands sdk not installed: {exc}", file=sys.stderr)
-        return 4
+        message = f"OpenHands SDK not installed or incomplete: {exc}"
+        print(f"setup_missing: {message}", file=sys.stderr)
+        _emit_summary(
+            _summary(
+                status="setup_missing",
+                model=model,
+                started=started,
+                exit_code=EXIT_SDK_MISSING,
+                termination_reason="sdk_missing",
+                setup_error=message,
+            )
+        )
+        return EXIT_SDK_MISSING
 
     # 04 sub-agents — register the built-in archetypes (code-explorer, general-purpose,
-    # web-researcher, bash-runner) so the `delegate` tool can spawn focused sub-agents.
+    # web-researcher, bash-runner) so the agent can delegate focused sub-tasks.
     register_builtins_agents()
-
-    workspace_mode = os.getenv("OPENHANDS_WORKSPACE", "local").lower()
 
     workspace = None
     try:
         llm = LLM(model=model, api_key=api_key)
-
-        # 02 context management — summarize older history, keep recent + first turns verbatim.
+        # 02 context management.
         condenser = LLMSummarizingCondenser(llm=llm, max_size=80, keep_first=4)
-
-        # 03/07 skills + system-prompt assembly — the AgentOps constraints are injected
-        # here; load any skills/microagents the project ships.
+        # 03/07 skills + system-prompt assembly (the AgentOps constraints bridge).
         agent_context = AgentContext(
             system_message_suffix=HARNESS_SYSTEM_SUFFIX,
             load_project_skills=True,
         )
-
-        # Full inner-loop toolset:
-        #   05 primitives ... terminal, file_editor
-        #   working memory .. task_tracker
-        #   retrieval ....... grep, glob (agentic search beats one-shot RAG, slide 17)
-        # 04 sub-agents: the archetypes (code-explorer/general-purpose/web-researcher/
-        #   bash-runner) are registered above; the `delegate` tool that spawns them needs an
-        #   explicit register_tool(DelegateExecutor(...)) hookup — tracked as a follow-up.
-        # 09 permissions/safety: an LLM security analyzer assesses each action's risk.
+        # 05 primitives + retrieval; 09 security analyzer assesses each action's risk.
         agent = Agent(
             llm=llm,
             tools=[
@@ -117,59 +224,82 @@ def main() -> int:
             agent_context=agent_context,
             security_analyzer=LLMSecurityAnalyzer(),
         )
-
-        # 01 while loop + workspace selection.
-        if workspace_mode == "docker":
-            from openhands.workspace import DockerWorkspace
-
-            # The agent's repo lives at /workspace/project (Conversation default). Bind-mount
-            # the host repo THERE (not /workspace) so the agent edits the real files and the
-            # changes reflect straight back to the host — bidirectional, no extraction needed.
-            workspace = DockerWorkspace(
-                working_dir="/workspace",
-                volumes=[f"{repo_path}:/workspace/project"],
-                forward_env=["ANTHROPIC_API_KEY", "LLM_API_KEY", "OPENHANDS_MODEL"],
-            )
-            ws_arg = workspace
-        else:
-            ws_arg = repo_path
-
-        # 06 session persistence — replayable event log per run. A docker workspace uses a
-        # RemoteConversation that persists inside the container, so persistence_dir must NOT
-        # be set there; it is only valid for the in-process LocalConversation.
-        # 08 lifecycle hooks — a callback observes every event (audit/observability);
-        # stuck-detection breaks pathological no-progress loops.
-        def _audit(event: object) -> None:
-            print(f"[oh-event] {type(event).__name__}", file=sys.stderr)
-
-        conv_kwargs: dict = {
+        notes = [
+            "OpenHands SDK controls the inner prompt-model-tool-observe loop.",
+            "Observable SDK events are captured through Conversation callbacks.",
+        ]
+        conversation_kwargs: dict[str, Any] = {
             "agent": agent,
-            "workspace": ws_arg,
-            "conversation_id": uuid.uuid4(),
-            "callbacks": [_audit],
-            "stuck_detection": True,
+            "callbacks": [event_recorder],
+            "stuck_detection": True,  # 08 hooks: break no-progress loops
         }
         if workspace_mode == "docker":
-            # The host repo is bind-mounted at /workspace/project, so the agent's edits
-            # reflect straight back to the host — no extraction step required.
-            conversation = Conversation(**conv_kwargs)
-            conversation.send_message(task)
-            conversation.run()
+            # The agent's repo lives at /workspace/project; bind-mount the host repo THERE
+            # so edits reflect back to the host (bidirectional, no extraction needed).
+            from openhands.workspace import DockerWorkspace
+
+            workspace = DockerWorkspace(
+                working_dir="/workspace",
+                volumes=[f"{os.path.abspath(repo_path)}:/workspace/project"],
+                forward_env=[
+                    "ANTHROPIC_API_KEY",
+                    "LLM_API_KEY",
+                    "OPENAI_API_KEY",
+                    "OPENHANDS_MODEL",
+                ],
+            )
+            conversation_kwargs["workspace"] = workspace
+            notes.append("OpenHands agent loop runs inside an isolated Docker container.")
+            # RemoteConversation (docker) persists in-container; persistence_dir is forbidden.
         else:
-            with tempfile.TemporaryDirectory(prefix="agentops-oh-") as persist:
-                conversation = Conversation(persistence_dir=persist, **conv_kwargs)
-                conversation.send_message(task)
-                conversation.run()
+            conversation_kwargs["workspace"] = str(repo_path)
+            if persistence_dir:
+                conversation_kwargs["persistence_dir"] = persistence_dir
+                notes.append("OpenHands conversation persistence directory was configured.")
+        if config.max_iterations is not None:
+            conversation_kwargs["max_iteration_per_run"] = config.max_iterations
+        conversation = Conversation(**conversation_kwargs)
+        conversation.send_message(task)
+        conversation.run()
     except Exception as exc:  # surface as a worker failure, not a crash
         print(f"openhands run error: {exc}", file=sys.stderr)
-        return 1
+        notes = ["OpenHands SDK run failed before completion."]
+        if event_recorder.write_error:
+            notes.append(f"OpenHands event log write failed: {event_recorder.write_error}")
+        _emit_summary(
+            _summary(
+                status="failed",
+                model=model,
+                started=started,
+                exit_code=EXIT_RUN_ERROR,
+                event_log_path=event_recorder.event_log_path,
+                observable_event_count=event_recorder.observable_event_count,
+                termination_reason="run_error",
+                notes=notes,
+            )
+        )
+        return EXIT_RUN_ERROR
     finally:
         # Clean up the docker workspace container if one was started.
         if workspace is not None:
             with contextlib.suppress(Exception):
                 workspace.close()
 
-    print(f"openhands run complete (workspace={workspace_mode})")
+    if event_recorder.write_error:
+        notes.append(f"OpenHands event log write failed: {event_recorder.write_error}")
+    _emit_summary(
+        _summary(
+            status="completed",
+            model=model,
+            started=started,
+            exit_code=0,
+            event_log_path=event_recorder.event_log_path,
+            observable_event_count=event_recorder.observable_event_count,
+            termination_reason="completed",
+            notes=notes,
+        )
+    )
+    print("openhands run complete")
     return 0
 
 

--- a/app/core/workers/openhands_worker.py
+++ b/app/core/workers/openhands_worker.py
@@ -223,8 +223,13 @@ def _status_from_exit_code(code: int, stdout: str, stderr: str) -> str:
         return "completed"
     if code == 3 or detect_auth_failure(stdout, stderr):
         return "auth_missing"
-    if code in (4, 6):
+    if code == 4:
         return "setup_missing"
+    if code == 6:
+        # Bad config (e.g. OPENHANDS_MAX_ITERATIONS=bad) is NOT a missing SDK, so it must
+        # not get the "reinstall the SDK" hint. The runner already prints the real cause
+        # to stderr ("configuration_error: ...").
+        return "configuration_error"
     return "failed"
 
 
@@ -290,17 +295,18 @@ def _persist_worker_artifacts(
             ],
         ),
     )
-    result_path = run_dir / "worker_result.json"
     result.artifact_paths = {
         "prompt": str(prompt_path),
         "stdout": str(stdout_path),
         "stderr": str(stderr_path),
         "summary": str(summary_path),
-        "result": str(result_path),
         "events": str(events_path) if events_path else None,
         "scorecard": str(scorecard_path),
     }
-    write_worker_result(run_dir, result)
+    # write_worker_result owns the filename; use its return value rather than
+    # re-deriving the path so the two can never drift apart.
+    result_path = write_worker_result(run_dir, result)
+    result.artifact_paths["result"] = str(result_path)
 
 
 def _existing_event_log_path(run_dir: Path, summary: WorkerLoopSummary) -> Path | None:
@@ -309,13 +315,17 @@ def _existing_event_log_path(run_dir: Path, summary: WorkerLoopSummary) -> Path 
         candidates.append(Path(summary.event_log_path))
     candidates.append(run_dir / "openhands_events.jsonl")
     for path in candidates:
-        if path.exists():
+        # The recorder pre-touches the log even when zero callbacks fire; treat an empty
+        # file as "no events captured" so artifact_paths["events"] is set iff events exist.
+        if path.exists() and path.stat().st_size > 0:
             return path
     return None
 
 
 def _worker_attempted_tests(stdout: str, stderr: str) -> bool | None:
     blob = f"{stdout}\n{stderr}".lower()
-    if any(marker in blob for marker in ("pytest", "unittest", "npm test", "uv run")):
+    # "pytest" already covers "uv run pytest"; a bare "uv run" would false-positive on
+    # "uv run black ." / "uv run pip install", so only the explicit test script counts.
+    if any(marker in blob for marker in ("pytest", "unittest", "npm test", "uv run test")):
         return True
     return None

--- a/app/core/workers/openhands_worker.py
+++ b/app/core/workers/openhands_worker.py
@@ -9,18 +9,31 @@ in place; the harness reads the diff (step 6) via its existing collect_diff node
 
 from __future__ import annotations
 
+import json
 import os
 import subprocess
 import sys
 import time
 from pathlib import Path
+from typing import Any
 
 from app.core.git_utils import collect_status_lines, is_git_repo
 from app.core.workers.auth_errors import detect_auth_failure
+from app.core.workers.openhands_artifacts import (
+    write_worker_logs,
+    write_worker_prompt,
+    write_worker_result,
+    write_worker_scorecard,
+    write_worker_summary,
+)
+from app.core.workers.openhands_config import OPENHANDS_TOOL_NAMES
+from app.core.workers.openhands_runner import SUMMARY_PREFIX
 from app.prompts.workers import build_worker_prompt
 from app.schemas.edit import ExternalEditResult
+from app.schemas.worker_loop import WorkerLoopSummary, WorkerScorecard
 
 COMMAND_STR = "python -m app.core.workers.openhands_runner <repo> (task on stdin)"
+HARNESS_ROOT = Path(__file__).resolve().parents[3]
 
 
 class OpenHandsWorker:
@@ -32,79 +45,277 @@ class OpenHandsWorker:
         task: str,
         timeout_seconds: int = 300,
         allow_dirty: bool = False,
+        run_dir: Path | None = None,
+        run_id: str | None = None,
+        plan: Any = None,
+        repo_profile: Any = None,
+        tests_to_run: list[str] | None = None,
+        forbidden_paths: list[str] | None = None,
+        permission_tier: str = "standard",
         workspace: str = "local",
     ) -> ExternalEditResult:
+        command = f"{sys.executable} -m app.core.workers.openhands_runner {repo_path}"
         if not is_git_repo(repo_path):
             return ExternalEditResult(
                 status="blocked",
-                command=COMMAND_STR,
+                command=command,
                 stderr="Target path must be a git repository for edit attribution.",
+                termination_reason="not_git_repo",
+                worker_type="openhands",
             )
 
         if collect_status_lines(repo_path) and not allow_dirty:
             return ExternalEditResult(
                 status="blocked",
-                command=COMMAND_STR,
+                command=command,
                 stderr=(
                     "Target repository is dirty. Commit, stash, or pass allow_dirty=True "
                     "before running an OpenHands worker."
                 ),
+                termination_reason="dirty_repo",
+                worker_type="openhands",
             )
 
-        prompt = build_worker_prompt(repo_path=repo_path, task=task)
+        prompt = build_worker_prompt(
+            repo_path=repo_path,
+            task=task,
+            plan=plan,
+            repo_profile=repo_profile,
+            forbidden_paths=forbidden_paths,
+            tests_to_run=tests_to_run,
+            permission_tier=permission_tier,
+        )
         argv = [sys.executable, "-m", "app.core.workers.openhands_runner", str(repo_path)]
-        # Select the OpenHands workspace mode (local in-process loop, or its own Docker
-        # agent-server container) for the runner subprocess.
-        env = os.environ.copy()
-        env["OPENHANDS_WORKSPACE"] = "docker" if workspace == "docker" else "local"
+        prompt_path = write_worker_prompt(run_dir, prompt) if run_dir else None
 
         started = time.perf_counter()
         try:
             completed = subprocess.run(
                 argv,
                 input=prompt,
-                cwd=repo_path,
+                cwd=HARNESS_ROOT,
                 capture_output=True,
                 text=True,
                 timeout=timeout_seconds,
                 check=False,
-                env=env,
+                env=_runner_env(run_dir, workspace),
             )
         except subprocess.TimeoutExpired as exc:
-            return ExternalEditResult(
-                status="failed",
-                command=COMMAND_STR,
-                exit_code=None,
-                stdout=exc.stdout or "",
-                stderr=exc.stderr or f"OpenHands worker timed out after {timeout_seconds}s.",
-                duration_seconds=round(time.perf_counter() - started, 3),
+            stdout = _coerce_text(exc.stdout or exc.output or "")
+            stderr = _coerce_text(
+                exc.stderr or f"OpenHands worker timed out after {timeout_seconds}s."
             )
+            duration = round(time.perf_counter() - started, 3)
+            result = ExternalEditResult(
+                status="timeout",
+                command=command,
+                exit_code=None,
+                stdout=stdout,
+                stderr=stderr,
+                duration_seconds=duration,
+                termination_reason="timeout",
+                worker_type="openhands",
+            )
+            summary = WorkerLoopSummary(
+                status="timeout",
+                exit_code=None,
+                duration_seconds=duration,
+                tools_requested=list(OPENHANDS_TOOL_NAMES),
+                termination_reason="timeout",
+                prompt_path=str(prompt_path) if prompt_path else None,
+            )
+            _persist_worker_artifacts(
+                run_dir=run_dir,
+                run_id=run_id,
+                prompt_path=prompt_path,
+                prompt=prompt,
+                result=result,
+                summary=summary,
+            )
+            return result
 
         duration = round(time.perf_counter() - started, 3)
         code = completed.returncode
+        summary = _summary_from_stdout(completed.stdout) or WorkerLoopSummary(
+            status=_status_from_exit_code(code, completed.stdout, completed.stderr),
+            exit_code=code,
+            duration_seconds=duration,
+            tools_requested=list(OPENHANDS_TOOL_NAMES),
+            termination_reason=_termination_from_exit_code(
+                code,
+                completed.stdout,
+                completed.stderr,
+            ),
+        )
+        summary.exit_code = code
+        summary.duration_seconds = duration
+        summary.prompt_path = str(prompt_path) if prompt_path else None
 
-        # Auth (exit 3) and missing-SDK (exit 4) are setup problems, not run failures.
-        if code in (3, 4) or detect_auth_failure(completed.stdout, completed.stderr):
-            reason = (
-                "OpenHands SDK not installed. Install: uv sync --extra openhands."
-                if code == 4
-                else detect_auth_failure(completed.stdout, completed.stderr)
-                or "OpenHands authentication failed; set ANTHROPIC_API_KEY and retry."
-            )
-            return ExternalEditResult(
-                status="blocked",
-                command=COMMAND_STR,
-                exit_code=code,
-                stdout=completed.stdout,
-                stderr=f"{reason}\n{completed.stderr}".strip(),
-                duration_seconds=duration,
-            )
-
-        return ExternalEditResult(
-            status="completed" if code == 0 else "failed",
-            command=COMMAND_STR,
+        status = _status_from_exit_code(code, completed.stdout, completed.stderr)
+        termination_reason = _termination_from_exit_code(code, completed.stdout, completed.stderr)
+        stderr = _stderr_with_setup_hint(status, completed.stdout, completed.stderr)
+        result = ExternalEditResult(
+            status=status,
+            command=command,
             exit_code=code,
             stdout=completed.stdout,
-            stderr=completed.stderr,
+            stderr=stderr,
             duration_seconds=duration,
+            termination_reason=termination_reason,
+            worker_type="openhands",
         )
+        summary.status = status
+        summary.termination_reason = termination_reason
+        _persist_worker_artifacts(
+            run_dir=run_dir,
+            run_id=run_id,
+            prompt_path=prompt_path,
+            prompt=prompt,
+            result=result,
+            summary=summary,
+        )
+        return result
+
+
+def _coerce_text(value: str | bytes) -> str:
+    if isinstance(value, bytes):
+        return value.decode("utf-8", errors="replace")
+    return value
+
+
+def _runner_env(run_dir: Path | None = None, workspace: str = "local") -> dict[str, str]:
+    env = os.environ.copy()
+    existing = env.get("PYTHONPATH")
+    env["PYTHONPATH"] = (
+        str(HARNESS_ROOT) if not existing else f"{HARNESS_ROOT}{os.pathsep}{existing}"
+    )
+    # Select the OpenHands workspace mode for the runner (local in-process loop, or its
+    # own Docker agent-server container).
+    env["OPENHANDS_WORKSPACE"] = "docker" if workspace == "docker" else "local"
+    if run_dir is not None:
+        run_dir.mkdir(parents=True, exist_ok=True)
+        events_path = run_dir / "openhands_events.jsonl"
+        persistence_dir = run_dir / "openhands_state"
+        events_path.touch(exist_ok=True)
+        persistence_dir.mkdir(parents=True, exist_ok=True)
+        env["OPENHANDS_EVENTS_PATH"] = str(events_path)
+        env["OPENHANDS_PERSISTENCE_DIR"] = str(persistence_dir)
+    return env
+
+
+def _summary_from_stdout(stdout: str) -> WorkerLoopSummary | None:
+    for line in stdout.splitlines():
+        if not line.startswith(SUMMARY_PREFIX):
+            continue
+        try:
+            return WorkerLoopSummary.model_validate_json(line.split("=", maxsplit=1)[1])
+        except (json.JSONDecodeError, ValueError):
+            return WorkerLoopSummary(
+                status="failed",
+                termination_reason="malformed_worker_summary",
+                notes=["OpenHands runner emitted malformed summary JSON."],
+            )
+    return None
+
+
+def _status_from_exit_code(code: int, stdout: str, stderr: str) -> str:
+    if code == 0:
+        return "completed"
+    if code == 3 or detect_auth_failure(stdout, stderr):
+        return "auth_missing"
+    if code in (4, 6):
+        return "setup_missing"
+    return "failed"
+
+
+def _termination_from_exit_code(code: int, stdout: str, stderr: str) -> str:
+    if code == 0:
+        return "completed"
+    if code == 2:
+        return "usage_error"
+    if code == 3 or detect_auth_failure(stdout, stderr):
+        return "auth_missing"
+    if code == 4:
+        return "sdk_missing"
+    if code == 6:
+        return "configuration_error"
+    return "run_error"
+
+
+def _stderr_with_setup_hint(status: str, stdout: str, stderr: str) -> str:
+    if status == "setup_missing":
+        hint = "OpenHands SDK not installed. Install with: uv sync --extra openhands."
+        return f"{hint}\n{stderr}".strip()
+    if status == "auth_missing":
+        hint = detect_auth_failure(stdout, stderr) or (
+            "OpenHands authentication missing. Set LLM_API_KEY, ANTHROPIC_API_KEY, "
+            "or OPENAI_API_KEY and retry."
+        )
+        return f"{hint}\n{stderr}".strip()
+    return stderr
+
+
+def _persist_worker_artifacts(
+    *,
+    run_dir: Path | None,
+    run_id: str | None,
+    prompt_path: Path | None,
+    prompt: str,
+    result: ExternalEditResult,
+    summary: WorkerLoopSummary,
+) -> None:
+    if run_dir is None:
+        return
+
+    if prompt_path is None:
+        prompt_path = write_worker_prompt(run_dir, prompt)
+    stdout_path, stderr_path = write_worker_logs(run_dir, result.stdout, result.stderr)
+    events_path = _existing_event_log_path(run_dir, summary)
+    summary.prompt_path = str(prompt_path)
+    summary.stdout_path = str(stdout_path)
+    summary.stderr_path = str(stderr_path)
+    if events_path:
+        summary.event_log_path = str(events_path)
+    summary_path = write_worker_summary(run_dir, summary)
+    scorecard_path = write_worker_scorecard(
+        run_dir,
+        WorkerScorecard(
+            task_id=run_id,
+            status=result.status,
+            duration_seconds=result.duration_seconds,
+            tests_attempted_by_worker=_worker_attempted_tests(result.stdout, result.stderr),
+            notes=[
+                "AgentOps owns final diff collection, permission enforcement, tests, "
+                "risk, and evidence."
+            ],
+        ),
+    )
+    result_path = run_dir / "worker_result.json"
+    result.artifact_paths = {
+        "prompt": str(prompt_path),
+        "stdout": str(stdout_path),
+        "stderr": str(stderr_path),
+        "summary": str(summary_path),
+        "result": str(result_path),
+        "events": str(events_path) if events_path else None,
+        "scorecard": str(scorecard_path),
+    }
+    write_worker_result(run_dir, result)
+
+
+def _existing_event_log_path(run_dir: Path, summary: WorkerLoopSummary) -> Path | None:
+    candidates = []
+    if summary.event_log_path:
+        candidates.append(Path(summary.event_log_path))
+    candidates.append(run_dir / "openhands_events.jsonl")
+    for path in candidates:
+        if path.exists():
+            return path
+    return None
+
+
+def _worker_attempted_tests(stdout: str, stderr: str) -> bool | None:
+    blob = f"{stdout}\n{stderr}".lower()
+    if any(marker in blob for marker in ("pytest", "unittest", "npm test", "uv run")):
+        return True
+    return None

--- a/app/prompts/workers.py
+++ b/app/prompts/workers.py
@@ -1,15 +1,178 @@
 from __future__ import annotations
 
 from pathlib import Path
+from typing import Any
 
 
-def build_worker_prompt(*, repo_path: Path, task: str) -> str:
+def _as_lines(values: list[str] | tuple[str, ...] | None, *, empty: str) -> str:
+    if not values:
+        return f"- {empty}"
+    return "\n".join(f"- {value}" for value in values)
+
+
+def _model_dict(value: Any) -> dict[str, Any]:
+    if value is None:
+        return {}
+    if hasattr(value, "model_dump"):
+        return value.model_dump(mode="json")
+    if isinstance(value, dict):
+        return value
+    return {}
+
+
+def _format_plan(plan: Any) -> str:
+    payload = _model_dict(plan)
+    if not payload:
+        return (
+            "- No formal AgentOps plan was provided. Inspect the repo and make the "
+            "smallest safe implementation that satisfies the task."
+        )
+
+    lines = []
+    summary = payload.get("summary")
+    if summary:
+        lines.append(f"- Summary: {summary}")
+    for step in payload.get("steps") or []:
+        title = step.get("title", "Plan step")
+        description = step.get("description", "")
+        lines.append(f"- Step {step.get('id', '?')}: {title} - {description}".rstrip())
+        files_to_inspect = step.get("files_to_inspect") or []
+        files_to_edit = step.get("files_to_edit") or []
+        tests = step.get("tests") or []
+        if files_to_inspect:
+            lines.append(f"  - Inspect: {', '.join(files_to_inspect)}")
+        if files_to_edit:
+            lines.append(f"  - Edit: {', '.join(files_to_edit)}")
+        if tests:
+            lines.append(f"  - Tests: {', '.join(tests)}")
+    criteria = payload.get("acceptance_criteria") or []
+    if criteria:
+        lines.append("- Acceptance criteria:")
+        lines.extend(f"  - {item}" for item in criteria)
+    risk_notes = payload.get("risk_notes") or []
+    if risk_notes:
+        lines.append("- Risk notes:")
+        lines.extend(f"  - {item}" for item in risk_notes)
+    return "\n".join(lines) if lines else "- AgentOps provided an empty plan."
+
+
+def _format_repo_context(repo_path: Path, repo_profile: Any) -> str:
+    payload = _model_dict(repo_profile)
+    lines = [f"- Repo path: {repo_path}"]
+    for key, label in (
+        ("language", "Language"),
+        ("framework", "Framework"),
+        ("package_manager", "Package manager"),
+        ("test_framework", "Test framework"),
+    ):
+        if payload.get(key):
+            lines.append(f"- {label}: {payload[key]}")
+    for key, label in (
+        ("entrypoints", "Entrypoints"),
+        ("important_folders", "Important folders"),
+        ("config_files", "Config files"),
+    ):
+        values = payload.get(key) or []
+        if values:
+            lines.append(f"- {label}: {', '.join(values)}")
+    return "\n".join(lines)
+
+
+def _plan_files(plan: Any) -> list[str]:
+    payload = _model_dict(plan)
+    files: list[str] = []
+    for step in payload.get("steps") or []:
+        files.extend(step.get("files_to_inspect") or [])
+        files.extend(step.get("files_to_edit") or [])
+    return sorted(set(files))
+
+
+def _plan_tests(plan: Any) -> list[str]:
+    payload = _model_dict(plan)
+    tests = list(payload.get("tests_to_run") or [])
+    for step in payload.get("steps") or []:
+        tests.extend(step.get("tests") or [])
+    return sorted(set(tests))
+
+
+def build_worker_prompt(
+    *,
+    repo_path: Path,
+    task: str,
+    plan: Any = None,
+    repo_profile: Any = None,
+    files_to_edit: list[str] | None = None,
+    forbidden_paths: list[str] | None = None,
+    tests_to_run: list[str] | None = None,
+    permission_tier: str = "standard",
+) -> str:
+    likely_files = files_to_edit or _plan_files(plan)
+    verification_commands = tests_to_run or _plan_tests(plan)
+    no_likely_files = (
+        "No likely files were provided. Discover the minimal relevant files before editing."
+    )
+    default_forbidden_paths = (
+        ".env, .env.*, **/*secret*, **/*token*, private keys, credential stores"
+    )
+    default_verification = (
+        "Run the smallest relevant test or validation command you can identify."
+    )
     return f"""\
-You are a coding agent working inside the repository at {repo_path}.
+# Worker Packet
+You are a coding worker running inside AgentOps Harness.
+AgentOps is the outer governance harness.
+You are the inner implementation worker.
 
-Task: {task}
+## Task
+{task}
 
-Implement the task. Edit files as needed, run tests to verify your work, then
-stop. Do not explain what you did — just make the changes and confirm with a
-one-sentence summary of what changed.
+## Plan as Contract
+{_format_plan(plan)}
+Follow this plan unless repo inspection proves it is wrong.
+If the plan is wrong, make the smallest safe correction and explain it.
+
+## Repo Context
+{_format_repo_context(repo_path, repo_profile)}
+
+## Likely Impacted Files
+{_as_lines(likely_files, empty=no_likely_files)}
+
+## Constraints
+- Keep the diff minimal.
+- Do not edit unrelated files.
+- Do not touch sensitive paths.
+- Do not modify tests just to make them pass unless explicitly required.
+- Prefer implementation changes over test weakening.
+- If you cannot proceed safely, stop and explain why.
+
+## Forbidden Actions
+- Do not add secrets, credentials, tokens, private keys, or real API keys.
+- Do not modify lockfiles, generated files, or CI configuration unless the plan requires it.
+- Do not change public behavior outside the task scope.
+- Do not claim tests passed unless you actually ran them and saw success.
+
+## Forbidden Paths
+{_as_lines(forbidden_paths, empty=default_forbidden_paths)}
+
+## Permission Tier
+{permission_tier}
+
+## Verification Obligations
+Run these if possible:
+{_as_lines(verification_commands, empty=default_verification)}
+If you cannot run them, explain why.
+
+## Definition of Done
+The task is done only when:
+- required implementation is complete
+- diff is minimal
+- validation has been attempted
+- no forbidden paths are touched
+- final message summarizes exactly what changed
+
+## Reporting Rules
+Do not claim tests passed unless you actually ran them and saw success.
+Do not claim files changed unless you changed them.
+Do not claim routes/endpoints were added unless they exist in the diff.
+If blocked, explain the blocker and stop.
 """

--- a/app/schemas/edit.py
+++ b/app/schemas/edit.py
@@ -10,6 +10,7 @@ ExternalEditStatus = Literal[
     "timeout",
     "setup_missing",
     "auth_missing",
+    "configuration_error",
 ]
 
 

--- a/app/schemas/edit.py
+++ b/app/schemas/edit.py
@@ -1,9 +1,16 @@
 from typing import Literal
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 EditMode = Literal["observe", "external_worker"]
-ExternalEditStatus = Literal["completed", "failed", "blocked"]
+ExternalEditStatus = Literal[
+    "completed",
+    "failed",
+    "blocked",
+    "timeout",
+    "setup_missing",
+    "auth_missing",
+]
 
 
 class ExternalEditResult(BaseModel):
@@ -14,3 +21,6 @@ class ExternalEditResult(BaseModel):
     stdout: str = ""
     stderr: str = ""
     duration_seconds: float = 0.0
+    termination_reason: str | None = None
+    worker_type: str | None = None
+    artifact_paths: dict[str, str | None] = Field(default_factory=dict)

--- a/app/schemas/worker_loop.py
+++ b/app/schemas/worker_loop.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from pydantic import BaseModel, Field
+
+
+class WorkerLoopSummary(BaseModel):
+    worker_type: str = "openhands"
+    loop_owner: str = "openhands_sdk"
+    agentops_role: str = "outer_governor"
+    model: str | None = None
+    status: str
+    exit_code: int | None = None
+    duration_seconds: float | None = None
+    tools_requested: list[str] = Field(default_factory=list)
+    prompt_path: str | None = None
+    stdout_path: str | None = None
+    stderr_path: str | None = None
+    event_log_path: str | None = None
+    observable_event_count: int = 0
+    termination_reason: str | None = None
+    setup_error: str | None = None
+    notes: list[str] = Field(default_factory=list)
+
+
+class WorkerArtifactPaths(BaseModel):
+    prompt: str
+    stdout: str
+    stderr: str
+    summary: str
+    result: str
+    events: str | None = None
+    scorecard: str | None = None
+
+
+class WorkerScorecard(BaseModel):
+    worker_type: str = "openhands"
+    task_id: str | None = None
+    status: str
+    duration_seconds: float | None = None
+    changed_file_count: int | None = None
+    tests_attempted_by_worker: bool | None = None
+    agentops_tests_passed: bool | None = None
+    permission_violations: int | None = None
+    unsupported_claims: int | None = None
+    risk_level: str | None = None
+    convergence_type: str | None = None
+    notes: list[str] = Field(default_factory=list)

--- a/docs/OPENHANDS_INNER_WORKER.md
+++ b/docs/OPENHANDS_INNER_WORKER.md
@@ -1,0 +1,196 @@
+# OpenHands Inner Worker
+
+AgentOps Harness is the outer governance harness. OpenHands is the inner worker
+harness. The integration lets AgentOps give OpenHands a structured worker packet,
+let OpenHands run its own implementation loop, then let AgentOps collect the diff
+and enforce the normal governance pipeline.
+
+## Boundary
+
+AgentOps owns:
+
+- scan, recall, plan, and workspace preparation
+- pre-dispatch permission checks
+- worker prompt contract
+- target repository and timeout
+- stdout, stderr, exit code, duration, and worker artifacts
+- final diff collection
+- permission enforcement, tests, risk, evidence, product review, and verification
+
+OpenHands owns:
+
+- prompt to model loop
+- file reads and edits inside the target repo
+- terminal commands inside the worker loop
+- local implementation attempts
+- stopping once it completes, blocks, errors, or reaches SDK limits
+
+AgentOps does not trust the worker's self-report. OpenHands may attempt tests, but
+AgentOps reruns configured validation after the worker returns.
+
+## Setup
+
+OpenHands remains optional. Normal AgentOps tests and demos do not install it and
+do not require provider credentials.
+
+Install the optional worker dependencies:
+
+```bash
+uv sync --extra dev --extra openhands
+```
+
+Configure a model and one API key:
+
+```bash
+export OPENHANDS_MODEL=anthropic/claude-sonnet-4-5-20250929
+export ANTHROPIC_API_KEY=...
+```
+
+The worker checks these environment variables:
+
+- `OPENHANDS_MODEL`
+- `OPENHANDS_MAX_ITERATIONS`
+- `LLM_API_KEY`
+- `ANTHROPIC_API_KEY`
+- `OPENAI_API_KEY`
+
+## Artifacts
+
+When invoked from an AgentOps run, OpenHands worker artifacts are written under
+the run directory:
+
+```text
+.agentops/runs/<run_id>/
+|-- worker_prompt.md
+|-- worker_stdout.log
+|-- worker_stderr.log
+|-- worker_loop_summary.json
+|-- worker_result.json
+|-- worker_scorecard.json
+|-- openhands_events.jsonl
+|-- openhands_state/
+|-- diff.patch
+|-- test_results.json
+|-- risk_report.json
+|-- permission_report.json
+|-- evidence_report.json
+|-- product_review.json
+|-- verification_bundle.json
+`-- run_record.json
+```
+
+`worker_loop_summary.json` records the observable inner-loop lifecycle:
+
+```json
+{
+  "worker_type": "openhands",
+  "loop_owner": "openhands_sdk",
+  "agentops_role": "outer_governor",
+  "status": "completed",
+  "model": "anthropic/claude-sonnet-4-5-20250929",
+  "tools_requested": ["terminal", "file_editor"],
+  "event_log_path": ".agentops/runs/<run_id>/openhands_events.jsonl",
+  "observable_event_count": 12,
+  "termination_reason": "completed"
+}
+```
+
+The runner uses OpenHands SDK `Conversation` callbacks to persist observable
+events as JSONL. It also configures a conversation persistence directory under
+the run directory, so SDK-managed state can be inspected separately from
+AgentOps-owned diff, test, risk, permission, evidence, and verification
+artifacts.
+
+## Status Mapping
+
+The subprocess runner uses stable exit codes:
+
+- `0`: completed
+- `1`: run error
+- `2`: usage error
+- `3`: authentication missing
+- `4`: SDK missing
+- `5`: timeout handled by parent
+- `6`: configuration error
+
+The parent worker maps those to `ExternalEditResult.status`:
+
+- `completed`
+- `failed`
+- `blocked`
+- `timeout`
+- `setup_missing`
+- `auth_missing`
+
+Missing SDK and missing auth are classified cleanly so CI can run without
+OpenHands installed and without provider keys.
+
+## Manual Tests
+
+The target repo must be a git root so AgentOps can attribute the worker diff.
+For the bundled sample app, prepare a temporary git repo first:
+
+```bash
+tmp_repo="$(mktemp -d)/sample_fastapi_app"
+cp -R examples/sample_fastapi_app "$tmp_repo"
+git -C "$tmp_repo" init -q
+git -C "$tmp_repo" add .
+git -C "$tmp_repo" commit -qm "initial sample app"
+```
+
+Setup missing:
+
+```bash
+uv run --extra dev agentops edit \
+  --repo "$tmp_repo" \
+  --task "Add request logging middleware" \
+  --worker-type openhands
+```
+
+Expected without OpenHands extras: `setup_missing`, with a diagnostic explaining
+that the OpenHands SDK is not installed.
+
+Auth missing:
+
+```bash
+uv run --extra dev --extra openhands agentops edit \
+  --repo "$tmp_repo" \
+  --task "Add request logging middleware" \
+  --worker-type openhands
+```
+
+Expected without an API key: `auth_missing`.
+
+Successful run:
+
+```bash
+OPENHANDS_MODEL=anthropic/claude-sonnet-4-5-20250929 \
+ANTHROPIC_API_KEY=... \
+uv run --extra dev --extra openhands agentops edit \
+  --repo "$tmp_repo" \
+  --task "Add request logging middleware" \
+  --worker-type openhands \
+  --max-attempts 1
+```
+
+Expected: OpenHands edits the repo, AgentOps collects the diff, reruns tests,
+classifies permissions and risk, checks evidence, runs product review, and writes
+the verification bundle.
+
+Sensitive path:
+
+```bash
+uv run --extra dev agentops edit \
+  --repo "$tmp_repo" \
+  --task "Add API key to .env for the app" \
+  --worker-type openhands
+```
+
+Expected: pre-dispatch governance blocks the worker before OpenHands runs.
+
+## Limitations
+
+- This integration does not add browser tools or network tools to OpenHands.
+- Event capture is limited to events surfaced through OpenHands SDK callbacks.
+- AgentOps does not use OpenHands as a replacement for governance.
+- AgentOps still performs final validation after every worker run.

--- a/examples/workloads/openhands_request_logging.yaml
+++ b/examples/workloads/openhands_request_logging.yaml
@@ -1,0 +1,8 @@
+name: OpenHands Request Logging
+repo: examples/sample_fastapi_app
+task: Add structured HTTP request logging middleware with accompanying pytest coverage.
+worker_type: openhands
+expected:
+  max_risk_score: 65
+  required_commands:
+    - python -m pytest -q

--- a/tests/test_openhands_artifacts.py
+++ b/tests/test_openhands_artifacts.py
@@ -1,0 +1,56 @@
+import json
+from pathlib import Path
+
+from app.core.workers.openhands_artifacts import (
+    write_worker_events,
+    write_worker_logs,
+    write_worker_prompt,
+    write_worker_result,
+    write_worker_scorecard,
+    write_worker_summary,
+)
+from app.schemas.edit import ExternalEditResult
+from app.schemas.worker_loop import WorkerLoopSummary, WorkerScorecard
+
+
+def test_openhands_artifact_writer_persists_worker_files(tmp_path: Path) -> None:
+    prompt_path = write_worker_prompt(tmp_path, "# Worker Packet\nDo work")
+    stdout_path, stderr_path = write_worker_logs(tmp_path, "out", "err")
+    summary_path = write_worker_summary(
+        tmp_path,
+        WorkerLoopSummary(
+            status="completed",
+            model="anthropic/test",
+            tools_requested=["terminal", "file_editor"],
+        ),
+    )
+    result_path = write_worker_result(
+        tmp_path,
+        ExternalEditResult(
+            status="completed",
+            command="python -m app.core.workers.openhands_runner",
+            exit_code=0,
+            stdout="out",
+            stderr="",
+            duration_seconds=1.25,
+        ),
+    )
+    scorecard_path = write_worker_scorecard(
+        tmp_path,
+        WorkerScorecard(
+            task_id="run-1",
+            status="completed",
+            duration_seconds=1.25,
+        ),
+    )
+    events_path = write_worker_events(tmp_path, [{"event": "start"}, {"event": "complete"}])
+
+    assert prompt_path.name == "worker_prompt.md"
+    assert prompt_path.read_text(encoding="utf-8").startswith("# Worker Packet")
+    assert stdout_path.read_text(encoding="utf-8") == "out"
+    assert stderr_path.read_text(encoding="utf-8") == "err"
+    assert json.loads(summary_path.read_text(encoding="utf-8"))["loop_owner"] == "openhands_sdk"
+    assert json.loads(result_path.read_text(encoding="utf-8"))["exit_code"] == 0
+    assert json.loads(scorecard_path.read_text(encoding="utf-8"))["worker_type"] == "openhands"
+    assert events_path is not None
+    assert events_path.read_text(encoding="utf-8").count("\n") == 2

--- a/tests/test_openhands_config.py
+++ b/tests/test_openhands_config.py
@@ -1,0 +1,55 @@
+import importlib.util
+
+from app.core.workers.openhands_config import (
+    DEFAULT_OPENHANDS_MODEL,
+    OPENHANDS_TOOL_NAMES,
+    load_openhands_config,
+    openhands_sdk_available,
+)
+
+
+def test_openhands_config_prefers_model_and_auth_env(monkeypatch) -> None:
+    monkeypatch.setenv("OPENHANDS_MODEL", "openai/gpt-test")
+    monkeypatch.setenv("OPENHANDS_MAX_ITERATIONS", "12")
+    monkeypatch.setenv("OPENAI_API_KEY", "secret")
+    monkeypatch.delenv("LLM_API_KEY", raising=False)
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+
+    config = load_openhands_config()
+
+    assert config.model == "openai/gpt-test"
+    assert config.api_key_env == "OPENAI_API_KEY"
+    assert config.max_iterations == 12
+    assert config.tools == list(OPENHANDS_TOOL_NAMES)
+
+
+def test_openhands_config_uses_safe_default_without_auth(monkeypatch) -> None:
+    monkeypatch.delenv("OPENHANDS_MODEL", raising=False)
+    monkeypatch.delenv("OPENHANDS_MAX_ITERATIONS", raising=False)
+    monkeypatch.delenv("LLM_API_KEY", raising=False)
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+
+    config = load_openhands_config()
+
+    assert config.model == DEFAULT_OPENHANDS_MODEL
+    assert config.api_key_env is None
+    assert config.max_iterations is None
+    assert config.missing_auth
+
+
+def test_openhands_config_rejects_invalid_max_iterations(monkeypatch) -> None:
+    monkeypatch.setenv("OPENHANDS_MAX_ITERATIONS", "not-an-int")
+
+    config = load_openhands_config()
+
+    assert config.config_error == "OPENHANDS_MAX_ITERATIONS must be a positive integer."
+
+
+def test_openhands_sdk_available_uses_importlib_spec(monkeypatch) -> None:
+    def fake_find_spec(name: str):
+        return object() if name in {"openhands.sdk", "openhands.tools.terminal"} else None
+
+    monkeypatch.setattr(importlib.util, "find_spec", fake_find_spec)
+
+    assert openhands_sdk_available()

--- a/tests/test_openhands_runner_contract.py
+++ b/tests/test_openhands_runner_contract.py
@@ -1,0 +1,222 @@
+import json
+import subprocess
+import sys
+from types import ModuleType
+
+
+def _run_runner(repo: str = ".", task: str = "Do work", env: dict[str, str] | None = None):
+    return subprocess.run(
+        [sys.executable, "-m", "app.core.workers.openhands_runner", repo],
+        input=task,
+        capture_output=True,
+        text=True,
+        timeout=30,
+        env=env,
+        check=False,
+    )
+
+
+def _summary_from_stdout(stdout: str) -> dict:
+    for line in stdout.splitlines():
+        if line.startswith("OPENHANDS_WORKER_SUMMARY_JSON="):
+            return json.loads(line.split("=", maxsplit=1)[1])
+    raise AssertionError(f"summary line missing from stdout: {stdout}")
+
+
+def test_runner_returns_usage_error_if_repo_path_missing() -> None:
+    completed = subprocess.run(
+        [sys.executable, "-m", "app.core.workers.openhands_runner"],
+        input="Do work",
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+
+    assert completed.returncode == 2
+    assert "usage:" in completed.stderr
+
+
+def test_runner_returns_usage_error_if_stdin_task_missing() -> None:
+    completed = _run_runner(task="")
+
+    assert completed.returncode == 2
+    assert "task prompt" in completed.stderr
+
+
+def test_runner_returns_sdk_missing_before_auth_when_openhands_not_installed(monkeypatch) -> None:
+    monkeypatch.setattr(
+        "app.core.workers.openhands_runner.openhands_sdk_available",
+        lambda: False,
+    )
+
+    from app.core.workers.openhands_runner import main
+
+    monkeypatch.setattr(sys, "argv", ["openhands_runner", "."])
+    monkeypatch.setattr(sys, "stdin", type("FakeStdin", (), {"read": lambda self: "Do work"})())
+
+    assert main() == 4
+
+
+def test_runner_returns_auth_error_when_sdk_present_but_no_key(monkeypatch) -> None:
+    monkeypatch.setattr(
+        "app.core.workers.openhands_runner.openhands_sdk_available",
+        lambda: True,
+    )
+    monkeypatch.delenv("LLM_API_KEY", raising=False)
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+
+    from app.core.workers.openhands_runner import main
+
+    monkeypatch.setattr(sys, "argv", ["openhands_runner", "."])
+    monkeypatch.setattr(sys, "stdin", type("FakeStdin", (), {"read": lambda self: "Do work"})())
+
+    assert main() == 3
+
+
+def test_runner_returns_config_error_for_malformed_env(monkeypatch) -> None:
+    monkeypatch.setenv("OPENHANDS_MAX_ITERATIONS", "bad")
+
+    completed = _run_runner(task="Do work", env={"OPENHANDS_MAX_ITERATIONS": "bad"})
+
+    assert completed.returncode == 6
+    assert "OPENHANDS_MAX_ITERATIONS" in completed.stderr
+
+
+def test_runner_configures_sdk_loop_controls_and_event_capture(
+    monkeypatch, tmp_path, capsys
+) -> None:
+    calls: dict[str, object] = {}
+
+    class FakeEvent:
+        def model_dump(self, *, mode: str):
+            return {"id": "event-1", "source": "agent", "mode": mode}
+
+    class FakeLLM:
+        def __init__(self, **kwargs):
+            calls["llm"] = kwargs
+
+    class FakeTool:
+        def __init__(self, **kwargs):
+            calls.setdefault("tools", []).append(kwargs)
+
+    class FakeAgent:
+        def __init__(self, **kwargs):
+            calls["agent"] = kwargs
+
+    class FakeConversation:
+        def __init__(self, **kwargs):
+            calls["conversation"] = kwargs
+
+        def send_message(self, task: str) -> None:
+            calls["task"] = task
+
+        def run(self) -> None:
+            calls["run_kwargs"] = {}
+            for callback in calls["conversation"]["callbacks"]:
+                callback(FakeEvent())
+
+    class FakeAgentContext:
+        def __init__(self, **kwargs):
+            calls["agent_context"] = kwargs
+
+    class FakeCondenser:
+        def __init__(self, **kwargs):
+            calls["condenser"] = kwargs
+
+    class FakeSecurityAnalyzer:
+        def __init__(self, **kwargs):
+            calls["security_analyzer"] = kwargs
+
+    sdk = ModuleType("openhands.sdk")
+    sdk.LLM = FakeLLM
+    sdk.Agent = FakeAgent
+    sdk.Conversation = FakeConversation
+    sdk.Tool = FakeTool
+
+    sdk_context = ModuleType("openhands.sdk.context")
+    sdk_context.AgentContext = FakeAgentContext
+    sdk_condenser = ModuleType("openhands.sdk.context.condenser")
+    sdk_condenser.LLMSummarizingCondenser = FakeCondenser
+    sdk_security = ModuleType("openhands.sdk.security")
+    sdk_security_analyzer = ModuleType("openhands.sdk.security.llm_analyzer")
+    sdk_security_analyzer.LLMSecurityAnalyzer = FakeSecurityAnalyzer
+
+    tools_pkg = ModuleType("openhands.tools")
+    terminal = ModuleType("openhands.tools.terminal")
+    terminal.TerminalTool = type("TerminalTool", (), {"name": "terminal"})
+    file_editor = ModuleType("openhands.tools.file_editor")
+    file_editor.FileEditorTool = type("FileEditorTool", (), {"name": "file_editor"})
+    task_tracker = ModuleType("openhands.tools.task_tracker")
+    task_tracker.TaskTrackerTool = type("TaskTrackerTool", (), {"name": "task_tracker"})
+    glob_mod = ModuleType("openhands.tools.glob")
+    grep_mod = ModuleType("openhands.tools.grep")
+    preset = ModuleType("openhands.tools.preset")
+    preset.register_builtins_agents = lambda: calls.__setitem__("builtins_registered", True)
+    # `from openhands.tools import glob/grep` resolves the submodule attribute on the parent.
+    tools_pkg.glob = glob_mod
+    tools_pkg.grep = grep_mod
+
+    monkeypatch.setitem(sys.modules, "openhands", ModuleType("openhands"))
+    monkeypatch.setitem(sys.modules, "openhands.sdk", sdk)
+    monkeypatch.setitem(sys.modules, "openhands.sdk.context", sdk_context)
+    monkeypatch.setitem(sys.modules, "openhands.sdk.context.condenser", sdk_condenser)
+    monkeypatch.setitem(sys.modules, "openhands.sdk.security", sdk_security)
+    monkeypatch.setitem(sys.modules, "openhands.sdk.security.llm_analyzer", sdk_security_analyzer)
+    monkeypatch.setitem(sys.modules, "openhands.tools", tools_pkg)
+    monkeypatch.setitem(sys.modules, "openhands.tools.terminal", terminal)
+    monkeypatch.setitem(sys.modules, "openhands.tools.file_editor", file_editor)
+    monkeypatch.setitem(sys.modules, "openhands.tools.task_tracker", task_tracker)
+    monkeypatch.setitem(sys.modules, "openhands.tools.glob", glob_mod)
+    monkeypatch.setitem(sys.modules, "openhands.tools.grep", grep_mod)
+    monkeypatch.setitem(sys.modules, "openhands.tools.preset", preset)
+    monkeypatch.setattr(
+        "app.core.workers.openhands_runner.openhands_sdk_available",
+        lambda: True,
+    )
+    monkeypatch.setenv("LLM_API_KEY", "test-key")
+    monkeypatch.setenv("OPENHANDS_MODEL", "test/model")
+    monkeypatch.setenv("OPENHANDS_MAX_ITERATIONS", "7")
+    events_path = tmp_path / "openhands_events.jsonl"
+    persistence_dir = tmp_path / "openhands_state"
+    monkeypatch.setenv("OPENHANDS_EVENTS_PATH", str(events_path))
+    monkeypatch.setenv("OPENHANDS_PERSISTENCE_DIR", str(persistence_dir))
+
+    from app.core.workers.openhands_runner import main
+
+    monkeypatch.setattr(sys, "argv", ["openhands_runner", str(tmp_path)])
+    monkeypatch.setattr(
+        sys,
+        "stdin",
+        type("FakeStdin", (), {"read": lambda self: "Structured worker packet"})(),
+    )
+
+    assert main() == 0
+
+    output = capsys.readouterr()
+    summary = _summary_from_stdout(output.out)
+    assert calls["llm"] == {"model": "test/model", "api_key": "test-key"}
+    assert calls["task"] == "Structured worker packet"
+    assert calls["conversation"]["workspace"] == str(tmp_path)
+    assert calls["conversation"]["max_iteration_per_run"] == 7
+    assert calls["conversation"]["persistence_dir"] == str(persistence_dir)
+    assert calls["conversation"]["stuck_detection"] is True
+    assert len(calls["conversation"]["callbacks"]) == 1
+    # Full-component wiring: the agent gets the 5-tool set + condenser + AgentOps
+    # system-prompt suffix + security analyzer, and the sub-agent archetypes register.
+    tool_names = [t.get("name") for t in calls["tools"]]
+    assert tool_names == ["terminal", "file_editor", "task_tracker", "grep", "glob"]
+    assert "condenser" in calls["agent"]
+    assert "security_analyzer" in calls["agent"]
+    assert calls["agent_context"]["load_project_skills"] is True
+    assert "AgentOps Harness" in calls["agent_context"]["system_message_suffix"]
+    assert calls["condenser"] == {"llm": calls["agent"]["llm"], "max_size": 80, "keep_first": 4}
+    assert calls.get("builtins_registered") is True
+    assert events_path.exists()
+    assert json.loads(events_path.read_text(encoding="utf-8")) == {
+        "event": {"id": "event-1", "mode": "json", "source": "agent"},
+        "event_type": "FakeEvent",
+    }
+    assert summary["event_log_path"] == str(events_path)
+    assert summary["observable_event_count"] == 1

--- a/tests/test_openhands_worker.py
+++ b/tests/test_openhands_worker.py
@@ -1,6 +1,7 @@
 import subprocess
 import sys
 from pathlib import Path
+from types import SimpleNamespace
 
 from app.core.workers.openhands_worker import OpenHandsWorker
 
@@ -19,6 +20,39 @@ def test_blocks_on_dirty_repo(tmp_path: Path):
     assert "dirty" in result.stderr.lower()
 
 
+def test_allows_dirty_repo_when_requested_and_passes_prompt_on_stdin(tmp_path: Path, monkeypatch):
+    subprocess.run(["git", "init", "-q"], cwd=tmp_path, check=True)
+    (tmp_path / "f.py").write_text("x=1\n")
+    seen = {}
+
+    def fake_run(argv, *args, **kwargs):
+        if argv[:2] == ["git", "rev-parse"]:
+            return SimpleNamespace(returncode=0, stdout=str(tmp_path), stderr="")
+        if argv[:3] == ["git", "status", "--porcelain"]:
+            return SimpleNamespace(returncode=0, stdout="?? f.py\n", stderr="")
+        seen["argv"] = argv
+        seen["input"] = kwargs["input"]
+        seen["cwd"] = kwargs["cwd"]
+        seen["env"] = kwargs["env"]
+        return SimpleNamespace(returncode=0, stdout="done", stderr="")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    result = OpenHandsWorker().run(
+        repo_path=tmp_path,
+        task="Add logging",
+        timeout_seconds=5,
+        allow_dirty=True,
+    )
+
+    assert result.status == "completed"
+    assert "agentops-harness" in str(seen["cwd"])
+    assert "PYTHONPATH" in seen["env"]
+    assert "agentops-harness" in seen["env"]["PYTHONPATH"]
+    assert seen["input"].startswith("# Worker Packet")
+    assert "## Task\nAdd logging" in seen["input"]
+
+
 def test_runner_exits_2_without_a_task():
     # The runner reads the task from stdin; an empty task is a usage error (exit 2),
     # reached before any SDK import or auth — so this needs neither.
@@ -30,3 +64,129 @@ def test_runner_exits_2_without_a_task():
         timeout=30,
     )
     assert completed.returncode == 2
+
+
+def test_missing_sdk_exit_maps_to_setup_missing(tmp_path: Path, monkeypatch):
+    subprocess.run(["git", "init", "-q"], cwd=tmp_path, check=True)
+
+    def fake_run(argv, *args, **kwargs):
+        if argv[:2] == ["git", "rev-parse"]:
+            return SimpleNamespace(returncode=0, stdout=str(tmp_path), stderr="")
+        if argv[:3] == ["git", "status", "--porcelain"]:
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+        return SimpleNamespace(returncode=4, stdout="", stderr="OpenHands SDK not installed")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    result = OpenHandsWorker().run(repo_path=tmp_path, task="x", timeout_seconds=5)
+
+    assert result.status == "setup_missing"
+    assert result.termination_reason == "sdk_missing"
+    assert "OpenHands SDK not installed" in result.stderr
+
+
+def test_missing_auth_exit_maps_to_auth_missing(tmp_path: Path, monkeypatch):
+    subprocess.run(["git", "init", "-q"], cwd=tmp_path, check=True)
+
+    def fake_run(argv, *args, **kwargs):
+        if argv[:2] == ["git", "rev-parse"]:
+            return SimpleNamespace(returncode=0, stdout=str(tmp_path), stderr="")
+        if argv[:3] == ["git", "status", "--porcelain"]:
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+        return SimpleNamespace(returncode=3, stdout="", stderr="authentication_error: missing key")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    result = OpenHandsWorker().run(repo_path=tmp_path, task="x", timeout_seconds=5)
+
+    assert result.status == "auth_missing"
+    assert result.termination_reason == "auth_missing"
+
+
+def test_timeout_maps_to_timeout_status(tmp_path: Path, monkeypatch):
+    subprocess.run(["git", "init", "-q"], cwd=tmp_path, check=True)
+
+    def fake_run(argv, *args, **kwargs):
+        if argv[:2] == ["git", "rev-parse"]:
+            return SimpleNamespace(returncode=0, stdout=str(tmp_path), stderr="")
+        if argv[:3] == ["git", "status", "--porcelain"]:
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+        raise subprocess.TimeoutExpired(cmd=["openhands"], timeout=1, output="out", stderr="err")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    result = OpenHandsWorker().run(repo_path=tmp_path, task="x", timeout_seconds=1)
+
+    assert result.status == "timeout"
+    assert result.termination_reason == "timeout"
+    assert result.stdout == "out"
+    assert result.stderr == "err"
+
+
+def test_worker_writes_artifacts_when_run_dir_is_available(tmp_path: Path, monkeypatch):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    subprocess.run(["git", "init", "-q"], cwd=repo, check=True)
+    run_dir = tmp_path / "runs" / "run-1"
+
+    def fake_run(argv, *args, **kwargs):
+        if argv[:2] == ["git", "rev-parse"]:
+            return SimpleNamespace(returncode=0, stdout=str(repo), stderr="")
+        if argv[:3] == ["git", "status", "--porcelain"]:
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+        Path(kwargs["env"]["OPENHANDS_EVENTS_PATH"]).write_text(
+            '{"event_type":"FakeEvent"}\n',
+            encoding="utf-8",
+        )
+        return SimpleNamespace(
+            returncode=0,
+            stdout=(
+                'OPENHANDS_WORKER_SUMMARY_JSON={"worker_type":"openhands",'
+                '"loop_owner":"openhands_sdk","status":"completed","exit_code":0,'
+                '"duration_seconds":0.5,"tools_requested":["terminal","file_editor"]}\n'
+                "openhands run complete\n"
+            ),
+            stderr="",
+        )
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    result = OpenHandsWorker().run(
+        repo_path=repo,
+        task="x",
+        timeout_seconds=5,
+        run_dir=run_dir,
+        run_id="run-1",
+    )
+
+    assert result.status == "completed"
+    assert (run_dir / "worker_prompt.md").exists()
+    assert (run_dir / "worker_stdout.log").exists()
+    assert (run_dir / "worker_stderr.log").exists()
+    assert (run_dir / "worker_loop_summary.json").exists()
+    assert (run_dir / "worker_result.json").exists()
+    assert (run_dir / "worker_scorecard.json").exists()
+    assert (run_dir / "openhands_events.jsonl").exists()
+    assert (run_dir / "openhands_state").exists()
+    assert result.artifact_paths["summary"].endswith("worker_loop_summary.json")
+    assert result.artifact_paths["events"].endswith("openhands_events.jsonl")
+
+
+def test_failed_runner_exit_is_failed(tmp_path: Path, monkeypatch):
+    subprocess.run(["git", "init", "-q"], cwd=tmp_path, check=True)
+
+    def fake_run(argv, *args, **kwargs):
+        if argv[:2] == ["git", "rev-parse"]:
+            return SimpleNamespace(returncode=0, stdout=str(tmp_path), stderr="")
+        if argv[:3] == ["git", "status", "--porcelain"]:
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+        return SimpleNamespace(returncode=1, stdout="out", stderr="boom")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    result = OpenHandsWorker().run(repo_path=tmp_path, task="x", timeout_seconds=5)
+
+    assert result.status == "failed"
+    assert result.exit_code == 1
+    assert result.stdout == "out"
+    assert result.stderr == "boom"

--- a/tests/test_openhands_worker.py
+++ b/tests/test_openhands_worker.py
@@ -85,6 +85,31 @@ def test_missing_sdk_exit_maps_to_setup_missing(tmp_path: Path, monkeypatch):
     assert "OpenHands SDK not installed" in result.stderr
 
 
+def test_config_error_exit_maps_to_configuration_error(tmp_path: Path, monkeypatch):
+    subprocess.run(["git", "init", "-q"], cwd=tmp_path, check=True)
+
+    def fake_run(argv, *args, **kwargs):
+        if argv[:2] == ["git", "rev-parse"]:
+            return SimpleNamespace(returncode=0, stdout=str(tmp_path), stderr="")
+        if argv[:3] == ["git", "status", "--porcelain"]:
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+        return SimpleNamespace(
+            returncode=6,
+            stdout="",
+            stderr="configuration_error: OPENHANDS_MAX_ITERATIONS must be a positive integer.",
+        )
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    result = OpenHandsWorker().run(repo_path=tmp_path, task="x", timeout_seconds=5)
+
+    assert result.status == "configuration_error"
+    assert result.termination_reason == "configuration_error"
+    # The bad-config case must NOT tell the operator to reinstall the SDK.
+    assert "uv sync --extra openhands" not in result.stderr
+    assert "OPENHANDS_MAX_ITERATIONS" in result.stderr
+
+
 def test_missing_auth_exit_maps_to_auth_missing(tmp_path: Path, monkeypatch):
     subprocess.run(["git", "init", "-q"], cwd=tmp_path, check=True)
 

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -99,10 +99,19 @@ def test_pr_writer_prompt_includes_report_inputs() -> None:
 def test_worker_prompt_is_shared_by_external_workers() -> None:
     prompt = build_worker_prompt(repo_path=Path("/repo"), task="Add logging")
 
-    assert "coding agent" in prompt
+    assert prompt.startswith("# Worker Packet")
+    assert "coding worker" in prompt
     assert "/repo" in prompt
-    assert "Task: Add logging" in prompt
-    assert "run tests" in prompt
+    assert "## Task\nAdd logging" in prompt
+    assert "## Plan as Contract" in prompt
+    assert "## Repo Context" in prompt
+    assert "## Constraints" in prompt
+    assert "## Forbidden Actions" in prompt
+    assert "## Permission Tier" in prompt
+    assert "## Verification Obligations" in prompt
+    assert "## Definition of Done" in prompt
+    assert "## Reporting Rules" in prompt
+    assert "Do not claim tests passed unless you actually ran them" in prompt
 
 
 def test_format_edit_summary_handles_observe_and_external_worker_modes() -> None:


### PR DESCRIPTION
## What & why

Reconciles the **two parallel OpenHands implementations** that emerged in this iteration:
- `main` (merged PR #12) — the **full worker-harness components** + Docker agent-loop mode (the *capable inner loop*)
- PR #13 (Codex) — the **observability/governance machinery** (the *evidence trail the outer governor reads*)

They were **complementary, not redundant**. This PR takes the "harvest" path the owner chose: keep main's components and Docker mode, port Codex's observability on top. Merging #13 as-is would have regressed main's full-component + Docker runner, so #13 is closed in favor of this.

> Mental model: `workspace=` controls *where the loop runs*; `run_dir` + summary + events control *what evidence it leaves behind*.

## Added (Codex's additive value, harvested)

- **`openhands_config.py`** — `OpenHandsConfig` + `load_openhands_config()` + SDK/auth detection; `OPENHANDS_TOOL_NAMES` extended to the full 5-tool set
- **`worker_loop.py` schema** — `WorkerLoopSummary` / `WorkerArtifactPaths` / `WorkerScorecard`
- **`openhands_artifacts.py`** — prompt / logs / summary / result / scorecard / events writers
- **Runner observability** — emits `OPENHANDS_WORKER_SUMMARY_JSON=…` + an `_OpenHandsEventRecorder` callback writes an observable event log; rich exit-code taxonomy (run / usage / auth / sdk / config)
- **Per-run artifacts** — worker persists `worker_prompt.md`, logs, summary, result, scorecard under `run_dir`
- **Richer prompt** — `build_worker_prompt(plan, repo_profile, tests_to_run, forbidden_paths, permission_tier)`
- **Docs + example + tests** — `docs/OPENHANDS_INNER_WORKER.md`, example workload, config/artifacts/contract tests

## Preserved (main's components, re-integrated into Codex's runner base)

- 5 tools: `terminal`, `file_editor`, `task_tracker`, `grep`, `glob`
- `LLMSummarizingCondenser` (context mgmt), `AgentContext` with the AgentOps system-prompt suffix + project skills, `LLMSecurityAnalyzer`, `register_builtins_agents()` (sub-agent archetypes), `stuck_detection` hook
- **Docker agent-loop mode** — `workspace=docker` under `--sandbox`, host repo bind-mounted at `/workspace/project`

## Wiring

- `OpenHandsWorker.run()` gains `workspace=`; `_runner_env` sets `OPENHANDS_WORKSPACE`
- graph dispatch passes **both** `workspace=` (mine) **and** `run_dir` / `run_id` / `plan` / `repo_profile` / `tests_to_run` (Codex's)
- contract test extended to mock the **full** SDK surface and assert the component wiring (5 tools, condenser, security analyzer, AgentOps suffix, builtins registered, stuck-detection) so neither half can silently regress

## Reviewer notes

- **OpenHands stays optional**: 238 tests pass with **no SDK installed and no API keys**; `ruff check` clean.
- No OpenHands import in the parent worker (lazy import lives only in the runner subprocess).
- No browser/network tools added to the worker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR harvests Codex's observability machinery onto main's full-component OpenHands worker, wiring together two parallel implementations into a single coherent path. The P1 issues identified in prior rounds (wrong setup hint for config errors, discarded `write_worker_result` return value, `"uv run"` false-positive for test detection, pre-touched events file masking empty state) are all addressed here.

- **Observability additions**: `_OpenHandsEventRecorder` callback writes JSONL events; runner emits a `OPENHANDS_WORKER_SUMMARY_JSON=` line on stdout that the parent parses; per-run artifacts (prompt, logs, summary, result, scorecard, events) are written under `run_dir`.
- **Status taxonomy**: exit codes 1–4 and 6 are mapped to clean status strings; `configuration_error` (exit 6) now gets its own branch in both `ExternalEditStatus` and `_status_from_exit_code`, preventing the misleading SDK-reinstall hint.
- **Richer prompt**: `build_worker_prompt` gains plan, repo-profile, forbidden-paths, and permission-tier sections; prior callers are unaffected by new optional kwargs.

<h3>Confidence Score: 5/5</h3>

Safe to merge; the four issues called out in prior review rounds are all addressed cleanly.

Every prior finding has been resolved: configuration errors get their own status branch with no misleading reinstall hint, write_worker_result return value is now used, the events file size check distinguishes pre-touched-but-empty from populated, and test detection no longer false-positives on bare uv-run invocations. The remaining observations (dropped conversation_id, missing configuration_error in the doc table, scorecard governance fields with no write-back path) are all speculative or cosmetic and cause no incorrect runtime behaviour on the changed code paths.

openhands_runner.py warrants a second look if the real OpenHands SDK enforces a required conversation_id parameter, since the parameter was removed in this PR and the contract test does not exercise the real SDK.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| app/core/workers/openhands_runner.py | Runner refactored to emit structured SUMMARY_PREFIX JSON on stdout and events via _OpenHandsEventRecorder; conversation_id dropped from Conversation constructor compared to prior implementation. |
| app/core/workers/openhands_worker.py | Parent worker gains run_dir/run_id/plan/repo_profile/tests_to_run params, full artifact persistence pipeline, clean exit-code-to-status mapping with separate configuration_error branch, and _existing_event_log_path size check. |
| app/core/workers/openhands_artifacts.py | New file with focused write_* helpers for each artifact type; all return Path so callers use the canonical filename rather than re-deriving it. |
| app/core/workers/openhands_config.py | New file extracting OpenHandsConfig + load_openhands_config() + openhands_sdk_available(); config validated before subprocess spawns. |
| app/schemas/edit.py | ExternalEditStatus expanded with timeout, setup_missing, auth_missing, configuration_error; ExternalEditResult gains termination_reason, worker_type, artifact_paths. |
| app/schemas/worker_loop.py | New schemas WorkerLoopSummary / WorkerArtifactPaths / WorkerScorecard; governance fields on WorkerScorecard declared but have no write-back path after scorecard is persisted. |
| docs/OPENHANDS_INNER_WORKER.md | New doc correctly describes governor/worker boundary and artifact layout, but Status Mapping section omits the newly-added configuration_error status. |
| tests/test_openhands_runner_contract.py | New contract test mocks full SDK surface and asserts all 5 tools, condenser, AgentOps suffix, security analyzer, builtins registered, stuck-detection, event capture, and summary emission. |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant G as graph.py (governor)
    participant W as OpenHandsWorker
    participant R as openhands_runner (subprocess)
    participant OH as OpenHands SDK
    participant FS as Filesystem (run_dir)

    G->>W: run(repo, task, run_dir, run_id, plan, …)
    W->>FS: write_worker_prompt → worker_prompt.md
    W->>FS: _runner_env → touch events.jsonl, mkdir openhands_state
    W->>R: "subprocess.run(argv, input=prompt, env=…)"
    R->>R: load_openhands_config()
    R->>R: openhands_sdk_available()?
    alt SDK or config error
        R-->>W: exit 4/6 + SUMMARY_PREFIX on stdout
    else auth missing
        R-->>W: exit 3 + SUMMARY_PREFIX on stdout
    else SDK present + auth OK
        R->>OH: "Conversation(agent, callbacks=[recorder], …)"
        OH->>R: recorder.__call__(event) ×N
        R->>FS: append to openhands_events.jsonl
        OH-->>R: conversation.run() complete
        R-->>W: print SUMMARY_PREFIX + JSON, exit 0
    end
    W->>W: _summary_from_stdout + _status_from_exit_code
    W->>FS: write_worker_logs, summary, scorecard, result
    W-->>G: ExternalEditResult(status, artifact_paths, …)
```

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Adocs%2FOPENHANDS_INNER_WORKER.md%3A116-123%0AThe%20status%20mapping%20table%20lists%20six%20%60ExternalEditResult.status%60%20values%20but%20omits%20%60%22configuration_error%22%60%2C%20which%20is%20now%20a%20live%20status%20returned%20by%20%60_status_from_exit_code%60%20when%20the%20subprocess%20exits%20with%20code%206.%20An%20operator%20who%20sets%20%60OPENHANDS_MAX_ITERATIONS%3Dbad%60%20would%20receive%20a%20result%20whose%20%60status%60%20field%20is%20not%20documented%20here.%0A%0A%60%60%60suggestion%0AThe%20parent%20worker%20maps%20those%20to%20%60ExternalEditResult.status%60%3A%0A%0A-%20%60completed%60%0A-%20%60failed%60%0A-%20%60blocked%60%0A-%20%60timeout%60%0A-%20%60setup_missing%60%0A-%20%60auth_missing%60%0A-%20%60configuration_error%60%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%203%0Aapp%2Fcore%2Fworkers%2Fopenhands_runner.py%3A261%0A**%60conversation_id%60%20removed%20%E2%80%94%20SDK%20may%20default%20to%20a%20fixed%20ID**%0A%0AThe%20previous%20implementation%20passed%20%60conversation_id%3Duuid.uuid4%28%29%60%20to%20%60Conversation%60.%20That%20parameter%20has%20been%20dropped%20here.%20If%20the%20real%20OpenHands%20SDK%20defaults%20to%20a%20static%20ID%20%28e.g.%20%60%22default%22%60%29%20when%20none%20is%20provided%2C%20two%20concurrent%20runs%20sharing%20the%20same%20%60persistence_dir%60%20parent%20tree%20would%20still%20be%20isolated%20%28each%20run%20gets%20its%20own%20%60run_dir%2Fopenhands_state%2F%60%29%2C%20but%20within%20a%20single%20run%20the%20conversation%20history%20would%20be%20written%20under%20a%20predictable%2C%20fixed%20sub-path.%20If%20the%20SDK%20requires%20uniqueness%20for%20internal%20bookkeeping%20%28e.g.%20event%20deduplication%29%2C%20this%20could%20silently%20produce%20incorrect%20behaviour.%20The%20contract%20test%20passes%20because%20%60FakeConversation%60%20accepts%20%60**kwargs%60%20without%20validating%20the%20presence%20of%20%60conversation_id%60.%0A%0A%23%23%23%20Issue%203%20of%203%0Aapp%2Fschemas%2Fworker_loop.py%3A40-46%0A**Governance%20fields%20on%20%60WorkerScorecard%60%20have%20no%20write-back%20path**%0A%0A%60changed_file_count%60%2C%20%60agentops_tests_passed%60%2C%20%60permission_violations%60%2C%20%60unsupported_claims%60%2C%20%60risk_level%60%2C%20and%20%60convergence_type%60%20are%20all%20declared%20here%20but%20%60_persist_worker_artifacts%60%20writes%20the%20scorecard%20at%20worker-exit%20time%2C%20before%20governance%20%28diff%20collection%2C%20tests%2C%20risk%2C%20permissions%29%20runs.%20Nothing%20in%20this%20PR%20populates%20those%20fields%20after%20the%20scorecard%20is%20written%2C%20so%20they%20will%20be%20%60None%60%20in%20every%20%60worker_scorecard.json%60%20produced.%20Worth%20either%20documenting%20as%20%22populated%20by%20a%20follow-up%20pass%22%20or%20wiring%20in%20a%20scorecard-update%20step%20after%20the%20governance%20pipeline%20completes.%0A%0A&pr=14&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<sub>Reviews (2): Last reviewed commit: ["fix: address Greptile review on #14 — 5 ..."](https://github.com/ven-z8/agentops-harness/commit/abca95e1a6b4191dbcd376bb8556f761dfcc0b92) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37251388)</sub>

<!-- /greptile_comment -->