### PR TITLE
fix: Product Reviewer LLM path now sees the actual diff (blocker #3)

### DIFF
--- a/app/agents/product_reviewer.py
+++ b/app/agents/product_reviewer.py
@@ -78,7 +78,7 @@ class ProductReviewer:
                 build_product_reviewer_prompt(
                     task=task, plan=plan, changed_files=changed_files,
                     diff_summary=diff_summary, goal_model=goal_model,
-                    target_goal_id=target_goal_id,
+                    target_goal_id=target_goal_id, diff_body=diff_body,
                 ),
                 ProductReview,
             )

--- a/app/prompts/product_reviewer.py
+++ b/app/prompts/product_reviewer.py
@@ -3,10 +3,29 @@ from __future__ import annotations
 from app.schemas.goal_model import ProductGoalModel
 from app.schemas.plan import ImplementationPlan
 
+# Cap the diff included in the prompt so a large migration diff cannot blow the context
+# window. The upstream diff_body is already bounded; this is a second, prompt-local guard.
+_MAX_DIFF_CHARS = 16000
+
+
+def _diff_block(diff_body: str) -> str:
+    body = diff_body.strip()
+    if not body:
+        return "Actual diff: (no diff body was captured for this run)"
+    if len(body) > _MAX_DIFF_CHARS:
+        body = body[:_MAX_DIFF_CHARS] + "\n... [diff truncated for prompt length]"
+    return (
+        "Actual diff (judge completeness against THESE concrete changes, not just the file "
+        "names or the summary — e.g. confirm the work is actually finished, not merely "
+        "started):\n"
+        f"{body}"
+    )
+
 
 def build_product_reviewer_prompt(
     *, task: str, plan: ImplementationPlan, changed_files: list[str],
     diff_summary: str, goal_model: ProductGoalModel, target_goal_id: str | None,
+    diff_body: str = "",
 ) -> str:
     goal = goal_model.goal(target_goal_id) if target_goal_id else None
     goal_block = (
@@ -37,4 +56,5 @@ Plan summary: {plan.summary}
 Changed files:
 {files}
 Diff summary: {diff_summary}
+{_diff_block(diff_body)}
 """

--- a/tests/test_product_reviewer.py
+++ b/tests/test_product_reviewer.py
@@ -111,3 +111,40 @@ def test_completeness_credits_signals_found_only_in_diff_body():
     )
     completeness = next(f for f in review.findings if f.lens == "completeness")
     assert completeness.verdict == "pass", completeness.observation
+
+
+def test_llm_path_includes_diff_body_in_prompt():
+    """With a provider configured, the LLM Product Reviewer must see the actual diff body.
+
+    Regression for the blocker: completeness was graded from changed_files + diff_summary
+    only — the diff body never reached the prompt, so a half-finished migration could be
+    judged 'done' from file names alone (the Cockpit then shows green on a half-done repo).
+    """
+    from app.schemas.product_review import ProductReview
+
+    captured: dict[str, str] = {}
+
+    class CapturingClient:
+        def generate_structured(self, prompt: str, schema):
+            captured["prompt"] = prompt
+            return ProductReview()
+
+    diff_body = (
+        "+SENTINEL_DIFF_MARKER_4242\n"
+        "+@app.get('/healthz')\n+def healthz():\n+    return {'status': 'ok'}\n"
+    )
+    ProductReviewer(llm_client=CapturingClient()).review(
+        task="add healthz",
+        plan=plan(["src/main.py"]),
+        changed_files=["src/main.py"],
+        diff_summary="1 file changed",
+        diff_body=diff_body,
+        changed_subgraph=None,
+        test_results=make_test_results(True),
+        goal_model=model(),
+        target_goal_id="G1",
+    )
+    assert "prompt" in captured, "LLM client was not called"
+    assert "SENTINEL_DIFF_MARKER_4242" in captured["prompt"], (
+        "the diff body did not reach the Product Reviewer prompt"
+    )


### PR DESCRIPTION
## What & why

**Blocker #3** from the M4/M5 research doc. With a provider configured (the real M5 case), `ProductReviewer.review()` built the LLM prompt from `changed_files` + `diff_summary` + `goal_model` only — the **diff body was consumed solely by the deterministic fallback**. So *"did the migration finish?"* was graded from file **names**, and the Cockpit could show **green on a half-migrated repo**.

## Fix (TDD, red → green)

- `build_product_reviewer_prompt` gains a `diff_body` param and renders an **"Actual diff"** section that instructs the reviewer to judge completeness against the concrete changes (*finished, not merely started*), bounded to 16k chars with a truncation marker (a second, prompt-local guard).
- `review()` threads `diff_body` into the prompt on the LLM path. The graph already collects it (`collect_diff_body`) and passes it through `review(**kwargs)` — so the fix is live end-to-end.
- **New test** (`test_llm_path_includes_diff_body_in_prompt`): a sentinel diff line must reach the LLM prompt. It failed before the fix (the prompt ended at "Diff summary"), passes after.

## Verification

- **266 tests pass**, ruff clean.
- Watched the new test fail (sentinel absent) → pass (sentinel present).

## Reviewer notes

- The deterministic path already used `diff_body`; this aligns the LLM path with it.
- **Out of scope (separate gap #6):** `diff_body` is still capped at 20KB upstream and excludes untracked files. This PR ensures whatever diff is collected reaches the LLM; improving the collection (raise/stream the cap, include untracked files, emit a truncation breadcrumb) is a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)