### PR TITLE
fix(M2): detect worker-added routes in changed-subgraph (route-impact fidelity)

### DIFF
--- a/app/core/graph.py
+++ b/app/core/graph.py
@@ -442,6 +442,7 @@ def build_changed_subgraph_node(state: AgentOpsGraphState) -> AgentOpsGraphState
         changed_files=state["changed_files"],
         deleted_files=state["deleted_files"],
         fallback_validation=state["plan"].tests_to_run,
+        repo_path=state["repo_path"],
     )
     return {
         "changed_subgraph": changed_subgraph,

--- a/app/core/repo_graph/impact.py
+++ b/app/core/repo_graph/impact.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from pydantic import BaseModel, Field
 
 from app.core.repo_graph.models import RepoGraph, RepoGraphEdge, RepoGraphNode
+from app.core.repo_graph.python_parser import PythonParser
 from app.core.repo_graph.query import RepoGraphQuery
 
 
@@ -54,6 +55,7 @@ class ChangedSubgraphBuilder:
         changed_files: list[str],
         deleted_files: list[str],
         fallback_validation: list[str],
+        repo_path: Path | None = None,
     ) -> ChangedSubgraph:
         query = RepoGraphQuery(graph)
         nodes_by_id = {node.id: node for node in graph.nodes}
@@ -85,6 +87,14 @@ class ChangedSubgraphBuilder:
             for risk in self._risks_for_file(file_node, edge_index, nodes_by_id):
                 risk_notes.append(_risk_note(risk))
                 impacted_nodes.append(_impact_node(risk, "risk_attached_to_changed_file"))
+
+        # The repo graph is built from the PRE-edit snapshot, so routes a worker ADDS in
+        # its diff are absent from it. Re-parse the changed files' current content to surface
+        # them, otherwise the Evidence Guard false-flags the new route as an ungrounded claim.
+        if repo_path is not None:
+            impacted_routes.extend(
+                self._routes_added_by_change(Path(repo_path), normalized_changed)
+            )
 
         for path in normalized_deleted:
             risk_notes.append(f"Deleted file requires review: {path}")
@@ -134,6 +144,31 @@ class ChangedSubgraphBuilder:
             for edge in edge_index.outgoing(defined_node.id, "exposes_route")
             if edge.target in nodes_by_id
         ]
+
+    def _routes_added_by_change(
+        self, repo_path: Path, changed_files: list[str]
+    ) -> list[ImpactedRoute]:
+        parser = PythonParser()
+        added: list[ImpactedRoute] = []
+        for path in changed_files:
+            if not path.endswith(".py"):
+                continue
+            try:
+                result = parser.parse(repo_path, path)
+            except (OSError, SyntaxError, ValueError):
+                continue
+            for route in result.routes:
+                # node_id matches the graph builder's scheme so _unique_routes dedups any
+                # route the pre-edit graph already exposed; only genuinely-new ones survive.
+                added.append(
+                    ImpactedRoute(
+                        method=route.method,
+                        path=route.path,
+                        source_file=path,
+                        node_id=f"route:python:{route.method}:{route.path}",
+                    )
+                )
+        return added
 
     def _imports_for_file(
         self,

--- a/app/core/repo_graph/impact.py
+++ b/app/core/repo_graph/impact.py
@@ -93,7 +93,7 @@ class ChangedSubgraphBuilder:
         # them, otherwise the Evidence Guard false-flags the new route as an ungrounded claim.
         if repo_path is not None:
             impacted_routes.extend(
-                self._routes_added_by_change(Path(repo_path), normalized_changed)
+                self._routes_added_by_change(repo_path, normalized_changed)
             )
 
         for path in normalized_deleted:
@@ -155,7 +155,9 @@ class ChangedSubgraphBuilder:
                 continue
             try:
                 result = parser.parse(repo_path, path)
-            except (OSError, SyntaxError, ValueError):
+            except (OSError, ValueError):
+                # PythonParser.parse swallows SyntaxError itself; OSError (unreadable file)
+                # and ValueError (e.g. null bytes in source) can still propagate.
                 continue
             for route in result.routes:
                 # node_id matches the graph builder's scheme so _unique_routes dedups any

--- a/tests/test_changed_subgraph_routes.py
+++ b/tests/test_changed_subgraph_routes.py
@@ -1,0 +1,74 @@
+from pathlib import Path
+
+from app.core.repo_graph import RepoGraphBuilder
+from app.core.repo_graph.impact import ChangedSubgraphBuilder
+
+
+def _write(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+
+
+_PRE_EDIT = (
+    "from fastapi import FastAPI\n"
+    "app = FastAPI()\n\n"
+    "@app.get('/old')\n"
+    "def old():\n"
+    "    return {}\n"
+)
+
+_POST_EDIT = _PRE_EDIT + (
+    "\n@app.post('/new')\n"
+    "def new():\n"
+    "    return {}\n"
+)
+
+
+def test_route_added_by_change_is_detected_as_impacted(tmp_path: Path) -> None:
+    """A route the worker ADDS in its diff must appear in impacted_routes.
+
+    The repo graph is built from the pre-edit snapshot, so a brand-new route is
+    absent from it. The Evidence Guard then false-flags the report's mention of
+    that route as ungrounded. The builder must re-parse the changed file's
+    current content and pick up routes the diff introduced.
+    """
+    repo = tmp_path
+    main = repo / "app" / "main.py"
+
+    # Pre-edit snapshot: one existing route -> graph knows only /old.
+    _write(main, _PRE_EDIT)
+    graph = RepoGraphBuilder().build(repo)
+
+    # Worker edit lands on disk: the same file now also exposes POST /new.
+    _write(main, _POST_EDIT)
+
+    changed = ChangedSubgraphBuilder().build(
+        graph,
+        changed_files=["app/main.py"],
+        deleted_files=[],
+        fallback_validation=[],
+        repo_path=repo,
+    )
+
+    routes = {(route.method, route.path) for route in changed.impacted_routes}
+    assert ("POST", "/new") in routes  # the newly-added route is recognized
+    assert ("GET", "/old") in routes  # and the pre-existing one is still present
+
+
+def test_added_route_not_duplicated_when_already_in_graph(tmp_path: Path) -> None:
+    """Re-parsing must not double-list a route the graph already exposes."""
+    repo = tmp_path
+    main = repo / "app" / "main.py"
+    _write(main, _PRE_EDIT)
+    graph = RepoGraphBuilder().build(repo)  # graph already has GET /old
+
+    changed = ChangedSubgraphBuilder().build(
+        graph,
+        changed_files=["app/main.py"],
+        deleted_files=[],
+        fallback_validation=[],
+        repo_path=repo,
+    )
+
+    old_routes = [r for r in changed.impacted_routes if (r.method, r.path) == ("GET", "/old")]
+    assert len(old_routes) == 1


### PR DESCRIPTION
## What & why (Milestone M2 — outer evidence fidelity)

The repo graph is built from the **pre-edit** snapshot, so a route the worker **adds** in its diff is absent from it. `changed_subgraph.impacted_routes` — derived only from pre-edit graph edges — therefore **omitted worker-added routes**, and the **Evidence Guard false-flagged** the report's (correct) mention of them as an ungrounded claim, flipping the **Verification Stack to `Accepted: False`**. Reproduced 2/2 on `nl2sql-viz` during inner-loop verification.

## Fix

`ChangedSubgraphBuilder.build()` gains an optional `repo_path`. When provided, it re-parses each changed `.py` file's **current** content (`PythonParser`) and merges any routes the diff introduced. Synthesized node ids match the graph builder's `route:python:{METHOD}:{path}` scheme, so `_unique_routes` dedups routes the pre-edit graph already exposed — only genuinely-new routes are added. The graph node wires `repo_path` through; default `None` keeps the builder backward-compatible.

- `app/core/repo_graph/impact.py` — `repo_path` param + `_routes_added_by_change` helper
- `app/core/graph.py` — `build_changed_subgraph_node` passes `repo_path=state["repo_path"]`

## Tests (TDD, red → green)

`tests/test_changed_subgraph_routes.py`:
- a route added by the change appears in `impacted_routes`
- a route already in the graph is not double-listed

## Verification

- **Unit:** watched both tests fail (route missing), then pass after the fix.
- **E2E (free, mock provider):** `agentops run` on a repo with an uncommitted new route now lists it in `impacted_routes`; Evidence Guard raises no unsupported-route claim.
- **E2E (live, complex inner loop):** a 21-iteration OpenHands run on `nl2sql-viz` that adds `GET /api/stats` + a test → the **outer Verification Stack now returns `Accepted: True`** (`evidence_guard: pass`, 0 unsupported claims), where the same shape returned `Accepted: False` before this fix.
- Full suite: **239 passed (+2 new)**, 3 docker-skips (env), ruff clean.

## Reviewer notes

- Scope is the **under-inclusion** fix (new routes missing). The separate over-inclusion concern (untouched routes in a changed file listed as impacted) is intentionally left out of this PR.
- Follow-up surfaced during E2E: the **Product Reviewer's success-signal detection** has a similar gap (doesn't credit the M2-recognized route / untracked test files) — to be filed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a route under-inclusion bug in `ChangedSubgraphBuilder`: because the repo graph is built from the pre-edit snapshot, routes a worker adds in its diff were absent from `impacted_routes`, causing the Evidence Guard to false-flag them as ungrounded claims.

- `ChangedSubgraphBuilder.build()` gains an optional `repo_path`; when supplied, `_routes_added_by_change()` re-parses the current on-disk content of every changed `.py` file via `PythonParser` and appends the results to `impacted_routes`. Deduplication is handled downstream by `_unique_routes` keyed on `node_id` (`route:python:{METHOD}:{path}`), so pre-existing routes already surfaced via graph traversal are not double-listed.
- `build_changed_subgraph_node` in `graph.py` is updated to pass `repo_path=state["repo_path"]` to the builder.
- Two new tests cover the added-route detection and the no-duplication guarantee.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is additive, backward-compatible (default repo_path=None), and the deduplication logic correctly prevents pre-existing routes from being double-listed.

The fix is narrowly scoped: it re-parses changed Python files from current disk state and merges routes that the pre-edit graph missed. The _unique_routes deduplication by node_id is correctly relied upon to filter pre-existing routes, and both the detection and no-duplication paths are covered by new tests. Error handling for OSError and ValueError propagating out of PythonParser.parse() is correct. No existing call sites are affected when repo_path is omitted.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| app/core/repo_graph/impact.py | Adds repo_path param to build() and new _routes_added_by_change() helper that re-parses current on-disk content of changed Python files; all routes (pre-existing + new) are returned and deduplicated downstream by _unique_routes via node_id. Error handling for OSError/ValueError is correct. Backward-compatible default of None. |
| app/core/graph.py | One-line change: passes repo_path=state["repo_path"] through to ChangedSubgraphBuilder.build(). Safe and consistent with the rest of the node. |
| tests/test_changed_subgraph_routes.py | Two targeted tests: one verifies that a worker-added route appears in impacted_routes, the other verifies a pre-existing route is not double-listed. Both cover the critical paths of the fix. |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant G as build_changed_subgraph_node
    participant B as ChangedSubgraphBuilder.build()
    participant Q as RepoGraphQuery (pre-edit graph)
    participant P as PythonParser (current disk)
    participant U as _unique_routes

    G->>B: build(graph, changed_files, ..., repo_path)
    B->>Q: traverse file→defines→exposes_route edges
    Q-->>B: pre-edit impacted_routes (old routes only)
    alt repo_path is not None
        B->>P: _routes_added_by_change(repo_path, changed_files)
        P->>P: parse current .py content from disk
        P-->>B: ALL routes in current files (old + new)
    end
    B->>U: _unique_routes(pre-edit + re-parsed routes)
    note over U: dedup by node_id<br/>route:python:{METHOD}:{path}
    U-->>B: deduplicated list (new routes survive)
    B-->>G: ChangedSubgraph with full impacted_routes
```

<sub>Reviews (2): Last reviewed commit: ["fix: address Greptile P2s on #17 — drop ..."](https://github.com/ven-z8/agentops-harness/commit/e539a041073c4620225d816846a1e675f847a78e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37354871)</sub>

<!-- /greptile_comment -->