### PR TITLE
docs: refresh ROADMAP — M1–M3 done, Cockpit shipped, migration ahead

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -4,12 +4,15 @@
 
 The inner loop is **locked** (all 9 worker-harness components wired + verified live on `nl2sql-viz`; PRs #12/#14/#15 merged). These milestones carry that foundation into the outer loop and the migration finale.
 
+**Status — Jun 15:** M1–M3 are **done** and the observability **Cockpit shipped** (#16 docs, #19 M2+M3, #18 Cockpit all merged to `main`). The outer→inner pack mechanism (M3) and the transparency surface (Cockpit) are both in place; the M2 fix was verified **end-to-end** (complex OpenHands run → outer Verification Stack `Accepted: True`, Evidence Guard clean). What remains is the payoff — author the migration pack (M4) and run the governed migration demo (M5) — **gated on the migration repo + domain resources coming from the owner's side.**
+
 | # | Milestone | Due | Status |
 |---|---|---|---|
-| M1 | Inner loop locked + README + north-star | Jun 13 | active |
-| M2 | Outer evidence fidelity: route-impact | Jun 14 | done |
-| M3 | Capability-pack loader (outer → inner) | Jun 16 | done |
-| M4 | Migration domain pack | Jun 17 | open |
+| M1 | Inner loop locked + README + north-star | Jun 13 | ✅ done |
+| M2 | Outer evidence fidelity: route-impact | Jun 14 | ✅ done (#19, verified e2e) |
+| M3 | Capability-pack loader (outer → inner) | Jun 16 | ✅ done (#19) |
+| — | Observability Cockpit (Phase 1 Run Inspector) | Jun 14 | ✅ shipped (#18) |
+| M4 | Migration domain pack | Jun 17 | open — awaiting repo + resources |
 | M5 | Final migration demo on a good repo | Jun 18 | open |
 
 ---
@@ -22,7 +25,7 @@ Declare the inner loop locked and make the repo communicate it.
 - [x] README: agent-loop + nine-components slides visible, **inner loop** section, 9-component coverage table, inner/outer boundary
 - [x] README: *Where this is going* — domain capability packs + migration finale
 - [x] ROADMAP.md (this file)
-- [ ] Lock-in artifact: architecture → code matrix (workspace-artifacts)
+- [x] Lock-in artifact: architecture → code matrix — the README's 9-component coverage table *is* the slide→code matrix (slides `agent-loop.png` / `nine-components.png` → wired-via column)
 
 ## M2 — Outer evidence fidelity: route-impact · due Jun 14
 
@@ -65,5 +68,6 @@ The payoff.
 
 ## Supporting tasks (slot in as time allows, not standalone milestones)
 
-- **Run-artifact retention / GC** — `task_9767cbb9` — keep-last-N / max-age + `agentops prune`; do before the viewer reads many run folders.
-- **Observability viewer** — `agentops-observability-viewer-goal` memory — folds into M5 (the demo needs it to *show* the loop behaving).
+- **Observability Cockpit** — ✅ **Phase 1 (Run Inspector) shipped** (#18): in-repo vanilla-JS + SSE UI at `/cockpit` — run list, 5-phase governance ribbon, guard cards, raw-artifact browser, bundle download, and a **Worker loop** tab streaming the OpenHands `prompt→tool→observation` trajectory. **Still open:** dispatch console (POST a run + watch live), run history/trends, goals/intent-graph view. Folds into M5. (`agentops-observability-viewer-goal` memory.)
+- **Product-Reviewer success-signal fidelity** — surfaced during M2 e2e: the Product Reviewer returned "0 of 2 signals met" even though the endpoint **and** its test were added — it doesn't yet credit M2-recognized routes (`impacted_routes`) or untracked new test files. Same *class* of gap as M2, but for the CEO/intent layer. Teach it to read `impacted_routes` + the on-disk test files.
+- **Run-artifact retention / GC** — `task_9767cbb9` — keep-last-N / max-age + `agentops prune`; do before the Cockpit reads many run folders.


### PR DESCRIPTION
## What & why

Refresh the roadmap to match reality after this week's merges. Docs-only.

### Updated
- **Status table** — M1 ✅, M2 ✅ (verified e2e via #19), M3 ✅ (#19), plus a new row for the **Observability Cockpit (Phase 1)** shipped in #18.
- **Jun 15 status line** — the outer→inner **pack mechanism (M3)** and the **transparency Cockpit** both landed; the M2 fix was verified end-to-end (complex OpenHands run → outer Verification Stack `Accepted: True`, Evidence Guard clean). M4/M5 (migration pack + governed demo) are **gated on the migration repo + domain resources** coming from the owner.
- **M1 lock-in artifact** checked off — the README's 9-component coverage table *is* the slide→code matrix.
- **Supporting tasks** — Cockpit Phase 1 marked done (with the still-open dispatch/history/goals views); added the **Product-Reviewer success-signal fidelity** follow-up surfaced during M2 e2e (it doesn't yet credit M2-recognized routes or untracked test files).

### Not changed
North star (migration via capability packs) and the M4/M5 checklists stand — those are the next work, pending your resources.

Docs-only; no code/tests touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This is a docs-only PR that refreshes `ROADMAP.md` to reflect the current state of the project after this week's merges — no code or tests are touched.

- **Status table updated**: M1, M2, and M3 are marked ✅ done with PR references; an unnumbered Cockpit row is added for the Phase 1 Run Inspector shipped in #18; M4/M5 remain open with a note that they are gated on owner-side resources.
- **M1 lock-in artifact checked off**: the existing README coverage table is declared the slide→code matrix, closing the previously open checklist item.
- **Supporting tasks expanded**: the Observability Cockpit entry is fleshed out with shipped features and still-open views; a new "Product-Reviewer success-signal fidelity" task is added; the GC task is reworded to reference the Cockpit.

<h3>Confidence Score: 5/5</h3>

Documentation-only change with no code, tests, or configuration touched — safe to merge as-is.

The entire change is a single Markdown file update that reflects already-merged work. All status changes (M1–M3 ✅, Cockpit ✅) reference existing, merged PRs (#18, #19), the lock-in artifact rationale is self-consistent with the existing README content, and the new supporting-task entry is purely descriptive. There is nothing here that can break a build, introduce a regression, or misrepresent the codebase state.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| ROADMAP.md | Docs-only update: marks M1–M3 and Cockpit Phase 1 as done, adds Jun 15 status banner, checks off the M1 lock-in artifact, expands supporting-tasks section with Cockpit details and a new Product-Reviewer fidelity task. |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    M1["✅ M1 — Inner loop locked\n+ README + north-star\n(Jun 13)"]
    M2["✅ M2 — Outer evidence fidelity:\nroute-impact\n(Jun 14, verified e2e #19)"]
    M3["✅ M3 — Capability-pack loader\nouter → inner\n(Jun 16, #19)"]
    COCKPIT["✅ Cockpit Phase 1\nRun Inspector\n(Jun 14, #18)"]
    M4["⬜ M4 — Migration domain pack\n(Jun 17)\nAwaiting repo + resources"]
    M5["⬜ M5 — Final migration demo\n(Jun 18)"]

    M1 --> M2
    M2 --> M3
    M3 --> M4
    COCKPIT --> M5
    M4 --> M5
```

<sub>Reviews (1): Last reviewed commit: ["docs: refresh ROADMAP — M1-M3 done, Cock..."](https://github.com/ven-z8/agentops-harness/commit/1970c78e6b00bc8ca0a1abe0071190a5ed2733fb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37660668)</sub>

<!-- /greptile_comment -->