### PR TITLE
feat: AgentOps Cockpit — local observability UI over run artifacts

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -1,0 +1,11 @@
+{
+  "version": "0.0.1",
+  "configurations": [
+    {
+      "name": "cockpit",
+      "runtimeExecutable": ".venv/bin/uvicorn",
+      "runtimeArgs": ["app.api:api", "--port", "8770"],
+      "port": 8770
+    }
+  ]
+}

--- a/app/api.py
+++ b/app/api.py
@@ -5,6 +5,7 @@ from fastapi import FastAPI, HTTPException, Query
 from fastapi.responses import PlainTextResponse
 from pydantic import BaseModel
 
+from app.cockpit import mount_cockpit
 from app.core.config import settings
 from app.core.graph import run_harness
 from app.core.handoff import handoff_document_json, render_handoff_markdown, worker_handoff_from_run
@@ -98,6 +99,7 @@ def create_api(storage_path: Path | None = None, llm_client: LLMClient | None = 
             media_type="text/markdown; charset=utf-8",
         )
 
+    mount_cockpit(api, selected_storage)
     return api
 
 

--- a/app/cockpit/__init__.py
+++ b/app/cockpit/__init__.py
@@ -1,0 +1,11 @@
+"""AgentOps Cockpit — a local-first observability UI over run artifacts.
+
+The cockpit is *pure projection*: it reads the run records and per-run artifact
+bundles the harness already writes, and renders them. It adds no new source of
+truth and makes no LLM calls. Mounted onto the existing FastAPI app so a single
+``uvicorn app.api:api`` serves both the JSON API and the cockpit at ``/cockpit``.
+"""
+
+from app.cockpit.mount import mount_cockpit
+
+__all__ = ["mount_cockpit"]

--- a/app/cockpit/artifacts.py
+++ b/app/cockpit/artifacts.py
@@ -1,0 +1,317 @@
+"""Read run records + artifact bundles into cockpit-shaped payloads.
+
+Everything here is deterministic projection over data the harness already owns:
+the ``RunRecord`` (via ``RunStorage``) and the per-run ``trace.jsonl`` written by
+``RunArtifactWriter``. No LLM calls, no new persistence.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime
+from pathlib import Path
+
+from app.core.run_artifacts import artifact_dir_for_run
+from app.core.storage import RunStorage
+from app.schemas.run import RunRecord
+
+# The five macro-phases the governance pipeline collapses to, and the LangGraph
+# node names whose lifecycle events feed each one. Order is display order.
+PIPELINE_PHASES: list[tuple[str, tuple[str, ...]]] = [
+    ("plan", ("scan_repo", "repo_graph", "goal_model", "recall_experience",
+              "create_plan", "prepare_workspace", "pre_dispatch")),
+    ("worker", ("run_external_worker", "collect_diff")),
+    ("enforce", ("enforce_permissions",)),
+    ("tests", ("run_tests", "check_convergence")),
+    ("review", ("build_changed_subgraph", "review_diff", "assess_risk",
+                "classify_permissions", "write_report", "check_report_quality",
+                "check_evidence", "build_product_review", "assemble_verification",
+                "audit_conflicts")),
+]
+
+# Per-run live event log appended by the openhands worker during an in-flight run.
+LIVE_EVENT_FILE = "openhands_events.jsonl"
+WORKER_SUMMARY_FILE = "worker_loop_summary.json"
+WORKER_SCORECARD_FILE = "worker_scorecard.json"
+
+
+class CockpitReader:
+    """Projects stored runs + artifacts into cockpit JSON payloads."""
+
+    def __init__(self, storage_path: Path) -> None:
+        self.storage_path = storage_path
+        self._storage = RunStorage(storage_path)
+
+    # ── collection-level ────────────────────────────────────────────────
+    def stats(self, records: list[RunRecord] | None = None) -> dict:
+        records = records if records is not None else self._storage.list(limit=500)
+        total = len(records)
+        completed = sum(1 for r in records if r.status == "completed")
+        running = sum(1 for r in records if r.status not in {"completed", "blocked", "failed"})
+        avg_risk = round(sum(r.risk_report.risk_score for r in records) / total) if total else 0
+        return {
+            "total": total,
+            "pass_rate": round(100 * completed / total) if total else 0,
+            "avg_risk": avg_risk,
+            "running": running,
+        }
+
+    def list_summaries(self, limit: int = 50) -> dict:
+        records = self._storage.list(limit=limit)
+        return {
+            "stats": self.stats(records),
+            "runs": [self.summarize(r) for r in records],
+        }
+
+    # ── single run ──────────────────────────────────────────────────────
+    def summarize(self, record: RunRecord) -> dict:
+        commands = record.test_results.commands
+        passed = sum(1 for c in commands if c.exit_code == 0)
+        return {
+            "run_id": record.run_id,
+            "task": record.task,
+            "repo_path": record.repo_path,
+            "status": record.status,
+            "worker": _worker_label(record),
+            "risk_score": record.risk_report.risk_score,
+            "risk_level": record.risk_report.risk_level,
+            "blocked": record.risk_report.blocked or record.permission_report.blocked,
+            "permission_tier": record.permission_report.highest_tier,
+            "changed_files": len(record.changed_files),
+            "tests_passed": passed,
+            "tests_total": len(commands),
+            "evidence_flags": record.evidence_report.unsupported_claim_count,
+            "evidence_grounded": record.evidence_report.grounded,
+            "product_verdict": record.product_review.overall_verdict,
+            "attempts": record.attempts,
+            "converged": record.converged,
+            "started_at": record.started_at.isoformat(),
+            "completed_at": record.completed_at.isoformat(),
+            "duration_seconds": _duration(record.started_at, record.completed_at),
+        }
+
+    def detail(self, run_id: str) -> dict:
+        """Full inspector payload: record + derived phases + trajectory."""
+        record = self._storage.get(run_id)
+        return {
+            "summary": self.summarize(record),
+            "record": record.model_dump(mode="json"),
+            "phases": self.phases(record),
+            "trajectory": self.trajectory(run_id, record),
+            "live": self.live_event_path(run_id).exists(),
+            "artifacts": self.artifact_files(run_id),
+            "worker": self.worker_view(run_id),
+        }
+
+    # ── derived views ───────────────────────────────────────────────────
+    def trajectory(self, run_id: str, record: RunRecord | None = None) -> list[dict]:
+        """Parsed governance/loop events, newest semantics preserved in order."""
+        record = record if record is not None else self._storage.get(run_id)
+        events = self._read_trace(run_id) or [
+            {"index": i, "event": e} for i, e in enumerate(record.execution_logs)
+        ]
+        parsed = []
+        for raw in events:
+            event = raw.get("event", "")
+            node, _, phase = event.partition(":")
+            parsed.append({
+                "index": raw.get("index", len(parsed)),
+                "node": node,
+                "phase": phase or "event",
+                "raw": event,
+                "tone": _event_tone(phase),
+            })
+        return parsed
+
+    def phases(self, record: RunRecord) -> list[dict]:
+        """Map node lifecycle events onto the five macro-phases with a status."""
+        seen: dict[str, set[str]] = {}
+        for entry in record.execution_logs:
+            node, _, phase = entry.partition(":")
+            seen.setdefault(node, set()).add(phase)
+        result = []
+        for name, nodes in PIPELINE_PHASES:
+            phases_hit = {p for n in nodes for p in seen.get(n, set())}
+            if "complete" in phases_hit:
+                status = "done"
+            elif "start" in phases_hit:
+                status = "active"
+            elif phases_hit & {"skip", "observe", "absent", "miss"}:
+                status = "skipped"
+            else:
+                status = "pending"
+            result.append({"name": name, "status": status})
+        return result
+
+    def live_event_path(self, run_id: str) -> Path:
+        return artifact_dir_for_run(self.storage_path, run_id) / LIVE_EVENT_FILE
+
+    # ── raw artifact files ──────────────────────────────────────────────
+    def artifact_files(self, run_id: str) -> list[dict]:
+        """List the literal files the backend wrote for this run."""
+        run_dir = artifact_dir_for_run(self.storage_path, run_id)
+        if not run_dir.is_dir():
+            return []
+        files = [p for p in run_dir.iterdir() if p.is_file()]
+        return [
+            {"name": p.name, "size": p.stat().st_size}
+            for p in sorted(files, key=lambda p: p.name)
+        ]
+
+    def artifact_text(self, run_id: str, name: str, max_bytes: int = 400_000) -> str:
+        """Return the raw text of one artifact file, guarded against traversal."""
+        run_dir = artifact_dir_for_run(self.storage_path, run_id)
+        allowed = {p.name for p in run_dir.iterdir() if p.is_file()} if run_dir.is_dir() else set()
+        if name not in allowed:
+            raise KeyError(f"Artifact not found: {name}")
+        data = (run_dir / name).read_text(encoding="utf-8", errors="replace")
+        if len(data) > max_bytes:
+            return data[:max_bytes] + f"\n… (truncated at {max_bytes} bytes)"
+        return data
+
+    # ── inner OpenHands worker loop ─────────────────────────────────────
+    def worker_view(self, run_id: str) -> dict:
+        """The inner agent loop: model/tools machinery + tool-call trajectory.
+
+        Sourced from the openhands worker artifacts (``worker_loop_summary.json``,
+        ``worker_scorecard.json``, ``openhands_events.jsonl``). Empty when the run
+        did not use ``--worker-type openhands`` — observe/CLI runs have no inner loop.
+        """
+        run_dir = artifact_dir_for_run(self.storage_path, run_id)
+        summary = self._read_json(run_dir / WORKER_SUMMARY_FILE)
+        scorecard = self._read_json(run_dir / WORKER_SCORECARD_FILE)
+        events = self.inner_events(run_id)
+        return {
+            "present": bool(events or summary),
+            "live": (run_dir / LIVE_EVENT_FILE).exists(),
+            "summary": summary,
+            "scorecard": scorecard,
+            "events": events,
+            "count": len(events),
+        }
+
+    def inner_events(self, run_id: str) -> list[dict]:
+        path = artifact_dir_for_run(self.storage_path, run_id) / LIVE_EVENT_FILE
+        if not path.exists():
+            return []
+        events = []
+        for i, line in enumerate(path.read_text(encoding="utf-8").splitlines()):
+            if line.strip():
+                events.append(_normalize_inner_event(i, json.loads(line)))
+        return events
+
+    # ── internals ───────────────────────────────────────────────────────
+    def _read_json(self, path: Path) -> dict | None:
+        if not path.exists():
+            return None
+        return json.loads(path.read_text(encoding="utf-8"))
+
+    def _read_trace(self, run_id: str) -> list[dict]:
+        trace = artifact_dir_for_run(self.storage_path, run_id) / "trace.jsonl"
+        if not trace.exists():
+            return []
+        out = []
+        for line in trace.read_text(encoding="utf-8").splitlines():
+            if line.strip():
+                out.append(json.loads(line))
+        return out
+
+
+def _worker_label(record: RunRecord) -> str:
+    edit = record.edit_result
+    if not edit:
+        return "observe"
+    return edit.worker_type or edit.mode
+
+
+def _duration(start: datetime, end: datetime) -> float:
+    return round(max((end - start).total_seconds(), 0.0), 2)
+
+
+def _event_tone(phase: str) -> str:
+    if phase == "complete":
+        return "ok"
+    if phase == "start":
+        return "active"
+    if phase in {"skip", "observe", "absent", "miss"}:
+        return "muted"
+    return "info"
+
+
+# Map OpenHands SDK event class names onto a small set of display kinds. Matched
+# as substrings so SDK-version renames (ActionEvent / AgentActionEvent / …) still land.
+def _inner_kind(event_type: str) -> str:
+    t = event_type.lower()
+    if "action" in t:
+        return "action"
+    if "observation" in t:
+        return "observation"
+    if "message" in t:
+        return "message"
+    if "error" in t or "exception" in t:
+        return "error"
+    if "state" in t or "finish" in t:
+        return "state"
+    return "other"
+
+
+def _flatten_content(value: object) -> str:
+    """Reduce an OpenHands content value (str / block dict / list of blocks) to text."""
+    if isinstance(value, str):
+        return value
+    if isinstance(value, dict):
+        return _flatten_content(value.get("content") or value.get("text") or "")
+    if isinstance(value, list):
+        parts = [
+            p.get("text", "") if isinstance(p, dict) else str(p)
+            for p in value
+        ]
+        return " ".join(p for p in parts if p)
+    return ""
+
+
+def _normalize_inner_event(index: int, obj: dict) -> dict:
+    """Project one ``{event_type, event}`` line into a readable inner-loop row.
+
+    Defensive: OpenHands event field names shift across SDK versions, so we probe
+    a list of candidate keys and fall back to a compact snippet rather than break.
+    """
+    event_type = obj.get("event_type", "Event")
+    ev = obj.get("event", {})
+    if not isinstance(ev, dict):
+        return {"index": index, "type": event_type, "kind": "other",
+                "tool": "", "source": "", "summary": str(ev)[:400]}
+
+    source = ev.get("source") or ev.get("role") or ""
+    tool = ev.get("tool_name") or ev.get("tool") or ""
+    summary = ""
+
+    action = ev.get("action")
+    if isinstance(action, dict):
+        tool = tool or action.get("tool") or action.get("kind") or action.get("name") or ""
+        command = action.get("command") or action.get("code") or ""
+        path = action.get("path") or ""
+        summary = " ".join(x for x in (command, path) if x) \
+            or _flatten_content(action.get("content") or action.get("thought"))
+
+    obs = ev.get("observation")
+    if isinstance(obs, dict):
+        summary = summary or _flatten_content(
+            obs.get("content") or obs.get("output") or obs.get("message")
+        )
+
+    if not summary:
+        summary = _flatten_content(
+            ev.get("message") or ev.get("llm_message") or ev.get("content") or ev.get("thought")
+        )
+
+    text = str(summary).strip()
+    return {
+        "index": index,
+        "type": event_type,
+        "kind": _inner_kind(event_type),
+        "tool": str(tool),
+        "source": str(source),
+        "summary": text[:300],
+        "full": text[:6000],
+    }

--- a/app/cockpit/artifacts.py
+++ b/app/cockpit/artifacts.py
@@ -196,8 +196,13 @@ class CockpitReader:
             return []
         events = []
         for i, line in enumerate(path.read_text(encoding="utf-8").splitlines()):
-            if line.strip():
-                events.append(_normalize_inner_event(i, json.loads(line)))
+            if not line.strip():
+                continue
+            try:
+                payload = json.loads(line)
+            except json.JSONDecodeError:
+                continue  # skip a partially-written line while the worker appends
+            events.append(_normalize_inner_event(i, payload))
         return events
 
     # ── internals ───────────────────────────────────────────────────────
@@ -212,8 +217,12 @@ class CockpitReader:
             return []
         out = []
         for line in trace.read_text(encoding="utf-8").splitlines():
-            if line.strip():
+            if not line.strip():
+                continue
+            try:
                 out.append(json.loads(line))
+            except json.JSONDecodeError:
+                continue  # skip a partially-written line
         return out
 
 

--- a/app/cockpit/mount.py
+++ b/app/cockpit/mount.py
@@ -16,6 +16,7 @@ from pathlib import Path
 from fastapi import APIRouter, FastAPI, HTTPException
 from fastapi.responses import FileResponse, PlainTextResponse, StreamingResponse
 from fastapi.staticfiles import StaticFiles
+from starlette.background import BackgroundTask
 
 from app.cockpit.artifacts import CockpitReader, _normalize_inner_event
 from app.core.run_artifacts import artifact_dir_for_run, export_artifact_bundle
@@ -49,7 +50,13 @@ def build_router(reader: CockpitReader) -> APIRouter:
             raise HTTPException(status_code=404, detail=f"No artifacts for run: {run_id}")
         out = Path(tempfile.gettempdir()) / f"agentops-run-{run_id}.zip"
         export_artifact_bundle(run_dir, out)
-        return FileResponse(out, media_type="application/zip", filename=f"run-{run_id[:8]}.zip")
+        # Delete the temp zip once the response is sent so they don't accumulate.
+        return FileResponse(
+            out,
+            media_type="application/zip",
+            filename=f"run-{run_id[:8]}.zip",
+            background=BackgroundTask(out.unlink, missing_ok=True),
+        )
 
     @router.get("/runs/{run_id}/artifacts/{name}", response_model=None)
     def get_artifact(run_id: str, name: str) -> PlainTextResponse:
@@ -103,35 +110,44 @@ async def _sse_governance(reader: CockpitReader, run_id: str) -> AsyncIterator[s
 
 
 async def _sse_worker(reader: CockpitReader, run_id: str) -> AsyncIterator[str]:
-    """Inner loop: tail the live openhands event log, else replay normalized events."""
+    """Inner loop: follow the openhands event log — backlog first, then live appends."""
     yield _sse_message("open", {"run_id": run_id})
     live_path = reader.live_event_path(run_id)
-    inner = reader.inner_events(run_id)
-    # A live, still-growing event log → follow it. A finished run → replay what's there.
-    if live_path.exists() and not inner:
+    if live_path.exists():
         async for message in _tail_live(live_path):
             yield message
-    else:
-        for event in inner:
-            yield _sse_message("event", event)
-            await asyncio.sleep(_REPLAY_GAP)
     yield _sse_message("done", {"run_id": run_id})
 
 
 async def _tail_live(path: Path) -> AsyncIterator[str]:
-    """Follow an in-flight openhands event log, emitting each appended line."""
+    """Emit the existing events, then follow the file for ones appended live.
+
+    Handles both a finished run (emit the backlog, then idle out) and an in-flight
+    run (emit the backlog, then keep streaming as the worker appends). Reads
+    off-thread so the event loop is never blocked, and only consumes complete,
+    newline-terminated lines so a partially-written trailing line is left for the
+    next pass instead of raising a JSON error.
+    """
     offset = 0
     idle = 0
     index = 0
     while idle < _TAIL_IDLE_LIMIT:
-        text = path.read_text(encoding="utf-8")
-        if len(text) > offset:
-            for line in text[offset:].splitlines():
-                if line.strip():
-                    yield _sse_message("event", _normalize_inner_event(index, json.loads(line)))
-                    index += 1
-            offset = len(text)
-            idle = 0
-        else:
+        text = await asyncio.to_thread(path.read_text, encoding="utf-8")
+        last_newline = text.rfind("\n", offset)
+        if last_newline < offset:
             idle += 1
-        await asyncio.sleep(0.1)
+            await asyncio.sleep(0.1)
+            continue
+        complete = text[offset : last_newline + 1]
+        offset = last_newline + 1
+        idle = 0
+        for line in complete.splitlines():
+            if not line.strip():
+                continue
+            try:
+                event = _normalize_inner_event(index, json.loads(line))
+            except json.JSONDecodeError:
+                continue
+            yield _sse_message("event", event)
+            index += 1
+            await asyncio.sleep(_REPLAY_GAP)

--- a/app/cockpit/mount.py
+++ b/app/cockpit/mount.py
@@ -1,0 +1,137 @@
+"""Mount the cockpit (API routes + static UI) onto the FastAPI app.
+
+Read endpoints live under ``/cockpit/api`` and the vanilla static UI is served
+at ``/cockpit``. The API routes are registered *before* the static mount so an
+exact route like ``/cockpit/api/runs`` is matched ahead of the ``/cockpit`` mount.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import tempfile
+from collections.abc import AsyncIterator
+from pathlib import Path
+
+from fastapi import APIRouter, FastAPI, HTTPException
+from fastapi.responses import FileResponse, PlainTextResponse, StreamingResponse
+from fastapi.staticfiles import StaticFiles
+
+from app.cockpit.artifacts import CockpitReader, _normalize_inner_event
+from app.core.run_artifacts import artifact_dir_for_run, export_artifact_bundle
+
+WEB_DIR = Path(__file__).resolve().parents[2] / "web"
+
+# Seconds between replayed trajectory events — fast enough to feel live, slow
+# enough to read. Live (in-flight) tails emit as soon as a line is appended.
+_REPLAY_GAP = 0.12
+_TAIL_IDLE_LIMIT = 50  # ~5s of no new lines on a live file ends the stream
+
+
+def build_router(reader: CockpitReader) -> APIRouter:
+    router = APIRouter(prefix="/cockpit/api", tags=["cockpit"])
+
+    @router.get("/runs")
+    def list_runs(limit: int = 50) -> dict:
+        return reader.list_summaries(limit=limit)
+
+    @router.get("/runs/{run_id}")
+    def get_run(run_id: str) -> dict:
+        try:
+            return reader.detail(run_id)
+        except KeyError as exc:
+            raise HTTPException(status_code=404, detail=str(exc)) from exc
+
+    @router.get("/runs/{run_id}/bundle.zip", response_model=None)
+    def get_bundle(run_id: str) -> FileResponse:
+        run_dir = artifact_dir_for_run(reader.storage_path, run_id)
+        if not run_dir.is_dir():
+            raise HTTPException(status_code=404, detail=f"No artifacts for run: {run_id}")
+        out = Path(tempfile.gettempdir()) / f"agentops-run-{run_id}.zip"
+        export_artifact_bundle(run_dir, out)
+        return FileResponse(out, media_type="application/zip", filename=f"run-{run_id[:8]}.zip")
+
+    @router.get("/runs/{run_id}/artifacts/{name}", response_model=None)
+    def get_artifact(run_id: str, name: str) -> PlainTextResponse:
+        try:
+            return PlainTextResponse(reader.artifact_text(run_id, name))
+        except KeyError as exc:
+            raise HTTPException(status_code=404, detail=str(exc)) from exc
+
+    @router.get("/runs/{run_id}/stream")
+    def stream_run(run_id: str) -> StreamingResponse:
+        return _event_stream(_sse_governance(reader, run_id))
+
+    @router.get("/runs/{run_id}/worker/stream")
+    def stream_worker(run_id: str) -> StreamingResponse:
+        return _event_stream(_sse_worker(reader, run_id))
+
+    return router
+
+
+def _event_stream(generator: AsyncIterator[str]) -> StreamingResponse:
+    return StreamingResponse(
+        generator,
+        media_type="text/event-stream",
+        headers={"Cache-Control": "no-cache", "X-Accel-Buffering": "no"},
+    )
+
+
+def mount_cockpit(api: FastAPI, storage_path: Path) -> None:
+    reader = CockpitReader(storage_path)
+    api.include_router(build_router(reader))
+    if WEB_DIR.is_dir():
+        api.mount("/cockpit", StaticFiles(directory=WEB_DIR, html=True), name="cockpit")
+
+
+def _sse_message(event: str, data: dict) -> str:
+    return f"event: {event}\ndata: {json.dumps(data)}\n\n"
+
+
+async def _sse_governance(reader: CockpitReader, run_id: str) -> AsyncIterator[str]:
+    """Outer loop: replay the governance node trajectory (trace.jsonl)."""
+    try:
+        events = reader.trajectory(run_id)
+    except KeyError:
+        yield _sse_message("error", {"detail": f"Run not found: {run_id}"})
+        return
+    yield _sse_message("open", {"run_id": run_id})
+    for event in events:
+        yield _sse_message("event", event)
+        await asyncio.sleep(_REPLAY_GAP)
+    yield _sse_message("done", {"run_id": run_id})
+
+
+async def _sse_worker(reader: CockpitReader, run_id: str) -> AsyncIterator[str]:
+    """Inner loop: tail the live openhands event log, else replay normalized events."""
+    yield _sse_message("open", {"run_id": run_id})
+    live_path = reader.live_event_path(run_id)
+    inner = reader.inner_events(run_id)
+    # A live, still-growing event log → follow it. A finished run → replay what's there.
+    if live_path.exists() and not inner:
+        async for message in _tail_live(live_path):
+            yield message
+    else:
+        for event in inner:
+            yield _sse_message("event", event)
+            await asyncio.sleep(_REPLAY_GAP)
+    yield _sse_message("done", {"run_id": run_id})
+
+
+async def _tail_live(path: Path) -> AsyncIterator[str]:
+    """Follow an in-flight openhands event log, emitting each appended line."""
+    offset = 0
+    idle = 0
+    index = 0
+    while idle < _TAIL_IDLE_LIMIT:
+        text = path.read_text(encoding="utf-8")
+        if len(text) > offset:
+            for line in text[offset:].splitlines():
+                if line.strip():
+                    yield _sse_message("event", _normalize_inner_event(index, json.loads(line)))
+                    index += 1
+            offset = len(text)
+            idle = 0
+        else:
+            idle += 1
+        await asyncio.sleep(0.1)

--- a/tests/test_cockpit.py
+++ b/tests/test_cockpit.py
@@ -4,6 +4,7 @@ from fastapi.testclient import TestClient
 
 from app.api import create_api
 from app.cockpit.artifacts import CockpitReader
+from app.core.run_artifacts import artifact_dir_for_run
 from app.core.storage import RunStorage
 from tests.helpers_runrecord import minimal_run_record
 
@@ -51,6 +52,50 @@ def test_reader_summary_stats_and_phases(tmp_path: Path) -> None:
         "tests": "done",
         "review": "done",
     }
+
+
+def test_inner_events_skips_partial_json_line(tmp_path: Path) -> None:
+    # A mid-write trailing line must be skipped, not raise (the cockpit polls the
+    # file while the worker appends to it).
+    storage = tmp_path / "runs.jsonl"
+    run_dir = artifact_dir_for_run(storage, "r1")
+    run_dir.mkdir(parents=True)
+    (run_dir / "openhands_events.jsonl").write_text(
+        '{"event_type": "ActionEvent", "event": {"tool_name": "terminal"}}\n'
+        '{"event_type": "Obs", "event": {"observ',  # partial, malformed
+        encoding="utf-8",
+    )
+    events = CockpitReader(storage).inner_events("r1")
+    assert len(events) == 1
+
+
+def test_cockpit_worker_stream_emits_existing_inner_events(tmp_path: Path, monkeypatch) -> None:
+    # Regression: the worker stream must emit events that already exist in the log
+    # (the prior logic skipped the tail path once any event was present).
+    monkeypatch.setattr("app.api.settings.llm_provider", "mock")
+    storage = tmp_path / "runs.db"
+    client = TestClient(create_api(storage_path=storage))
+    run_id = client.post(
+        "/runs",
+        json={"repo_path": "examples/sample_fastapi_app", "task": "Inner stream"},
+    ).json()["run_id"]
+    run_dir = artifact_dir_for_run(storage, run_id)
+    (run_dir / "openhands_events.jsonl").write_text(
+        '{"event_type": "ActionEvent", "event": {"tool_name": "terminal", '
+        '"action": {"command": "pytest -q"}}}\n'
+        '{"event_type": "ObservationEvent", "event": {"observation": {"content": "ok"}}}\n',
+        encoding="utf-8",
+    )
+
+    seen = 0
+    with client.stream("GET", f"/cockpit/api/runs/{run_id}/worker/stream") as resp:
+        assert resp.status_code == 200
+        for line in resp.iter_lines():
+            if line == "event: event":
+                seen += 1
+            if seen == 2:
+                break
+    assert seen == 2
 
 
 def test_reader_worker_view_absent_for_observe_runs(tmp_path: Path) -> None:

--- a/tests/test_cockpit.py
+++ b/tests/test_cockpit.py
@@ -1,0 +1,171 @@
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+
+from app.api import create_api
+from app.cockpit.artifacts import CockpitReader
+from app.core.storage import RunStorage
+from tests.helpers_runrecord import minimal_run_record
+
+_OBSERVE_LOGS = [
+    "scan_repo:start",
+    "scan_repo:complete",
+    "create_plan:complete",
+    "prepare_workspace:complete",
+    "pre_dispatch:observe",
+    "collect_diff:complete",
+    "enforce_permissions:skip",
+    "run_tests:complete",
+    "review_diff:complete",
+    "assess_risk:complete",
+    "audit_conflicts:complete",
+]
+
+
+def _saved_reader(tmp_path: Path) -> CockpitReader:
+    record = minimal_run_record()
+    record.run_id = "r1"
+    record.task = "Add logging"
+    record.execution_logs = list(_OBSERVE_LOGS)
+    storage = tmp_path / "runs.jsonl"
+    RunStorage(storage).save(record)
+    return CockpitReader(storage)
+
+
+def test_reader_summary_stats_and_phases(tmp_path: Path) -> None:
+    reader = _saved_reader(tmp_path)
+
+    listing = reader.list_summaries()
+    assert listing["stats"] == {"total": 1, "pass_rate": 100, "avg_risk": 0, "running": 0}
+    summary = listing["runs"][0]
+    assert summary["task"] == "Add logging"
+    assert summary["worker"] == "observe"
+    assert summary["product_verdict"] == "not_evaluated"
+
+    detail = reader.detail("r1")
+    statuses = {p["name"]: p["status"] for p in detail["phases"]}
+    assert statuses == {
+        "plan": "done",
+        "worker": "done",
+        "enforce": "skipped",
+        "tests": "done",
+        "review": "done",
+    }
+
+
+def test_reader_worker_view_absent_for_observe_runs(tmp_path: Path) -> None:
+    reader = _saved_reader(tmp_path)
+    worker = reader.worker_view("r1")
+    assert worker["present"] is False
+    assert worker["count"] == 0
+
+
+def test_reader_worker_view_parses_inner_loop(tmp_path: Path) -> None:
+    from app.core.run_artifacts import artifact_dir_for_run
+    from app.core.workers.openhands_artifacts import write_worker_events, write_worker_summary
+    from app.schemas.worker_loop import WorkerLoopSummary
+
+    reader = _saved_reader(tmp_path)
+    run_dir = artifact_dir_for_run(tmp_path / "runs.jsonl", "r1")
+    write_worker_summary(run_dir, WorkerLoopSummary(status="completed", model="anthropic/x"))
+    write_worker_events(run_dir, [
+        {"event_type": "ActionEvent",
+         "event": {"source": "agent", "tool_name": "terminal", "action": {"command": "pytest -q"}}},
+        {"event_type": "ObservationEvent", "event": {"observation": {"content": "3 passed"}}},
+    ])
+
+    worker = reader.worker_view("r1")
+    assert worker["present"] is True
+    assert worker["count"] == 2
+    assert worker["summary"]["model"] == "anthropic/x"
+    first = worker["events"][0]
+    assert first["kind"] == "action"
+    assert first["tool"] == "terminal"
+    assert first["summary"] == "pytest -q"
+    assert worker["events"][1]["kind"] == "observation"
+
+
+def test_reader_trajectory_falls_back_to_execution_logs(tmp_path: Path) -> None:
+    reader = _saved_reader(tmp_path)
+    trajectory = reader.trajectory("r1")
+    assert trajectory[0] == {
+        "index": 0,
+        "node": "scan_repo",
+        "phase": "start",
+        "raw": "scan_repo:start",
+        "tone": "active",
+    }
+    assert trajectory[1]["tone"] == "ok"  # scan_repo:complete
+
+
+def test_cockpit_api_lists_and_inspects(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setattr("app.api.settings.llm_provider", "mock")
+    client = TestClient(create_api(storage_path=tmp_path / "runs.db"))
+
+    run_id = client.post(
+        "/runs",
+        json={"repo_path": "examples/sample_fastapi_app", "task": "Add a /health endpoint"},
+    ).json()["run_id"]
+
+    listing = client.get("/cockpit/api/runs").json()
+    assert listing["stats"]["total"] == 1
+    assert any(r["run_id"] == run_id for r in listing["runs"])
+
+    detail = client.get(f"/cockpit/api/runs/{run_id}").json()
+    assert len(detail["phases"]) == 5
+    assert detail["trajectory"]
+    assert detail["live"] is False
+    assert detail["record"]["run_id"] == run_id
+
+
+def test_cockpit_api_returns_404_for_missing_run(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setattr("app.api.settings.llm_provider", "mock")
+    client = TestClient(create_api(storage_path=tmp_path / "runs.db"))
+    assert client.get("/cockpit/api/runs/missing").status_code == 404
+
+
+def test_cockpit_serves_raw_artifacts_and_blocks_traversal(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setattr("app.api.settings.llm_provider", "mock")
+    client = TestClient(create_api(storage_path=tmp_path / "runs.db"))
+    run_id = client.post(
+        "/runs",
+        json={"repo_path": "examples/sample_fastapi_app", "task": "Inspect artifacts"},
+    ).json()["run_id"]
+
+    detail = client.get(f"/cockpit/api/runs/{run_id}").json()
+    names = {a["name"] for a in detail["artifacts"]}
+    assert "run_record.json" in names
+    assert "final_report.md" in names
+
+    raw = client.get(f"/cockpit/api/runs/{run_id}/artifacts/risk_report.json")
+    assert raw.status_code == 200
+    assert "risk_score" in raw.text
+
+    # a name that is not a file in the run dir must 404 (no path traversal)
+    missing = client.get(f"/cockpit/api/runs/{run_id}/artifacts/does_not_exist.json")
+    assert missing.status_code == 404
+
+    bundle = client.get(f"/cockpit/api/runs/{run_id}/bundle.zip")
+    assert bundle.status_code == 200
+    assert bundle.headers["content-type"] == "application/zip"
+    assert bundle.content[:2] == b"PK"
+
+
+def test_cockpit_stream_emits_sse_events(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setattr("app.api.settings.llm_provider", "mock")
+    client = TestClient(create_api(storage_path=tmp_path / "runs.db"))
+    run_id = client.post(
+        "/runs",
+        json={"repo_path": "examples/sample_fastapi_app", "task": "Stream me"},
+    ).json()["run_id"]
+
+    seen_open = seen_event = False
+    with client.stream("GET", f"/cockpit/api/runs/{run_id}/stream") as resp:
+        assert resp.status_code == 200
+        assert resp.headers["content-type"].startswith("text/event-stream")
+        for line in resp.iter_lines():
+            seen_open = seen_open or line == "event: open"
+            seen_event = seen_event or line == "event: event"
+            if seen_open and seen_event:
+                break
+    assert seen_open and seen_event

--- a/web/app.js
+++ b/web/app.js
@@ -1,0 +1,553 @@
+"use strict";
+
+// AgentOps Cockpit — vanilla ES-module client. Pure projection of the harness
+// run artifacts served by app/cockpit. The top strip is the live "at a glance"
+// (SSE trajectory + guard summary); the deep-dive tabs showcase the entire
+// RunRecord plus the raw artifact files the backend wrote on disk.
+
+const ICON = {
+  play: '<svg width="13" height="13" viewBox="0 0 24 24" fill="currentColor"><path d="M8 5v14l11-7z"/></svg>',
+  pause: '<svg width="12" height="12" viewBox="0 0 24 24" fill="currentColor"><path d="M6 5h4v14H6zM14 5h4v14h-4z"/></svg>',
+  download: '<svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3v12m0 0 4-4m-4 4-4-4M5 21h14"/></svg>',
+};
+
+const PHASE_LABEL = { plan: "plan", worker: "worker", enforce: "enforce", tests: "tests", review: "review" };
+const RISK_TONE = { low: "t-green", medium: "t-amber", high: "t-red", critical: "t-red" };
+const TIER_TONE = { auto: "b-green", ask: "b-amber", deny: "b-red" };
+const SEV_TONE = { info: "b-mut", warning: "b-amber", error: "b-red" };
+const VERDICT_TONE = {
+  aligned: "t-green", pass: "t-green",
+  incomplete: "t-amber", concern: "t-amber", drifted: "t-amber", overbuilt: "t-amber", unclear: "t-amber",
+  fail: "t-red", not_evaluated: "t-mut",
+};
+
+const esc = s => String(s ?? "").replace(/[&<>"]/g, c => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;" }[c]));
+
+function fmtAge(iso) {
+  const secs = (Date.now() - new Date(iso).getTime()) / 1000;
+  if (secs < 60) return "just now";
+  if (secs < 3600) return `${Math.round(secs / 60)}m ago`;
+  if (secs < 86400) return `${Math.round(secs / 3600)}h ago`;
+  return `${Math.round(secs / 86400)}d ago`;
+}
+const fmtDur = s => (s < 60 ? `${s.toFixed(1)}s` : `${Math.floor(s / 60)}m ${Math.round(s % 60)}s`);
+const fmtBytes = n => (n < 1024 ? `${n} B` : n < 1048576 ? `${(n / 1024).toFixed(1)} KB` : `${(n / 1048576).toFixed(1)} MB`);
+
+async function api(path) {
+  const resp = await fetch(path);
+  if (!resp.ok) throw new Error(`${resp.status} ${path}`);
+  return resp.json();
+}
+async function apiText(path) {
+  const resp = await fetch(path);
+  if (!resp.ok) throw new Error(`${resp.status}`);
+  return resp.text();
+}
+
+const state = { runs: [], selected: null, es: null, wes: null, detail: null, tab: "plan", wfilter: "all" };
+
+async function init() {
+  await loadRuns();
+  if (state.runs[0]) selectRun(state.runs[0].run_id);
+}
+
+async function loadRuns() {
+  const data = await api("/cockpit/api/runs?limit=50");
+  state.runs = data.runs;
+  renderStats(data.stats);
+  renderRunList();
+}
+
+function renderStats(s) {
+  document.getElementById("kTotal").textContent = s.total;
+  document.getElementById("kPass").textContent = `${s.pass_rate}%`;
+  document.getElementById("kRisk").textContent = s.avg_risk;
+  const ind = document.getElementById("liveInd");
+  if (s.running > 0) {
+    ind.className = "live on";
+    ind.innerHTML = `<span class="dot pulse"></span>${s.running} live`;
+  } else {
+    ind.className = "live";
+    ind.innerHTML = `<span class="dot"></span>idle`;
+  }
+}
+
+function statusDot(run) {
+  if (run.blocked) return '<span class="dot" style="background:var(--red)"></span>';
+  if (run.status === "completed") return '<span class="dot" style="background:var(--green)"></span>';
+  if (run.status === "failed") return '<span class="dot" style="background:var(--red)"></span>';
+  return '<span class="dot pulse" style="background:var(--amber)"></span>';
+}
+
+function renderRunList() {
+  const host = document.getElementById("runs");
+  if (!state.runs.length) { host.innerHTML = '<div class="empty">No runs yet.</div>'; return; }
+  host.innerHTML = state.runs.map(r => `
+    <button class="run" data-id="${esc(r.run_id)}">
+      <span style="margin-top:4px">${statusDot(r)}</span>
+      <span class="run-main">
+        <div class="run-task">${esc(r.task)}</div>
+        <div class="run-meta">${esc(r.run_id.slice(0, 4))} · ${esc(fmtAge(r.completed_at))} · ${r.tests_passed}/${r.tests_total} tests</div>
+      </span>
+      <span class="risk ${RISK_TONE[r.risk_level] || "t-mut"}">${r.risk_score}</span>
+    </button>`).join("");
+  host.querySelectorAll(".run").forEach(b => b.addEventListener("click", () => selectRun(b.dataset.id)));
+  markSelected();
+}
+
+function markSelected() {
+  document.querySelectorAll(".run").forEach(b => b.classList.toggle("sel", b.dataset.id === state.selected));
+}
+
+function closeStreams() {
+  if (state.es) { state.es.close(); state.es = null; }
+  if (state.wes) { state.wes.close(); state.wes = null; }
+}
+
+async function selectRun(runId) {
+  state.selected = runId;
+  markSelected();
+  closeStreams();
+  const insp = document.getElementById("inspector");
+  insp.innerHTML = '<div class="empty">Loading run…</div>';
+  try {
+    state.detail = await api(`/cockpit/api/runs/${runId}`);
+  } catch (err) {
+    insp.innerHTML = `<div class="empty">Failed to load: ${esc(err.message)}</div>`;
+    return;
+  }
+  renderInspector(state.detail);
+  streamTrajectory(runId);
+}
+
+function renderInspector(d) {
+  const s = d.summary, rec = d.record;
+  const statusTone = s.blocked ? "t-red" : s.status === "completed" ? "t-green" : "t-amber";
+  const statusBg = s.blocked ? "var(--red-bg)" : s.status === "completed" ? "var(--green-bg)" : "var(--amber-bg)";
+  document.getElementById("inspector").innerHTML = `
+    <div class="insp-head">
+      <div class="insp-head-l">
+        <span class="pill ${statusTone}" style="background:${statusBg}">${esc(s.blocked ? "blocked" : s.status)}</span>
+        <span class="insp-task">${esc(s.task)}</span>
+      </div>
+      <a class="dl-btn" href="/cockpit/api/runs/${esc(s.run_id)}/bundle.zip" download>${ICON.download}bundle.zip</a>
+    </div>
+    <div class="insp-meta">${esc(s.run_id.slice(0, 8))} · ${esc(s.worker)} · ${fmtDur(s.duration_seconds)} · attempt ${s.attempts} · converged ${s.converged} · ${esc(s.repo_path)}</div>
+    <div class="ribbon">${d.phases.map(phaseEl).join("")}</div>
+    <div class="insp-body">
+      <div class="card">
+        <div class="card-head">
+          <span class="lbl"><span class="dot pulse" style="background:var(--green)" id="trajDot"></span>Governance loop <span class="sub">· outer (AgentOps)</span></span>
+          <button class="btn-ghost" id="pauseBtn">${ICON.pause}<span>pause</span></button>
+        </div>
+        <div class="traj" id="traj"></div>
+      </div>
+      <div class="guards">${guardCards(s, rec)}</div>
+    </div>
+    <div class="deep">
+      <div class="tabs" id="tabs">${TABS.map(t => tabBtn(t, d)).join("")}</div>
+      <div class="tabbody" id="tabbody"></div>
+    </div>`;
+  document.getElementById("pauseBtn").addEventListener("click", togglePause);
+  document.querySelectorAll("#tabs .tab").forEach(b => b.addEventListener("click", () => selectTab(b.dataset.tab)));
+  if (!TABS.some(t => t.key === state.tab)) state.tab = "plan";
+  selectTab(state.tab);
+}
+
+const phaseEl = p => `<div class="phase ${p.status}"><span class="ph-icon">${phaseGlyph(p.status)}</span>${esc(PHASE_LABEL[p.name] || p.name)}</div>`;
+function phaseGlyph(status) {
+  if (status === "done") return "✓";
+  if (status === "active") return ICON.play;
+  if (status === "skipped") return "–";
+  return "·";
+}
+
+function guardCards(s, rec) {
+  const counts = tierCounts(rec.permission_report);
+  const ev = rec.evidence_report || {};
+  return `
+    <div class="guard">
+      <div class="g-lbl">Risk assessment</div>
+      <div><span class="g-big ${RISK_TONE[s.risk_level] || "t-mut"}">${s.risk_score}</span>
+        <span class="${RISK_TONE[s.risk_level] || "t-mut"}" style="font-size:12px">${esc(s.risk_level)}</span></div>
+      <div class="g-val t-mut" style="margin-top:4px;font-size:12px">${esc((rec.risk_report?.factors || [])[0] || "")}</div>
+    </div>
+    <div class="guard">
+      <div class="g-lbl">Permissions</div>
+      <div class="g-val mono">${counts.auto} auto · ${counts.ask} ask · <span class="${counts.deny ? "t-red" : "t-green"}">${counts.deny} deny</span></div>
+    </div>
+    <div class="guard">
+      <div class="g-lbl">Evidence guard</div>
+      <div class="g-val ${ev.unsupported_claim_count ? "t-amber" : "t-green"}">
+        ${ev.unsupported_claim_count ? `${ev.unsupported_claim_count} flag${ev.unsupported_claim_count === 1 ? "" : "s"}` : "✓ 0 flags · grounded"}</div>
+    </div>
+    <div class="guard">
+      <div class="g-lbl">Product review</div>
+      <div class="g-val"><span class="${VERDICT_TONE[s.product_verdict] || "t-mut"}">${esc(s.product_verdict.replace(/_/g, " "))}</span>
+        <span class="t-mut" style="font-size:12px"> · ${lensSummary(rec.product_review)}</span></div>
+    </div>`;
+}
+
+function tierCounts(perm) {
+  const c = { auto: 0, ask: 0, deny: 0 };
+  ((perm && perm.decisions) || []).forEach(x => { c[x.tier] = (c[x.tier] || 0) + 1; });
+  return c;
+}
+function lensSummary(pr) {
+  const lenses = Object.values((pr && pr.per_lens) || {});
+  if (!lenses.length) return "4 lenses";
+  return `${lenses.filter(v => v === "pass").length}/${lenses.length} lenses`;
+}
+
+// ── live trajectory via SSE ──────────────────────────────────────────────
+function streamTrajectory(runId) {
+  const host = document.getElementById("traj");
+  if (!host) return;
+  host.innerHTML = "";
+  const es = new EventSource(`/cockpit/api/runs/${runId}/stream`);
+  state.es = es;
+  es.addEventListener("event", e => appendEvent(host, JSON.parse(e.data)));
+  es.addEventListener("done", finishStream);
+  es.addEventListener("error", finishStream);
+}
+function appendEvent(host, ev) {
+  const row = document.createElement("div");
+  row.className = `ev ${ev.tone || "info"}`;
+  const node = ev.node || ev.raw || "";
+  const ph = ev.phase && ev.phase !== "event" ? ev.phase : "";
+  row.innerHTML = `<span class="idx">${ev.index}</span><span class="node">${esc(node)}</span>${ph ? `<span class="ph">${esc(ph)}</span>` : ""}`;
+  host.appendChild(row);
+  host.scrollTop = host.scrollHeight;
+}
+function finishStream() {
+  if (state.es) { state.es.close(); state.es = null; }
+  document.getElementById("trajDot")?.classList.remove("pulse");
+  const btn = document.getElementById("pauseBtn");
+  if (btn) btn.style.display = "none";
+}
+function togglePause() {
+  if (state.es) {
+    state.es.close(); state.es = null;
+    document.getElementById("trajDot")?.classList.remove("pulse");
+    const btn = document.getElementById("pauseBtn"); if (btn) btn.innerHTML = `${ICON.play}<span>resume</span>`;
+  } else if (state.selected) {
+    streamTrajectory(state.selected);
+    const btn = document.getElementById("pauseBtn"); if (btn) btn.innerHTML = `${ICON.pause}<span>pause</span>`;
+  }
+}
+
+// ── deep-dive tabs (full record showcase) ────────────────────────────────
+const TABS = [
+  { key: "plan", label: "Plan", count: d => d.record.plan?.steps?.length, render: tabPlan },
+  { key: "diff", label: "Diff", count: d => d.record.changed_files?.length, render: tabDiff },
+  { key: "tests", label: "Tests", count: d => d.record.test_results?.commands?.length, render: tabTests },
+  { key: "worker", label: "Worker loop", count: d => d.worker?.count || undefined, render: tabWorker },
+  { key: "governance", label: "Governance", render: tabGovernance },
+  { key: "product", label: "Product", count: d => d.record.product_review?.findings?.length, render: tabProduct },
+  { key: "graph", label: "Graph", render: tabGraph },
+  { key: "report", label: "Report", render: tabReport },
+  { key: "files", label: "Files", count: d => d.artifacts?.length, render: tabFiles },
+];
+const tabBtn = (t, d) => {
+  const n = t.count ? t.count(d) : undefined;
+  return `<button class="tab" data-tab="${t.key}">${t.label}${n != null ? `<span class="ct">${n}</span>` : ""}</button>`;
+};
+function selectTab(key) {
+  state.tab = key;
+  if (state.wes) { state.wes.close(); state.wes = null; }  // stop inner stream when leaving Worker tab
+  document.querySelectorAll("#tabs .tab").forEach(b => b.classList.toggle("sel", b.dataset.tab === key));
+  const body = document.getElementById("tabbody");
+  const tab = TABS.find(t => t.key === key) || TABS[0];
+  body.innerHTML = tab.render(state.detail);
+  if (tab.after) tab.after(state.detail);
+}
+
+function sec(title, inner) { return `<div class="sec"><div class="sec-h">${esc(title)}</div>${inner}</div>`; }
+function kv(rows) { return `<table class="kv">${rows.map(([k, v]) => `<tr><td>${esc(k)}</td><td class="mono">${v}</td></tr>`).join("")}</table>`; }
+function chips(items) { return items?.length ? `<div class="chips">${items.map(x => `<span class="chip">${esc(x)}</span>`).join("")}</div>` : ""; }
+function jsonView(obj) { return `<pre class="code">${esc(JSON.stringify(obj ?? {}, null, 2))}</pre>`; }
+function emptyNote(t) { return `<div class="note">${esc(t)}</div>`; }
+
+function tabPlan(d) {
+  const p = d.record.plan || {};
+  const steps = (p.steps || []).map((s, i) => `
+    <div class="step">
+      <div class="step-t">${i + 1}. ${esc(s.title || "")}</div>
+      <div class="step-d">${esc(s.description || "")}</div>
+      ${s.files_to_edit?.length ? `<div class="step-d" style="margin-top:5px">edit: ${chips(s.files_to_edit)}</div>` : ""}
+      ${s.files_to_inspect?.length ? `<div class="step-d" style="margin-top:3px">inspect: ${chips(s.files_to_inspect)}</div>` : ""}
+    </div>`).join("");
+  return [
+    p.summary ? sec("Summary", `<div class="finding-b">${esc(p.summary)}</div>`) : "",
+    steps ? sec(`Steps (${p.steps.length})`, steps) : "",
+    p.acceptance_criteria?.length ? sec("Acceptance criteria", `<ul>${p.acceptance_criteria.map(a => `<li class="finding-b">${esc(a)}</li>`).join("")}</ul>`) : "",
+    p.tests_to_run?.length ? sec("Tests to run", chips(p.tests_to_run)) : "",
+  ].join("") || emptyNote("No plan recorded.");
+}
+
+function tabDiff(d) {
+  const rec = d.record;
+  const hasPatch = (d.artifacts || []).some(a => a.name === "diff.patch");
+  return [
+    sec("Changed files", rec.changed_files?.length ? chips(rec.changed_files) : emptyNote("No files changed (observe mode makes no edits).")),
+    rec.deleted_files?.length ? sec("Deleted files", chips(rec.deleted_files)) : "",
+    rec.diff_summary ? sec("Diff summary", `<div class="finding-b">${esc(rec.diff_summary)}</div>`) : "",
+    sec("Patch", hasPatch ? `<pre class="code" id="diffPane">loading diff.patch…</pre>` : emptyNote("No diff.patch artifact for this run.")),
+  ].join("");
+}
+TABS.find(t => t.key === "diff").after = d => {
+  const pane = document.getElementById("diffPane");
+  if (!pane) return;
+  apiText(`/cockpit/api/runs/${d.summary.run_id}/artifacts/diff.patch`)
+    .then(txt => { pane.innerHTML = colorizeDiff(txt); })
+    .catch(() => { pane.textContent = "Could not load diff.patch"; });
+};
+function colorizeDiff(txt) {
+  return txt.split("\n").map(line => {
+    const e = esc(line);
+    if (line.startsWith("+")) return `<span class="da">${e}</span>`;
+    if (line.startsWith("-")) return `<span class="dd">${e}</span>`;
+    if (line.startsWith("@@") || line.startsWith("diff ") || line.startsWith("index ")) return `<span class="dm">${e}</span>`;
+    return `<span class="dc">${e}</span>`;
+  }).join("\n");
+}
+
+function tabTests(d) {
+  const cmds = d.record.test_results?.commands || [];
+  if (!cmds.length) return emptyNote("No test commands recorded.");
+  return cmds.map(c => {
+    const ok = c.exit_code === 0;
+    const out = (c.stdout || "") + (c.stderr ? `\n${c.stderr}` : "");
+    return sec("", `
+      <div class="finding-h">
+        <span class="badge ${ok ? "b-green" : "b-red"}">${ok ? "exit 0" : `exit ${c.exit_code}`}</span>
+        <code class="cite">${esc(c.command)}</code>
+        <span class="cite" style="margin-left:auto">${(c.duration_seconds ?? 0).toFixed(2)}s</span>
+      </div>
+      ${out.trim() ? `<pre class="code">${esc(out.trim().slice(0, 4000))}</pre>` : ""}`);
+  }).join("");
+}
+
+function tabWorker(d) {
+  const w = d.worker || {};
+  if (!w.present) return workerEmpty(d);
+  const s = w.summary || {}, sc = w.scorecard || {};
+  const mach = `<div class="mach">
+    ${machCell("Loop owner", s.loop_owner || "openhands_sdk")}
+    ${machCell("Model", s.model || "—")}
+    ${machCell("Observable events", w.count)}
+    ${machCell("Status", s.status || "—")}
+    ${machCell("Termination", s.termination_reason || "—")}
+    ${machCell("AgentOps role", s.agentops_role || "outer_governor")}
+  </div>`;
+  const tools = s.tools_requested?.length ? sec("Inner agent tools", chips(s.tools_requested)) : "";
+  const k = {};
+  (w.events || []).forEach(e => { k[e.kind] = (k[e.kind] || 0) + 1; });
+  const opt = (v, label) => `<option value="${v}">${label}</option>`;
+  const toolbar = `<div class="wtoolbar">
+    <span class="sec-h" style="margin:0"><span class="dot pulse" style="background:var(--green)" id="wDot"></span>Inner tool trajectory <span class="sub">· streaming ${w.count} events</span></span>
+    <select class="csel" id="wfilter" style="margin-left:auto">
+      ${opt("all", "all kinds")}${opt("action", `actions (${k.action || 0})`)}${opt("observation", `observations (${k.observation || 0})`)}${opt("message", `messages (${k.message || 0})`)}${opt("state", `state (${k.state || 0})`)}
+    </select></div>`;
+  const traj = `<div class="itraj" id="wtraj"></div>`;
+  const scRows = [
+    ["changed files", sc.changed_file_count],
+    ["worker ran tests", sc.tests_attempted_by_worker],
+    ["agentops tests passed", sc.agentops_tests_passed],
+    ["permission violations", sc.permission_violations],
+    ["unsupported claims", sc.unsupported_claims],
+    ["convergence", sc.convergence_type],
+  ].filter(([, v]) => v != null).map(([key, v]) => [key, esc(String(v))]);
+  const scCard = scRows.length ? dd("Worker scorecard", kv(scRows), sc.convergence_type || "") : "";
+  return mach + tools + toolbar + traj + scCard;
+}
+const machCell = (l, v) => `<div class="m"><div class="m-l">${esc(l)}</div><div class="m-v mono">${esc(v)}</div></div>`;
+function ievRow(e) {
+  const expandable = e.full && e.full.length > (e.summary || "").length;
+  return `<div class="iev k-${esc(e.kind)}${expandable ? " exp" : ""}" data-kind="${esc(e.kind)}">
+    <div class="iev-line">
+      <span class="iev-chev">${expandable ? "›" : ""}</span>
+      <span class="iev-type">${esc(e.type)}</span>
+      ${e.tool ? `<span class="iev-tool">${esc(e.tool)}</span>` : ""}
+      <span class="iev-sum">${esc(e.summary || e.source || "")}</span>
+    </div>
+    ${expandable ? `<pre class="iev-full" hidden>${esc(e.full)}</pre>` : ""}
+  </div>`;
+}
+function applyFilterToRow(row) {
+  row.style.display = (state.wfilter === "all" || row.dataset.kind === state.wfilter) ? "" : "none";
+}
+function streamWorker(runId) {
+  const host = document.getElementById("wtraj");
+  if (!host) return;
+  host.innerHTML = "";
+  const es = new EventSource(`/cockpit/api/runs/${runId}/worker/stream`);
+  state.wes = es;
+  es.addEventListener("event", e => {
+    host.insertAdjacentHTML("beforeend", ievRow(JSON.parse(e.data)));
+    applyFilterToRow(host.lastElementChild);
+    host.scrollTop = host.scrollHeight;
+  });
+  const stop = () => { if (state.wes) { state.wes.close(); state.wes = null; } document.getElementById("wDot")?.classList.remove("pulse"); };
+  es.addEventListener("done", stop);
+  es.addEventListener("error", stop);
+}
+TABS.find(t => t.key === "worker").after = d => {
+  if (!d.worker?.present) return;
+  const sel = document.getElementById("wfilter");
+  if (sel) {
+    sel.value = state.wfilter;
+    sel.addEventListener("change", () => {
+      state.wfilter = sel.value;
+      document.querySelectorAll("#wtraj .iev").forEach(applyFilterToRow);
+    });
+  }
+  document.getElementById("wtraj")?.addEventListener("click", e => {
+    const row = e.target.closest(".iev.exp");
+    if (!row) return;
+    row.classList.toggle("open");
+    const full = row.querySelector(".iev-full");
+    if (full) full.hidden = !row.classList.contains("open");
+  });
+  streamWorker(d.summary.run_id);
+};
+function dd(title, inner, tag = "", open = false) {
+  return `<details class="dd"${open ? " open" : ""}><summary>${esc(title)}${tag ? `<span class="dd-tag sub">${esc(tag)}</span>` : ""}</summary><div class="dd-body">${inner}</div></details>`;
+}
+function workerEmpty(d) {
+  return `<div class="bigempty">
+    <div class="be-h">No inner loop recorded for this run</div>
+    <div class="be-p">This run used the <b>${esc(d.summary.worker)}</b> path. The panel above streams the <b>outer</b> AgentOps governance loop — the node lifecycle that grades the work.</div>
+    <div class="be-p">The <b>inner</b> loop is the model's own <code>prompt → tool → observation</code> iterations (50–200×). It only emits events for the OpenHands worker, captured live to <code>openhands_events.jsonl</code>.</div>
+    <div class="be-p">Populate it with an edit run:<br><code>uv run agentops edit --repo &lt;repo&gt; --task "…" --worker-type openhands</code></div>
+  </div>`;
+}
+
+function tabGovernance(d) {
+  const rec = d.record;
+  const risk = rec.risk_report || {};
+  const perm = rec.permission_report || {};
+  const ev = rec.evidence_report || {};
+  const rev = rec.review_report || {};
+  const conf = rec.conflict_report || {};
+  const ver = rec.verification_bundle || {};
+
+  const riskSec = dd("Risk guard", kv([
+    ["score", `<span class="${RISK_TONE[risk.risk_level] || "t-mut"}">${risk.risk_score}</span>`],
+    ["level", esc(risk.risk_level || "")],
+    ["blocked", String(risk.blocked)],
+    ["factors", (risk.factors || []).map(f => esc(f)).join("<br>") || "—"],
+  ]), `${risk.risk_score} · ${risk.risk_level || ""}`, true);
+
+  const decisions = (perm.decisions || []).map(x => `
+    <div class="finding">
+      <div class="finding-h"><span class="badge ${TIER_TONE[x.tier] || "b-mut"}">${esc(x.tier)}</span><code class="cite">${esc(x.action)}</code></div>
+      <div class="finding-b">${esc(x.reason || "")} <span class="cite">(${esc(x.rule || "")})</span></div>
+    </div>`).join("");
+  const tiers = tierCounts(perm);
+  const permSec = dd("Permission gate",
+    (decisions || emptyNote("No classified actions."))
+    + (perm.enforced_reverts?.length ? `<div class="note">enforced reverts: ${chips(perm.enforced_reverts)}</div>` : ""),
+    `${tiers.auto}/${tiers.ask}/${tiers.deny} auto·ask·deny`);
+
+  const evFindings = (ev.findings || []).map(f => `
+    <div class="finding sev-${esc(f.severity)}">
+      <div class="finding-h"><span class="badge ${SEV_TONE[f.severity] || "b-mut"}">${esc(f.severity)}</span><b>${esc(f.claim)}</b></div>
+      <div class="finding-b">${esc(f.reason)}</div>
+      ${f.citation ? `<div class="cite">cite: ${esc(f.citation)}</div>` : ""}
+    </div>`).join("");
+  const evSec = dd("Evidence guard", kv([
+    ["grounded", `<span class="${ev.grounded ? "t-green" : "t-amber"}">${String(ev.grounded)}</span>`],
+    ["unsupported claims", String(ev.unsupported_claim_count ?? 0)],
+  ]) + (evFindings || `<div class="note" style="margin-top:8px">✓ all claims grounded in run evidence</div>`),
+    `${ev.unsupported_claim_count ?? 0} flags`);
+
+  const revSec = dd("Reviewer", `<div class="finding-b">${esc(rev.summary || "—")}</div>`
+    + (rev.findings?.length ? jsonView(rev.findings) : ""));
+
+  return riskSec + permSec + evSec + revSec
+    + dd("Conflict auditor", isEmpty(conf) ? emptyNote("No conflicts recorded.") : jsonView(conf))
+    + dd("Verification stack", isEmpty(ver) ? emptyNote("No verification bundle.") : jsonView(ver));
+}
+function isEmpty(o) { return !o || (typeof o === "object" && Object.values(o).every(v => v == null || (Array.isArray(v) && !v.length) || v === "" || v === false)); }
+
+function tabProduct(d) {
+  const pr = d.record.product_review || {};
+  const perLens = Object.entries(pr.per_lens || {}).map(([lens, v]) =>
+    `<span class="badge ${(VERDICT_TONE[v] || "t-mut").replace("t-", "b-")}">${esc(lens)}: ${esc(v)}</span>`).join(" ");
+  const findings = (pr.findings || []).map(f => `
+    <div class="finding v-${esc(f.verdict)}">
+      <div class="finding-h">
+        <span class="badge ${(VERDICT_TONE[f.verdict] || "t-mut").replace("t-", "b-")}">${esc(f.verdict)}</span>
+        <b>${esc(f.lens)}</b><span class="cite">confidence: ${esc(f.confidence)}</span>
+      </div>
+      <div class="finding-b">${esc(f.observation)}</div>
+      ${f.recommendation ? `<div class="finding-b" style="margin-top:4px"><b>→</b> ${esc(f.recommendation)}</div>` : ""}
+      <div class="cite">cite: ${esc(f.citation || f.source_of_truth)}</div>
+    </div>`).join("");
+  return [
+    sec("Overall verdict", `<span class="badge ${(VERDICT_TONE[pr.overall_verdict] || "t-mut").replace("t-", "b-")}">${esc((pr.overall_verdict || "").replace(/_/g, " "))}</span>${pr.summary ? `<div class="finding-b" style="margin-top:6px">${esc(pr.summary)}</div>` : ""}`),
+    perLens ? sec("Per lens", `<div class="finding-h">${perLens}</div>`) : "",
+    findings ? sec(`Findings (${pr.findings.length})`, findings) : emptyNote("No findings — author agentops.goals.yaml to enable product review."),
+  ].join("");
+}
+
+function tabGraph(d) {
+  const rec = d.record;
+  const prof = rec.repo_profile || {};
+  const cg = rec.changed_subgraph || {};
+  const rg = rec.repo_graph || {};
+  const profRows = Object.entries(prof).filter(([, v]) => typeof v !== "object").map(([k, v]) => [k, esc(v)]);
+  return [
+    profRows.length ? sec("Repo profile", kv(profRows)) : "",
+    sec("Impacted subgraph", isEmpty(cg) ? emptyNote("No impacted nodes (no diff).") : jsonView(cg)),
+    sec("Repo graph", isEmpty(rg) ? emptyNote("No repo graph.") : jsonView(graphCounts(rg))),
+  ].join("");
+}
+function graphCounts(rg) {
+  const out = {};
+  for (const [k, v] of Object.entries(rg)) out[k] = Array.isArray(v) ? `${v.length} items` : v;
+  return out;
+}
+
+function tabReport(d) {
+  const md = d.record.final_report?.markdown || "";
+  return md ? `<div class="md">${mdToHtml(md)}</div>` : emptyNote("No final report.");
+}
+function mdToHtml(md) {
+  const lines = esc(md).split("\n");
+  let html = "", inList = false;
+  const inline = s => s.replace(/`([^`]+)`/g, "<code>$1</code>").replace(/\*\*([^*]+)\*\*/g, "<b>$1</b>");
+  for (const ln of lines) {
+    if (/^### /.test(ln)) { html += closeList(); html += `<h3>${inline(ln.slice(4))}</h3>`; }
+    else if (/^## /.test(ln)) { html += closeList(); html += `<h2>${inline(ln.slice(3))}</h2>`; }
+    else if (/^# /.test(ln)) { html += closeList(); html += `<h1>${inline(ln.slice(2))}</h1>`; }
+    else if (/^[-*] /.test(ln)) { if (!inList) { html += "<ul>"; inList = true; } html += `<li>${inline(ln.slice(2))}</li>`; }
+    else if (ln.trim() === "") { html += closeList(); }
+    else { html += closeList(); html += `<p>${inline(ln)}</p>`; }
+  }
+  function closeList() { if (inList) { inList = false; return "</ul>"; } return ""; }
+  return html + closeList();
+}
+
+function tabFiles(d) {
+  const files = d.artifacts || [];
+  if (!files.length) return emptyNote("No artifact files on disk for this run.");
+  const rows = files.map(f => `<div class="filerow" data-name="${esc(f.name)}"><span>${esc(f.name)}</span><span class="filesize">${fmtBytes(f.size)}</span></div>`).join("");
+  return `<div class="sec"><div class="sec-h">Run artifact directory — ${files.length} files</div>${rows}</div><pre class="code" id="filePane" style="display:none"></pre>`;
+}
+TABS.find(t => t.key === "files").after = d => {
+  document.querySelectorAll("#tabbody .filerow").forEach(row => row.addEventListener("click", () => {
+    document.querySelectorAll("#tabbody .filerow").forEach(r => r.classList.remove("sel"));
+    row.classList.add("sel");
+    const pane = document.getElementById("filePane");
+    pane.style.display = "block";
+    pane.textContent = "loading…";
+    const name = row.dataset.name;
+    apiText(`/cockpit/api/runs/${d.summary.run_id}/artifacts/${encodeURIComponent(name)}`)
+      .then(txt => { pane.innerHTML = name.endsWith(".patch") ? colorizeDiff(txt) : esc(txt); })
+      .catch(() => { pane.textContent = "Could not load file."; });
+  }));
+};
+
+init();

--- a/web/index.html
+++ b/web/index.html
@@ -1,0 +1,252 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>AgentOps Cockpit</title>
+<style>
+  :root {
+    --bg:#0F172A; --surface:#15203A; --surface-2:#1E293B; --muted:#0B1426;
+    --border:#26324B; --border-2:#33415B;
+    --text:#F8FAFC; --text-2:#94A3B8; --text-3:#64748B;
+    --green:#22C55E; --amber:#F59E0B; --red:#EF4444; --blue:#38BDF8;
+    --green-bg:rgba(34,197,94,.12); --amber-bg:rgba(245,158,11,.12);
+    --red-bg:rgba(239,68,68,.12); --blue-bg:rgba(56,189,248,.12);
+    --mono:ui-monospace,SFMono-Regular,"SF Mono",Menlo,monospace;
+    --radius:8px;
+  }
+  * { box-sizing:border-box; }
+  html,body { height:100%; margin:0; }
+  body {
+    background:var(--bg); color:var(--text);
+    font-family:Inter,-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif;
+    font-size:14px; line-height:1.5; -webkit-font-smoothing:antialiased;
+    display:flex; flex-direction:column;
+  }
+  .mono { font-family:var(--mono); font-variant-numeric:tabular-nums; }
+  .tnum { font-variant-numeric:tabular-nums; }
+
+  /* top bar */
+  .topbar {
+    display:flex; align-items:center; justify-content:space-between; gap:16px;
+    padding:11px 18px; border-bottom:1px solid var(--border); background:var(--muted);
+    flex:0 0 auto;
+  }
+  .brand { display:flex; align-items:center; gap:9px; font-weight:600; letter-spacing:.2px; }
+  .brand svg { color:var(--green); }
+  .brand .path { font-family:var(--mono); font-size:11px; color:var(--text-3); font-weight:400; }
+  .kpis { display:flex; align-items:center; gap:18px; }
+  .kpi { font-size:12px; color:var(--text-2); }
+  .kpi b { color:var(--text); font-weight:600; }
+  .live { display:flex; align-items:center; gap:6px; font-size:12px; color:var(--text-3); }
+  .live.on { color:var(--green); }
+  .dot { width:8px; height:8px; border-radius:50%; display:inline-block; background:var(--text-3); }
+  .pulse { animation:pulse 1.4s ease-in-out infinite; }
+  @keyframes pulse { 0%,100%{opacity:1} 50%{opacity:.3} }
+  @media (prefers-reduced-motion:reduce){ .pulse{animation:none} }
+
+  /* main split */
+  .main { flex:1 1 auto; display:grid; grid-template-columns:268px 1fr; min-height:0; }
+  .runlist { border-right:1px solid var(--border); overflow-y:auto; background:var(--muted); }
+  .runlist h2 {
+    font-size:10px; text-transform:uppercase; letter-spacing:.08em; color:var(--text-3);
+    margin:0; padding:13px 16px 8px; font-weight:600;
+  }
+  .run {
+    display:flex; gap:10px; align-items:flex-start; width:100%; text-align:left;
+    background:none; border:0; border-bottom:1px solid var(--border);
+    padding:11px 16px; cursor:pointer; color:var(--text); transition:background .12s;
+  }
+  .run:hover { background:var(--surface); }
+  .run.sel { background:var(--surface-2); box-shadow:inset 3px 0 0 var(--blue); }
+  .run-main { min-width:0; flex:1; }
+  .run-task { font-size:13px; white-space:nowrap; overflow:hidden; text-overflow:ellipsis; }
+  .run-meta { font-size:11px; color:var(--text-2); margin-top:2px; }
+  .risk { font-family:var(--mono); font-size:13px; font-weight:600; min-width:26px; text-align:right; }
+
+  /* inspector */
+  .inspector { overflow-y:auto; padding:18px 22px; }
+  .insp-head { display:flex; align-items:center; justify-content:space-between; gap:10px; flex-wrap:wrap; margin-bottom:6px; }
+  .insp-head-l { display:flex; align-items:center; gap:10px; flex-wrap:wrap; min-width:0; }
+  .dl-btn { display:inline-flex; align-items:center; gap:6px; font-size:12px; color:var(--text-2); text-decoration:none;
+            border:1px solid var(--border-2); border-radius:6px; padding:5px 10px; white-space:nowrap; }
+  .dl-btn:hover { color:var(--text); border-color:var(--text-3); background:var(--surface); }
+  .insp-task { font-size:16px; font-weight:600; }
+  .insp-meta { font-family:var(--mono); font-size:11px; color:var(--text-3); margin-bottom:16px; }
+  .pill { font-size:11px; font-weight:600; padding:3px 9px; border-radius:6px; text-transform:lowercase; }
+
+  /* pipeline ribbon */
+  .ribbon { display:flex; gap:7px; margin-bottom:18px; }
+  .phase {
+    flex:1; text-align:center; padding:9px 6px; border-radius:var(--radius);
+    border:1px solid var(--border-2); background:var(--surface); font-size:12px; color:var(--text-2);
+  }
+  .phase .ph-icon { display:block; margin:0 auto 4px; }
+  .phase.done   { border-color:rgba(34,197,94,.4);  background:var(--green-bg); color:var(--green); }
+  .phase.active { border-color:rgba(245,158,11,.45); background:var(--amber-bg); color:var(--amber); }
+  .phase.skipped{ color:var(--text-3); }
+
+  /* body grid */
+  .insp-body { display:grid; grid-template-columns:1fr 320px; gap:14px; align-items:start; }
+  .card { background:var(--surface); border:1px solid var(--border); border-radius:var(--radius); }
+  .card-head {
+    display:flex; align-items:center; justify-content:space-between;
+    padding:9px 13px; border-bottom:1px solid var(--border); font-size:12px; font-weight:600;
+  }
+  .card-head .lbl { display:flex; align-items:center; gap:7px; }
+  .btn-ghost {
+    background:none; border:1px solid var(--border-2); color:var(--text-2);
+    font:inherit; font-size:11px; padding:3px 9px; border-radius:6px; cursor:pointer;
+    display:inline-flex; align-items:center; gap:5px;
+  }
+  .btn-ghost:hover { color:var(--text); border-color:var(--text-3); }
+
+  /* trajectory */
+  .traj { padding:8px 6px; max-height:420px; overflow-y:auto; }
+  .ev { display:flex; gap:9px; align-items:baseline; padding:3px 8px; font-family:var(--mono); font-size:12px; }
+  .ev .idx { color:var(--text-3); min-width:22px; text-align:right; }
+  .ev .node { color:var(--text); }
+  .ev .ph { font-size:11px; }
+  .ev.ok .ph { color:var(--green); }
+  .ev.active .ph { color:var(--amber); }
+  .ev.muted { opacity:.6; }
+  .ev.muted .ph { color:var(--text-3); }
+  .ev.info .ph { color:var(--blue); }
+
+  /* guard cards */
+  .guards { display:flex; flex-direction:column; gap:10px; }
+  .guard { background:var(--surface); border:1px solid var(--border); border-radius:var(--radius); padding:11px 13px; }
+  .guard .g-lbl { font-size:12px; color:var(--text-2); display:flex; align-items:center; gap:6px; margin-bottom:5px; }
+  .guard .g-val { font-size:13px; }
+  .guard .g-big { font-family:var(--mono); font-size:24px; font-weight:600; }
+  .t-green{color:var(--green)} .t-amber{color:var(--amber)} .t-red{color:var(--red)} .t-blue{color:var(--blue)} .t-mut{color:var(--text-3)}
+
+  .empty { color:var(--text-3); padding:40px; text-align:center; }
+  .skel { background:var(--surface); border-radius:6px; height:14px; animation:pulse 1.4s ease-in-out infinite; }
+  ::-webkit-scrollbar{width:9px;height:9px} ::-webkit-scrollbar-thumb{background:var(--border-2);border-radius:5px}
+
+  /* deep-dive — full record showcase */
+  .deep { margin-top:14px; border:1px solid var(--border); border-radius:var(--radius); background:var(--surface); }
+  .tabs { display:flex; gap:2px; overflow-x:auto; border-bottom:1px solid var(--border); padding:6px 6px 0; }
+  .tab { background:none; border:0; color:var(--text-2); font:inherit; font-size:12px; padding:8px 12px; cursor:pointer; border-radius:6px 6px 0 0; white-space:nowrap; }
+  .tab:hover { color:var(--text); }
+  .tab.sel { color:var(--text); background:var(--surface-2); box-shadow:inset 0 -2px 0 var(--blue); }
+  .tab .ct { color:var(--text-3); margin-left:5px; font-variant-numeric:tabular-nums; }
+  .tabbody { padding:15px 16px; min-height:220px; }
+  .sec { margin-bottom:18px; } .sec:last-child { margin-bottom:0; }
+  .sec-h { font-size:11px; text-transform:uppercase; letter-spacing:.06em; color:var(--text-3); margin:0 0 9px; font-weight:600; display:flex; align-items:center; gap:8px; }
+  .kv { width:100%; border-collapse:collapse; font-size:12px; }
+  .kv td { padding:5px 8px; border-bottom:1px solid var(--border); vertical-align:top; }
+  .kv td:first-child { color:var(--text-2); width:150px; white-space:nowrap; }
+  .kv .mono { color:var(--text); }
+  .code { font-family:var(--mono); font-size:12px; background:var(--muted); border:1px solid var(--border); border-radius:6px; padding:10px 12px; overflow:auto; white-space:pre-wrap; word-break:break-word; color:var(--text); max-height:360px; margin:0; }
+  .da{color:var(--green)} .dd{color:var(--red)} .dm{color:var(--blue)} .dc{color:var(--text-2)}
+  .badge { font-size:11px; padding:2px 7px; border-radius:5px; font-weight:600; }
+  .b-green{background:var(--green-bg);color:var(--green)} .b-amber{background:var(--amber-bg);color:var(--amber)}
+  .b-red{background:var(--red-bg);color:var(--red)} .b-blue{background:var(--blue-bg);color:var(--blue)} .b-mut{background:var(--muted);color:var(--text-2)}
+  .step { border:1px solid var(--border); border-radius:6px; padding:9px 11px; margin-bottom:7px; }
+  .step-t { font-size:13px; font-weight:600; margin-bottom:3px; }
+  .step-d { font-size:12px; color:var(--text-2); }
+  .chips { display:flex; flex-wrap:wrap; gap:5px; margin-top:6px; }
+  .chip { font-family:var(--mono); font-size:11px; background:var(--muted); border:1px solid var(--border); border-radius:5px; padding:2px 6px; color:var(--text-2); }
+  .finding { border:1px solid var(--border); border-left-width:2px; border-radius:6px; padding:8px 11px; margin-bottom:7px; }
+  .finding.sev-error,.finding.v-fail{border-left-color:var(--red)}
+  .finding.sev-warning,.finding.v-concern,.finding.v-drifted,.finding.v-incomplete{border-left-color:var(--amber)}
+  .finding.v-pass,.finding.v-aligned{border-left-color:var(--green)}
+  .finding.v-not_evaluated,.finding.sev-info{border-left-color:var(--text-3)}
+  .finding-h { display:flex; gap:8px; align-items:center; font-size:12px; margin-bottom:4px; flex-wrap:wrap; }
+  .finding-b { font-size:12px; color:var(--text-2); }
+  .finding-b b { color:var(--text); font-weight:600; }
+  .cite { font-family:var(--mono); font-size:11px; color:var(--text-3); }
+  .filerow { display:flex; justify-content:space-between; gap:10px; padding:6px 9px; border-radius:6px; cursor:pointer; font-family:var(--mono); font-size:12px; border:1px solid transparent; }
+  .filerow:hover{background:var(--surface-2)} .filerow.sel{background:var(--surface-2);border-color:var(--border-2);color:var(--blue)}
+  .filesize{color:var(--text-3)}
+  .md h1,.md h2,.md h3{margin:14px 0 6px;font-weight:600} .md h1{font-size:16px} .md h2{font-size:14px} .md h3{font-size:13px;color:var(--text-2)}
+  .md p{margin:6px 0;font-size:13px;color:var(--text-2)} .md li{font-size:13px;color:var(--text-2)} .md code{font-family:var(--mono);background:var(--muted);padding:1px 5px;border-radius:4px;font-size:12px}
+  .note{color:var(--text-3);font-size:12px}
+  .sub{color:var(--text-3);font-weight:400;font-size:11px}
+
+  /* inner OpenHands worker loop */
+  .mach { display:grid; grid-template-columns:repeat(auto-fit,minmax(150px,1fr)); gap:8px; margin-bottom:16px; }
+  .mach .m { background:var(--muted); border:1px solid var(--border); border-radius:6px; padding:8px 10px; }
+  .mach .m-l { font-size:11px; color:var(--text-3); }
+  .mach .m-v { font-size:13px; margin-top:2px; word-break:break-word; }
+  .iev { display:flex; gap:9px; align-items:baseline; padding:5px 8px; border-bottom:1px solid var(--border); }
+  .iev-type { font-family:var(--mono); font-size:11px; padding:1px 6px; border-radius:4px; white-space:nowrap; }
+  .k-action .iev-type{background:var(--blue-bg);color:var(--blue)}
+  .k-observation .iev-type{background:var(--green-bg);color:var(--green)}
+  .k-message .iev-type{background:var(--amber-bg);color:var(--amber)}
+  .k-error .iev-type{background:var(--red-bg);color:var(--red)}
+  .k-state .iev-type,.k-other .iev-type{background:var(--muted);color:var(--text-2)}
+  .iev-tool { font-family:var(--mono); font-size:12px; color:var(--text); white-space:nowrap; }
+  .iev-sum { color:var(--text-2); font-family:var(--mono); font-size:12px; overflow:hidden; text-overflow:ellipsis; white-space:nowrap; flex:1; min-width:0; }
+  .itraj { max-height:360px; overflow:auto; }
+  .bigempty { text-align:center; padding:34px 20px; }
+  .bigempty .be-h { font-size:14px; font-weight:600; margin-bottom:10px; }
+  .bigempty .be-p { font-size:12px; color:var(--text-2); max-width:540px; margin:0 auto 8px; line-height:1.65; }
+  .bigempty code { font-family:var(--mono); background:var(--muted); padding:2px 7px; border-radius:4px; color:var(--text); }
+
+  /* richer UI: toolbar, dropdown, expandable rows, accordions */
+  .wtoolbar { display:flex; gap:10px; align-items:center; margin-bottom:10px; flex-wrap:wrap; }
+  .csel { background:var(--surface-2); color:var(--text); border:1px solid var(--border-2); border-radius:6px;
+          font:inherit; font-size:12px; padding:5px 28px 5px 10px; cursor:pointer; appearance:none;
+          background-image:url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='10' height='10' viewBox='0 0 24 24' fill='none' stroke='%2394A3B8' stroke-width='3'><path d='M6 9l6 6 6-6'/></svg>");
+          background-repeat:no-repeat; background-position:right 9px center; }
+  .csel:hover { border-color:var(--text-3); }
+  .iev { flex-direction:column; align-items:stretch; cursor:default; }
+  .iev.exp { cursor:pointer; }
+  .iev-line { display:flex; gap:9px; align-items:baseline; }
+  .iev-chev { color:var(--text-3); font-size:10px; transition:transform .15s; display:inline-block; width:10px; }
+  .iev.open .iev-chev { transform:rotate(90deg); }
+  .iev-full { margin:7px 0 3px 28px; white-space:pre-wrap; word-break:break-word; color:var(--text-2);
+              font-family:var(--mono); font-size:12px; max-height:300px; overflow:auto;
+              background:var(--muted); border:1px solid var(--border); border-radius:6px; padding:9px 11px; }
+  details.dd { border:1px solid var(--border); border-radius:6px; margin-bottom:7px; background:var(--surface); }
+  details.dd > summary { cursor:pointer; padding:9px 12px; font-size:12px; font-weight:600; list-style:none;
+                         display:flex; align-items:center; gap:8px; }
+  details.dd > summary::-webkit-details-marker { display:none; }
+  details.dd > summary::before { content:"›"; color:var(--text-3); transition:transform .15s; display:inline-block; }
+  details.dd[open] > summary::before { transform:rotate(90deg); }
+  details.dd[open] > summary { border-bottom:1px solid var(--border); }
+  details.dd .dd-body { padding:11px 12px; }
+  details.dd .dd-tag { margin-left:auto; font-weight:400; }
+
+  /* responsive — graceful collapse on narrow viewports */
+  @media (max-width:1024px){
+    .insp-body{ grid-template-columns:1fr; }
+    .guards{ display:grid; grid-template-columns:repeat(auto-fit,minmax(160px,1fr)); }
+  }
+  @media (max-width:820px){
+    .main{ grid-template-columns:1fr; }
+    .runlist{ border-right:0; border-bottom:1px solid var(--border); max-height:34vh; }
+    .kpis{ gap:12px; }
+  }
+  @media (max-width:560px){
+    .ribbon{ flex-wrap:wrap; } .phase{ flex:1 1 30%; }
+    .kpis .kpi{ display:none; } .topbar .live{ display:flex; }
+  }
+</style>
+</head>
+<body>
+  <header class="topbar">
+    <div class="brand">
+      <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/><path d="m9 12 2 2 4-4"/></svg>
+      AgentOps cockpit
+      <span class="path" id="storePath">.agentops/runs</span>
+    </div>
+    <div class="kpis">
+      <span class="kpi">runs <b class="tnum" id="kTotal">—</b></span>
+      <span class="kpi">pass <b class="tnum" id="kPass">—</b></span>
+      <span class="kpi">risk <b class="tnum" id="kRisk">—</b></span>
+      <span class="live" id="liveInd"><span class="dot"></span>idle</span>
+    </div>
+  </header>
+  <div class="main">
+    <nav class="runlist"><h2>Runs</h2><div id="runs"></div></nav>
+    <section class="inspector" id="inspector">
+      <div class="empty">Select a run to inspect.</div>
+    </section>
+  </div>
+  <script type="module" src="./app.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## What

A self-contained **AgentOps Cockpit** — a local-first observability UI mounted on the existing FastAPI app at **`/cockpit`** (one command: `uv run uvicorn app.api:api`). The harness now owns its own face: a reviewer who clones the repo sees the governed loop, with no external service.

The cockpit is **pure projection** — it reads the run records + per-run artifact bundles the harness already writes (`.agentops/runs/<id>/`) and renders them. No new source of truth, no LLM calls.

## Why

The "AgentOps leaves an auditable, governed trail" thesis only pays off if a human can *see* the trail. Until now the run record, guard verdicts, and the OpenHands event log were only inspectable by hand-catting JSON. This makes the whole loop — outer governance **and** the inner worker loop — transparent and portfolio-presentable, and folds in the observability-viewer goal toward ROADMAP M5.

## What's in it

**Two clocks, both visible:**
- **Outer governance loop** — the LangGraph node lifecycle (`scan_repo → … → audit_conflicts`) streamed over SSE from `trace.jsonl`, plus a 5-phase pipeline ribbon and guard cards (risk / permissions / evidence / product-review).
- **Inner OpenHands worker loop** — the model's `prompt → tool → observation` trajectory parsed from `openhands_events.jsonl`, streamed live, with a kind-filter dropdown, expandable rows (full content), the 9-component machinery, and the worker scorecard. Honest empty-state for non-openhands runs.

**Full-transparency deep-dive (8 tabs):** Plan · Diff (colorized patch) · Tests · Worker loop · Governance (collapsible accordions) · Product (cited 4-lens review) · Graph · Report · raw artifact-file browser + `bundle.zip` download.

## Architecture

- `app/cockpit/artifacts.py` — `CockpitReader` projects `RunRecord` + artifacts into cockpit payloads; defensive inner-event normalizer (`_normalize_inner_event` / `_flatten_content`) survives OpenHands SDK field drift.
- `app/cockpit/mount.py` — `/cockpit/api` read endpoints, traversal-guarded raw artifact serving, `bundle.zip`, and two SSE streams: `/runs/{id}/stream` (governance) and `/runs/{id}/worker/stream` (inner loop, tails the live log).
- `app/api.py` — one-line `mount_cockpit(api, storage)`.
- `web/` — vanilla ES modules + SSE, **no build step**; OLED-slate / run-green skin; responsive desktop→tablet→mobile.

## Testing

- `tests/test_cockpit.py` covers the reader, API, 404s, SSE, raw-artifact serving + path-traversal guard, `bundle.zip`, and inner worker-loop parsing.
- **Full suite: 245 passed, 5 skipped · `ruff` clean.**
- Verified end-to-end in the browser against real observe-mode runs **and a real `--worker-type openhands` edit** (23 inner events rendered live).

## Reviewer notes

- New UI surface is additive and read-first; it changes no existing harness behavior beyond the one-line mount.
- SSE uses a plain `StreamingResponse` — **no new dependency** (no `sse-starlette`).
- Run artifacts (`.agentops/`) are gitignored and not included.
- VeN OS (skills-hud) is intended to become a thin link-out to this cockpit; `venos-command-center` + the old monorepo stay parked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a self-contained local observability UI ("AgentOps Cockpit") mounted at `/cockpit` on the existing FastAPI app, giving a human-readable view of run artifacts with no new dependencies and no changes to existing harness behavior.

- **`app/cockpit/artifacts.py`** projects stored `RunRecord` and per-run JSONL artifacts into cockpit JSON payloads; defensive normalizers handle OpenHands SDK field drift and partial writes.
- **`app/cockpit/mount.py`** wires up read-only API routes and two SSE streams (governance replay and live worker-loop tailing); all four previously-identified blocking-I/O, partial-JSON, bundle-cleanup, and live-stream bugs are addressed in this revision.
- **`web/`** delivers the UI as vanilla ES modules with no build step; all user-controlled values are escaped through the `esc` helper before insertion into innerHTML.

<h3>Confidence Score: 5/5</h3>

The cockpit is entirely additive and read-only; it changes no existing harness behavior beyond a single mount call.

All four issues identified in previous review rounds (async blocking I/O, partial-JSON parse errors, bundle zip accumulation, and the live-stream dead-path bug) are demonstrably fixed in this revision. The remaining feedback is limited to the worker SSE stream not mirroring the governance stream's error event for unknown run IDs, and a performance nit in the file-tail polling loop. Neither affects correctness of the happy path.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| app/cockpit/artifacts.py | Pure read-only projection of run records and artifact files; JSON parse errors on partial writes are silently skipped. No correctness issues found. |
| app/cockpit/mount.py | API router and SSE streams; previously flagged bugs (blocking I/O, partial-JSON, bundle cleanup, live-tail dead path) are all resolved. Minor inconsistency: _sse_worker silently returns HTTP 200 for non-existent run IDs, unlike _sse_governance which emits an error event. |
| tests/test_cockpit.py | Good coverage of reader, API endpoints, 404s, SSE, path-traversal guard, bundle.zip, and inner-loop parsing. Includes regression test for the previously reported live-stream bug. |
| web/app.js | Vanilla ES-module UI; all dynamic content inserted via esc() helper. Worker stream only opened when worker.present is true, which limits exposure to the missing-run inconsistency in the backend. |
| app/api.py | One-line addition mounts the cockpit at the end of create_api(); no other existing behavior changed. |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Browser
    participant FastAPI as FastAPI /cockpit/api
    participant CockpitReader
    participant Disk as Artifact Disk

    Browser->>FastAPI: GET /cockpit/api/runs
    FastAPI->>CockpitReader: list_summaries()
    CockpitReader->>Disk: RunStorage.list()
    Disk-->>CockpitReader: [RunRecord, ...]
    CockpitReader-->>FastAPI: "{stats, runs[]}"
    FastAPI-->>Browser: JSON

    Browser->>FastAPI: "GET /cockpit/api/runs/{id}"
    FastAPI->>CockpitReader: detail(run_id)
    CockpitReader->>Disk: RunStorage.get() + artifact files
    Disk-->>CockpitReader: record + trace.jsonl + openhands_events.jsonl
    CockpitReader-->>FastAPI: "{summary, phases, trajectory, worker, artifacts}"
    FastAPI-->>Browser: JSON

    Browser->>FastAPI: "GET /runs/{id}/stream (SSE)"
    FastAPI->>CockpitReader: trajectory(run_id)
    loop replay at 120ms/event
        FastAPI-->>Browser: "event: event {node, phase, tone}"
    end
    FastAPI-->>Browser: event: done

    Browser->>FastAPI: "GET /runs/{id}/worker/stream (SSE)"
    loop _tail_live — poll 100ms
        FastAPI->>Disk: read_text(openhands_events.jsonl)
        Disk-->>FastAPI: new lines since offset
        FastAPI-->>Browser: "event: event {type, kind, tool, summary}"
    end
    FastAPI-->>Browser: event: done
```

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Aapp%2Fcockpit%2Fmount.py%3A131-136%0A%60_tail_live%60%20calls%20%60path.read_text%28...%29%60%20on%20every%20100%20ms%20poll%2C%20re-reading%20the%20entire%20file%20from%20byte%200%20each%20time.%20Since%20%60offset%60%20already%20tracks%20the%20consumed%20boundary%2C%20only%20the%20new%20tail%20needs%20to%20be%20read.%20For%20short-lived%20runs%20this%20is%20harmless%2C%20but%20a%20long%20worker%20session%20writing%20thousands%20of%20events%20will%20produce%20continuous%20full-file%20reads%20at%2010%20Hz%2C%20growing%20linearly%20with%20log%20size.%20Opening%20the%20file%20once%20and%20seeking%20to%20%60offset%60%20instead%20avoids%20re-reading%20already-processed%20content.%0A%0A%60%60%60suggestion%0A%20%20%20%20offset%20%3D%200%0A%20%20%20%20idle%20%3D%200%0A%20%20%20%20index%20%3D%200%0A%20%20%20%20while%20idle%20%3C%20_TAIL_IDLE_LIMIT%3A%0A%20%20%20%20%20%20%20%20def%20_read_tail%28p%3A%20Path%2C%20off%3A%20int%29%20-%3E%20str%3A%0A%20%20%20%20%20%20%20%20%20%20%20%20with%20p.open%28encoding%3D%22utf-8%22%29%20as%20f%3A%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20f.seek%28off%29%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20return%20f.read%28%29%0A%20%20%20%20%20%20%20%20chunk%20%3D%20await%20asyncio.to_thread%28_read_tail%2C%20path%2C%20offset%29%0A%20%20%20%20%20%20%20%20last_newline%20%3D%20chunk.rfind%28%22%5Cn%22%29%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Aapp%2Fcockpit%2Fmount.py%3A112-119%0A%60_sse_worker%60%20silently%20returns%20HTTP%20200%20with%20an%20empty%20%60open%60%2F%60done%60%20stream%20when%20the%20%60run_id%60%20does%20not%20exist%20in%20storage.%20%60_sse_governance%60%20handles%20this%20correctly%20by%20emitting%20an%20%60error%60%20event%2C%20and%20%60GET%20%2Fruns%2F%7Brun_id%7D%60%20returns%20404.%20A%20direct%20API%20call%20with%20a%20garbage%20%60run_id%60%20to%20the%20worker%20stream%20endpoint%20gets%20a%20success%20response%20with%20no%20indication%20of%20the%20error%2C%20which%20is%20misleading%20for%20API%20consumers%20and%20test%20tooling.%0A%0A&pr=18&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<sub>Reviews (2): Last reviewed commit: ["fix: address Greptile review on the cock..."](https://github.com/ven-z8/agentops-harness/commit/5cb4b23533b4c8f78aa025672c1895c414fbf16e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37503577)</sub>

<!-- /greptile_comment -->