### PR TITLE
Wire OpenHands sub-agent delegation (component #04)

### DIFF
--- a/app/core/workers/openhands_config.py
+++ b/app/core/workers/openhands_config.py
@@ -7,7 +7,14 @@ from pydantic import BaseModel, Field
 
 DEFAULT_OPENHANDS_MODEL = "anthropic/claude-sonnet-4-5-20250929"
 DEFAULT_OPENHANDS_TIMEOUT_SECONDS = 300
-OPENHANDS_TOOL_NAMES = ("terminal", "file_editor", "task_tracker", "grep", "glob")
+OPENHANDS_TOOL_NAMES = (
+    "terminal",
+    "file_editor",
+    "task_tracker",
+    "grep",
+    "glob",
+    "task_tool_set",  # 04 sub-agent delegation
+)
 AUTH_ENV_NAMES = ("LLM_API_KEY", "ANTHROPIC_API_KEY", "OPENAI_API_KEY")
 
 

--- a/app/core/workers/openhands_runner.py
+++ b/app/core/workers/openhands_runner.py
@@ -197,14 +197,15 @@ def main() -> int:
         )
         return EXIT_SDK_MISSING
 
-    # 04 sub-agents — register the built-in archetypes so the agent can delegate focused
-    # sub-tasks. enable_browser=False keeps us to the terminal-only archetypes
-    # (bash-runner, code-explorer, general-purpose) and skips web-researcher, honoring the
-    # harness's no-browser/network constraint — sub-agents inherit only terminal/file tools.
-    register_builtins_agents(enable_browser=False)
-
     workspace = None
     try:
+        # 04 sub-agents — register the built-in archetypes so the agent can delegate focused
+        # sub-tasks. enable_browser=False keeps us to the terminal-only archetypes
+        # (bash-runner, code-explorer, general-purpose) and skips web-researcher, honoring the
+        # harness's no-browser/network constraint — sub-agents inherit only terminal/file tools.
+        # Inside the try so a registration failure still emits a summary + EXIT_RUN_ERROR
+        # instead of crashing main() with no observable outcome.
+        register_builtins_agents(enable_browser=False)
         llm = LLM(model=model, api_key=api_key)
         # 02 context management.
         condenser = LLMSummarizingCondenser(llm=llm, max_size=80, keep_first=4)

--- a/app/core/workers/openhands_runner.py
+++ b/app/core/workers/openhands_runner.py
@@ -179,6 +179,7 @@ def main() -> int:
         from openhands.tools import grep as _grep  # noqa: F401 (registers retrieval)
         from openhands.tools.file_editor import FileEditorTool
         from openhands.tools.preset import register_builtins_agents
+        from openhands.tools.task import TaskToolSet  # 04 sub-agent delegation tool
         from openhands.tools.task_tracker import TaskTrackerTool
         from openhands.tools.terminal import TerminalTool
     except ImportError as exc:
@@ -196,9 +197,11 @@ def main() -> int:
         )
         return EXIT_SDK_MISSING
 
-    # 04 sub-agents — register the built-in archetypes (code-explorer, general-purpose,
-    # web-researcher, bash-runner) so the agent can delegate focused sub-tasks.
-    register_builtins_agents()
+    # 04 sub-agents — register the built-in archetypes so the agent can delegate focused
+    # sub-tasks. enable_browser=False keeps us to the terminal-only archetypes
+    # (bash-runner, code-explorer, general-purpose) and skips web-researcher, honoring the
+    # harness's no-browser/network constraint — sub-agents inherit only terminal/file tools.
+    register_builtins_agents(enable_browser=False)
 
     workspace = None
     try:
@@ -210,7 +213,8 @@ def main() -> int:
             system_message_suffix=HARNESS_SYSTEM_SUFFIX,
             load_project_skills=True,
         )
-        # 05 primitives + retrieval; 09 security analyzer assesses each action's risk.
+        # 05 primitives + retrieval; 04 delegation (task_tool_set spawns sub-agents from the
+        # registered archetypes); 09 security analyzer assesses each action's risk.
         agent = Agent(
             llm=llm,
             tools=[
@@ -219,6 +223,7 @@ def main() -> int:
                 Tool(name=TaskTrackerTool.name),
                 Tool(name="grep"),
                 Tool(name="glob"),
+                Tool(name=TaskToolSet.name),
             ],
             condenser=condenser,
             agent_context=agent_context,

--- a/docs/OPENHANDS_INNER_WORKER.md
+++ b/docs/OPENHANDS_INNER_WORKER.md
@@ -88,7 +88,7 @@ the run directory:
   "agentops_role": "outer_governor",
   "status": "completed",
   "model": "anthropic/claude-sonnet-4-5-20250929",
-  "tools_requested": ["terminal", "file_editor"],
+  "tools_requested": ["terminal", "file_editor", "task_tracker", "grep", "glob", "task_tool_set"],
   "event_log_path": ".agentops/runs/<run_id>/openhands_events.jsonl",
   "observable_event_count": 12,
   "termination_reason": "completed"
@@ -121,9 +121,12 @@ The parent worker maps those to `ExternalEditResult.status`:
 - `timeout`
 - `setup_missing`
 - `auth_missing`
+- `configuration_error`
 
 Missing SDK and missing auth are classified cleanly so CI can run without
-OpenHands installed and without provider keys.
+OpenHands installed and without provider keys. A bad config value (exit `6`,
+e.g. a non-integer `OPENHANDS_MAX_ITERATIONS`) maps to `configuration_error` —
+distinct from `setup_missing`, so the operator is not told to reinstall the SDK.
 
 ## Manual Tests
 
@@ -188,9 +191,19 @@ uv run --extra dev agentops edit \
 
 Expected: pre-dispatch governance blocks the worker before OpenHands runs.
 
+## Sub-agent delegation
+
+The agent is given the OpenHands `task_tool_set` delegation tool plus the built-in
+terminal-only archetypes (`bash-runner`, `code-explorer`, `general-purpose`). It can
+spin up a focused sub-agent for a bounded sub-task and fold the result back into its
+own loop. Archetypes are registered with `enable_browser=False`, so the
+browser-dependent `web-researcher` is skipped and delegated sub-agents inherit only
+terminal/file tools — the no-browser/network constraint holds through delegation.
+
 ## Limitations
 
-- This integration does not add browser tools or network tools to OpenHands.
+- This integration does not add browser tools or network tools to OpenHands,
+  including to delegated sub-agents.
 - Event capture is limited to events surfaced through OpenHands SDK callbacks.
 - AgentOps does not use OpenHands as a replacement for governance.
 - AgentOps still performs final validation after every worker run.

--- a/tests/test_openhands_runner_contract.py
+++ b/tests/test_openhands_runner_contract.py
@@ -23,71 +23,14 @@ def _summary_from_stdout(stdout: str) -> dict:
     raise AssertionError(f"summary line missing from stdout: {stdout}")
 
 
-def test_runner_returns_usage_error_if_repo_path_missing() -> None:
-    completed = subprocess.run(
-        [sys.executable, "-m", "app.core.workers.openhands_runner"],
-        input="Do work",
-        capture_output=True,
-        text=True,
-        timeout=30,
-        check=False,
-    )
+def _install_fake_openhands(monkeypatch, calls: dict, *, register_raises: bool = False) -> None:
+    """Install a fake OpenHands SDK module tree into sys.modules and mark it available.
 
-    assert completed.returncode == 2
-    assert "usage:" in completed.stderr
-
-
-def test_runner_returns_usage_error_if_stdin_task_missing() -> None:
-    completed = _run_runner(task="")
-
-    assert completed.returncode == 2
-    assert "task prompt" in completed.stderr
-
-
-def test_runner_returns_sdk_missing_before_auth_when_openhands_not_installed(monkeypatch) -> None:
-    monkeypatch.setattr(
-        "app.core.workers.openhands_runner.openhands_sdk_available",
-        lambda: False,
-    )
-
-    from app.core.workers.openhands_runner import main
-
-    monkeypatch.setattr(sys, "argv", ["openhands_runner", "."])
-    monkeypatch.setattr(sys, "stdin", type("FakeStdin", (), {"read": lambda self: "Do work"})())
-
-    assert main() == 4
-
-
-def test_runner_returns_auth_error_when_sdk_present_but_no_key(monkeypatch) -> None:
-    monkeypatch.setattr(
-        "app.core.workers.openhands_runner.openhands_sdk_available",
-        lambda: True,
-    )
-    monkeypatch.delenv("LLM_API_KEY", raising=False)
-    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
-    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
-
-    from app.core.workers.openhands_runner import main
-
-    monkeypatch.setattr(sys, "argv", ["openhands_runner", "."])
-    monkeypatch.setattr(sys, "stdin", type("FakeStdin", (), {"read": lambda self: "Do work"})())
-
-    assert main() == 3
-
-
-def test_runner_returns_config_error_for_malformed_env(monkeypatch) -> None:
-    monkeypatch.setenv("OPENHANDS_MAX_ITERATIONS", "bad")
-
-    completed = _run_runner(task="Do work", env={"OPENHANDS_MAX_ITERATIONS": "bad"})
-
-    assert completed.returncode == 6
-    assert "OPENHANDS_MAX_ITERATIONS" in completed.stderr
-
-
-def test_runner_configures_sdk_loop_controls_and_event_capture(
-    monkeypatch, tmp_path, capsys
-) -> None:
-    calls: dict[str, object] = {}
+    The fakes record their constructor kwargs into ``calls`` so tests can assert how the
+    runner wires the agent loop. With ``register_raises=True``, ``register_builtins_agents``
+    raises — exercising the runner's contract that every failure still emits a
+    ``OPENHANDS_WORKER_SUMMARY_JSON`` line and a clean exit code, never an uncaught crash.
+    """
 
     class FakeEvent:
         def model_dump(self, *, mode: str):
@@ -157,6 +100,8 @@ def test_runner_configures_sdk_loop_controls_and_event_capture(
     preset = ModuleType("openhands.tools.preset")
 
     def _register_builtins_agents(*, enable_browser=True):
+        if register_raises:
+            raise RuntimeError("broken preset: archetype config missing")
         calls["builtins_registered"] = True
         calls["builtins_enable_browser"] = enable_browser
         return []
@@ -166,26 +111,99 @@ def test_runner_configures_sdk_loop_controls_and_event_capture(
     tools_pkg.glob = glob_mod
     tools_pkg.grep = grep_mod
 
-    monkeypatch.setitem(sys.modules, "openhands", ModuleType("openhands"))
-    monkeypatch.setitem(sys.modules, "openhands.sdk", sdk)
-    monkeypatch.setitem(sys.modules, "openhands.sdk.context", sdk_context)
-    monkeypatch.setitem(sys.modules, "openhands.sdk.context.condenser", sdk_condenser)
-    monkeypatch.setitem(sys.modules, "openhands.sdk.security", sdk_security)
-    monkeypatch.setitem(sys.modules, "openhands.sdk.security.llm_analyzer", sdk_security_analyzer)
-    monkeypatch.setitem(sys.modules, "openhands.tools", tools_pkg)
-    monkeypatch.setitem(sys.modules, "openhands.tools.terminal", terminal)
-    monkeypatch.setitem(sys.modules, "openhands.tools.file_editor", file_editor)
-    monkeypatch.setitem(sys.modules, "openhands.tools.task_tracker", task_tracker)
-    monkeypatch.setitem(sys.modules, "openhands.tools.task", task)
-    monkeypatch.setitem(sys.modules, "openhands.tools.glob", glob_mod)
-    monkeypatch.setitem(sys.modules, "openhands.tools.grep", grep_mod)
-    monkeypatch.setitem(sys.modules, "openhands.tools.preset", preset)
+    fake_modules = {
+        "openhands": ModuleType("openhands"),
+        "openhands.sdk": sdk,
+        "openhands.sdk.context": sdk_context,
+        "openhands.sdk.context.condenser": sdk_condenser,
+        "openhands.sdk.security": sdk_security,
+        "openhands.sdk.security.llm_analyzer": sdk_security_analyzer,
+        "openhands.tools": tools_pkg,
+        "openhands.tools.terminal": terminal,
+        "openhands.tools.file_editor": file_editor,
+        "openhands.tools.task_tracker": task_tracker,
+        "openhands.tools.task": task,
+        "openhands.tools.glob": glob_mod,
+        "openhands.tools.grep": grep_mod,
+        "openhands.tools.preset": preset,
+    }
+    for name, mod in fake_modules.items():
+        monkeypatch.setitem(sys.modules, name, mod)
+
     monkeypatch.setattr(
         "app.core.workers.openhands_runner.openhands_sdk_available",
         lambda: True,
     )
     monkeypatch.setenv("LLM_API_KEY", "test-key")
     monkeypatch.setenv("OPENHANDS_MODEL", "test/model")
+
+
+def test_runner_returns_usage_error_if_repo_path_missing() -> None:
+    completed = subprocess.run(
+        [sys.executable, "-m", "app.core.workers.openhands_runner"],
+        input="Do work",
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+
+    assert completed.returncode == 2
+    assert "usage:" in completed.stderr
+
+
+def test_runner_returns_usage_error_if_stdin_task_missing() -> None:
+    completed = _run_runner(task="")
+
+    assert completed.returncode == 2
+    assert "task prompt" in completed.stderr
+
+
+def test_runner_returns_sdk_missing_before_auth_when_openhands_not_installed(monkeypatch) -> None:
+    monkeypatch.setattr(
+        "app.core.workers.openhands_runner.openhands_sdk_available",
+        lambda: False,
+    )
+
+    from app.core.workers.openhands_runner import main
+
+    monkeypatch.setattr(sys, "argv", ["openhands_runner", "."])
+    monkeypatch.setattr(sys, "stdin", type("FakeStdin", (), {"read": lambda self: "Do work"})())
+
+    assert main() == 4
+
+
+def test_runner_returns_auth_error_when_sdk_present_but_no_key(monkeypatch) -> None:
+    monkeypatch.setattr(
+        "app.core.workers.openhands_runner.openhands_sdk_available",
+        lambda: True,
+    )
+    monkeypatch.delenv("LLM_API_KEY", raising=False)
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+
+    from app.core.workers.openhands_runner import main
+
+    monkeypatch.setattr(sys, "argv", ["openhands_runner", "."])
+    monkeypatch.setattr(sys, "stdin", type("FakeStdin", (), {"read": lambda self: "Do work"})())
+
+    assert main() == 3
+
+
+def test_runner_returns_config_error_for_malformed_env(monkeypatch) -> None:
+    monkeypatch.setenv("OPENHANDS_MAX_ITERATIONS", "bad")
+
+    completed = _run_runner(task="Do work", env={"OPENHANDS_MAX_ITERATIONS": "bad"})
+
+    assert completed.returncode == 6
+    assert "OPENHANDS_MAX_ITERATIONS" in completed.stderr
+
+
+def test_runner_configures_sdk_loop_controls_and_event_capture(
+    monkeypatch, tmp_path, capsys
+) -> None:
+    calls: dict[str, object] = {}
+    _install_fake_openhands(monkeypatch, calls)
     monkeypatch.setenv("OPENHANDS_MAX_ITERATIONS", "7")
     events_path = tmp_path / "openhands_events.jsonl"
     persistence_dir = tmp_path / "openhands_state"
@@ -238,3 +256,27 @@ def test_runner_configures_sdk_loop_controls_and_event_capture(
     }
     assert summary["event_log_path"] == str(events_path)
     assert summary["observable_event_count"] == 1
+
+
+def test_runner_surfaces_summary_when_archetype_registration_fails(
+    monkeypatch, tmp_path, capsys
+) -> None:
+    """A failure inside register_builtins_agents must still emit a summary + EXIT_RUN_ERROR.
+
+    Regression for the case where archetype registration ran outside the guarded try block,
+    so a broken preset / SDK mismatch would crash main() with no observable outcome.
+    """
+    calls: dict[str, object] = {}
+    _install_fake_openhands(monkeypatch, calls, register_raises=True)
+
+    from app.core.workers.openhands_runner import main
+
+    monkeypatch.setattr(sys, "argv", ["openhands_runner", str(tmp_path)])
+    monkeypatch.setattr(sys, "stdin", type("FakeStdin", (), {"read": lambda self: "task"})())
+
+    assert main() == 1  # EXIT_RUN_ERROR — caught and surfaced, not an uncaught crash
+    summary = _summary_from_stdout(capsys.readouterr().out)
+    assert summary["status"] == "failed"
+    assert summary["termination_reason"] == "run_error"
+    # The agent loop never started because registration failed first.
+    assert "conversation" not in calls

--- a/tests/test_openhands_runner_contract.py
+++ b/tests/test_openhands_runner_contract.py
@@ -150,10 +150,18 @@ def test_runner_configures_sdk_loop_controls_and_event_capture(
     file_editor.FileEditorTool = type("FileEditorTool", (), {"name": "file_editor"})
     task_tracker = ModuleType("openhands.tools.task_tracker")
     task_tracker.TaskTrackerTool = type("TaskTrackerTool", (), {"name": "task_tracker"})
+    task = ModuleType("openhands.tools.task")
+    task.TaskToolSet = type("TaskToolSet", (), {"name": "task_tool_set"})
     glob_mod = ModuleType("openhands.tools.glob")
     grep_mod = ModuleType("openhands.tools.grep")
     preset = ModuleType("openhands.tools.preset")
-    preset.register_builtins_agents = lambda: calls.__setitem__("builtins_registered", True)
+
+    def _register_builtins_agents(*, enable_browser=True):
+        calls["builtins_registered"] = True
+        calls["builtins_enable_browser"] = enable_browser
+        return []
+
+    preset.register_builtins_agents = _register_builtins_agents
     # `from openhands.tools import glob/grep` resolves the submodule attribute on the parent.
     tools_pkg.glob = glob_mod
     tools_pkg.grep = grep_mod
@@ -168,6 +176,7 @@ def test_runner_configures_sdk_loop_controls_and_event_capture(
     monkeypatch.setitem(sys.modules, "openhands.tools.terminal", terminal)
     monkeypatch.setitem(sys.modules, "openhands.tools.file_editor", file_editor)
     monkeypatch.setitem(sys.modules, "openhands.tools.task_tracker", task_tracker)
+    monkeypatch.setitem(sys.modules, "openhands.tools.task", task)
     monkeypatch.setitem(sys.modules, "openhands.tools.glob", glob_mod)
     monkeypatch.setitem(sys.modules, "openhands.tools.grep", grep_mod)
     monkeypatch.setitem(sys.modules, "openhands.tools.preset", preset)
@@ -203,16 +212,25 @@ def test_runner_configures_sdk_loop_controls_and_event_capture(
     assert calls["conversation"]["persistence_dir"] == str(persistence_dir)
     assert calls["conversation"]["stuck_detection"] is True
     assert len(calls["conversation"]["callbacks"]) == 1
-    # Full-component wiring: the agent gets the 5-tool set + condenser + AgentOps
-    # system-prompt suffix + security analyzer, and the sub-agent archetypes register.
+    # Full-component wiring: the agent gets the 6-tool set (incl. the sub-agent delegation
+    # tool) + condenser + AgentOps system-prompt suffix + security analyzer.
     tool_names = [t.get("name") for t in calls["tools"]]
-    assert tool_names == ["terminal", "file_editor", "task_tracker", "grep", "glob"]
+    assert tool_names == [
+        "terminal",
+        "file_editor",
+        "task_tracker",
+        "grep",
+        "glob",
+        "task_tool_set",
+    ]
     assert "condenser" in calls["agent"]
     assert "security_analyzer" in calls["agent"]
     assert calls["agent_context"]["load_project_skills"] is True
     assert "AgentOps Harness" in calls["agent_context"]["system_message_suffix"]
     assert calls["condenser"] == {"llm": calls["agent"]["llm"], "max_size": 80, "keep_first": 4}
+    # 04 sub-agents register, and with browser disabled to honor the no-network constraint.
     assert calls.get("builtins_registered") is True
+    assert calls.get("builtins_enable_browser") is False
     assert events_path.exists()
     assert json.loads(events_path.read_text(encoding="utf-8")) == {
         "event": {"id": "event-1", "mode": "json", "source": "agent"},


### PR DESCRIPTION
## What & why

Closes the last un-wired worker-harness component (#04, sub-agent delegation). We already registered the built-in sub-agent **archetypes**, but never gave the agent the delegation **tool** — so it could not actually spin up a sub-agent.

**Verified against the installed SDK, not guessed.** The earlier handoff assumed #04 needed hand-instantiating `DelegateExecutor`. Introspecting `openhands` 1.28 showed the canonical path is the high-level **`task_tool_set`** toolset — exactly what the SDK's own `get_default_tools(enable_sub_agents=True)` uses. It's a one-line tool addition, not an executor.

## Changes

**Runner (`openhands_runner.py`)**
- import `openhands.tools.task.TaskToolSet`
- add `Tool(name=TaskToolSet.name)` to the agent's tool list (now **6 tools**)
- `register_builtins_agents(enable_browser=False)` so only the terminal-only archetypes register (`bash-runner`, `code-explorer`, `general-purpose`); the browser-dependent `web-researcher` is skipped

**Config (`openhands_config.py`)**
- `OPENHANDS_TOOL_NAMES` gains `"task_tool_set"` so the scorecard/summary `tools_requested` reflects the real tool set

**Tests / docs**
- contract test mocks `openhands.tools.task`, asserts the 6-tool set incl. `task_tool_set`, and asserts `register_builtins_agents(enable_browser=False)`
- `docs/OPENHANDS_INNER_WORKER.md` gains a *Sub-agent delegation* section; also adds the `configuration_error` status (from #14) to the status map

## Safety — no-browser/network constraint holds through delegation

The hard constraint is no browser/network tools. I introspected every registered archetype's declared tools:

| archetype | tools |
|---|---|
| bash-runner | `terminal` |
| code-explorer | `terminal` |
| general-purpose | `terminal`, `file_editor`, `task_tracker` |

No browser, no network — and `web-researcher` (browser-dependent) is skipped. Delegated sub-agents inherit only terminal/file tools.

## Verification

- **239 tests pass** with no OpenHands SDK installed and no API keys; `ruff check` clean.
- **Real-SDK smoke** (no `conversation.run()`, so no API cost): the agent assembles with all 6 tools including `task_tool_set`, 3 archetypes registered, delegation present.

This completes the 9-component inner loop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR wires the final un-wired worker-harness component (#04): it adds the OpenHands `task_tool_set` delegation tool to the agent, registers the terminal-only built-in archetypes with `enable_browser=False`, and fixes a pre-existing gap where archetype registration ran outside the guarded `try` block.

- **`openhands_runner.py`**: imports `TaskToolSet`, moves `register_builtins_agents(enable_browser=False)` inside the `try` block so failures surface as `EXIT_RUN_ERROR` with a summary rather than an uncaught crash, and adds `Tool(name=TaskToolSet.name)` as the 6th agent tool.
- **`openhands_config.py`**: adds `"task_tool_set"` to `OPENHANDS_TOOL_NAMES` so the emitted summary's `tools_requested` field stays accurate.
- **Tests**: refactors the SDK fake into a reusable `_install_fake_openhands` helper, asserts `enable_browser=False`, and adds a regression test that confirms registration failures still emit a well-formed summary.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a well-contained one-tool addition with no new error paths left unguarded.

The core change is minimal: one new import, one additional Tool(...) in the agent constructor, and register_builtins_agents moved into the existing try block with enable_browser=False. The move into the try block actually closes a pre-existing crash surface. All new behaviour is covered by dedicated contract tests, including a regression test for the registration-failure path. No data-persistence, auth, or schema code is touched.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| app/core/workers/openhands_runner.py | Moves register_builtins_agents(enable_browser=False) inside the guarded try block, imports and wires TaskToolSet as the 6th agent tool — implementation is clean and well-structured. |
| app/core/workers/openhands_config.py | Adds "task_tool_set" to OPENHANDS_TOOL_NAMES so the scorecard summary reflects the real 6-tool set; no logic changes. |
| tests/test_openhands_runner_contract.py | Refactors SDK fake into _install_fake_openhands helper, adds task_tool_set and enable_browser=False assertions, and adds a new regression test confirming registration failures still emit a summary and EXIT_RUN_ERROR. |
| docs/OPENHANDS_INNER_WORKER.md | Adds Sub-agent delegation section, updates the tool list in the example summary JSON, and documents configuration_error status introduced in #14. |

</details>


</details>


<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant R as openhands_runner.main()
    participant P as register_builtins_agents(enable_browser=False)
    participant A as Agent (6 tools)
    participant T as TaskToolSet
    participant S as Sub-agent archetype

    R->>P: register terminal-only archetypes
    note over P: bash-runner, code-explorer,<br/>general-purpose registered.<br/>web-researcher skipped.
    P-->>R: archetypes ready (or raises → EXIT_RUN_ERROR)
    R->>A: construct with [terminal, file_editor, task_tracker, grep, glob, task_tool_set]
    A->>T: invoke task_tool_set during run
    T->>S: delegate sub-task to archetype
    S-->>T: result (terminal/file tools only)
    T-->>A: fold result into main loop
    A-->>R: conversation.run() complete
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `app/core/workers/openhands_config.py`, line 65-72 ([link](https://github.com/ven-z8/agentops-harness/blob/f8c00af6806994e5f63c435c65570b10f1586961/app/core/workers/openhands_config.py#L65-L72)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **`openhands_sdk_available()` does not probe the new required module**

   The availability check verifies `openhands.sdk` and `openhands.tools.terminal` as proxies for the full install, but the runner now also requires `openhands.tools.task`. If the SDK is partially installed and that module is absent, `openhands_sdk_available()` returns `True`, the SDK-missing early exit is skipped, and the `ImportError` caught further down emits `status="setup_missing"` — so the end result is the same exit code. There is no data-loss risk here, but the availability predicate silently under-represents what the runner actually needs, which could mislead future callers or diagnostics that inspect the flag independently.

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

   <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20app%2Fcore%2Fworkers%2Fopenhands_config.py%0ALine%3A%2065-72%0A%0AComment%3A%0A**%60openhands_sdk_available%28%29%60%20does%20not%20probe%20the%20new%20required%20module**%0A%0AThe%20availability%20check%20verifies%20%60openhands.sdk%60%20and%20%60openhands.tools.terminal%60%20as%20proxies%20for%20the%20full%20install%2C%20but%20the%20runner%20now%20also%20requires%20%60openhands.tools.task%60.%20If%20the%20SDK%20is%20partially%20installed%20and%20that%20module%20is%20absent%2C%20%60openhands_sdk_available%28%29%60%20returns%20%60True%60%2C%20the%20SDK-missing%20early%20exit%20is%20skipped%2C%20and%20the%20%60ImportError%60%20caught%20further%20down%20emits%20%60status%3D%22setup_missing%22%60%20%E2%80%94%20so%20the%20end%20result%20is%20the%20same%20exit%20code.%20There%20is%20no%20data-loss%20risk%20here%2C%20but%20the%20availability%20predicate%20silently%20under-represents%20what%20the%20runner%20actually%20needs%2C%20which%20could%20mislead%20future%20callers%20or%20diagnostics%20that%20inspect%20the%20flag%20independently.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=15&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (2): Last reviewed commit: ["fix: address Greptile P1 on #15 — guard ..."](https://github.com/ven-z8/agentops-harness/commit/89b119a02d33bb169c29a86a487d8a0405888e1e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37279188)</sub>

<!-- /greptile_comment -->