### PR TITLE
fix: a bad --pack blocks the run instead of crashing it (gap #18)

### DIFF
--- a/app/core/graph.py
+++ b/app/core/graph.py
@@ -32,6 +32,7 @@ from app.core.goal_model import GoalModelError, load_goal_model
 from app.core.llm import LLMClient
 from app.core.memory import ExperienceMemory
 from app.core.packs import select_pack
+from app.core.packs.loader import PackError
 from app.core.repo_graph import RepoGraphBuilder
 from app.core.repo_graph.impact import ChangedSubgraphBuilder, render_changed_subgraph_markdown
 from app.core.run_artifacts import RunArtifactWriter, append_artifact_links, artifact_dir_for_run
@@ -327,12 +328,28 @@ def run_external_worker_node(state: AgentOpsGraphState) -> AgentOpsGraphState:
     elif worker_type == "openhands":
         # --sandbox runs the OpenHands agent loop inside its own DockerWorkspace.
         oh_workspace = "docker" if (state.get("isolation") or "validation") == "full" else "local"
-        # Outer loop equips the inner loop: select a capability pack for this run.
-        pack_dir = select_pack(
-            state.get("pack"),
-            repo_profile=state.get("repo_profile"),
-            task=task,
-        )
+        # Outer loop equips the inner loop: select a capability pack for this run. A bad
+        # --pack (the most common authoring mistake) must block the run with a clear message,
+        # not crash graph.invoke() with no record.
+        try:
+            pack_dir = select_pack(
+                state.get("pack"),
+                repo_profile=state.get("repo_profile"),
+                task=task,
+            )
+        except PackError as exc:
+            return {
+                "attempts": attempts,
+                "edit_result": ExternalEditResult(
+                    status="blocked",
+                    command=f"--pack {state.get('pack')!r}",
+                    stderr=f"Capability pack error: {exc}",
+                    termination_reason="pack_error",
+                    worker_type="openhands",
+                ),
+                "sandbox_blocked": [],
+                "execution_logs": append_logs(state, "worker_blocked:pack_error"),
+            }
         edit_result = OpenHandsWorker().run(
             repo_path=state["repo_path"],
             task=task,

--- a/tests/test_graph_smoke.py
+++ b/tests/test_graph_smoke.py
@@ -73,6 +73,31 @@ def test_run_harness_produces_report_and_persists_record(tmp_path: Path) -> None
     assert str(artifact_dir) in result.final_report.markdown
 
 
+def test_bad_pack_name_blocks_run_instead_of_crashing(tmp_path: Path) -> None:
+    # A typo'd --pack must NOT crash graph.invoke() with no run record. The most common
+    # authoring mistake should produce a blocked run with a clear message, not a traceback.
+    repo = tmp_path / "sample_fastapi_app"
+    _copy_sample_repo(Path("examples/sample_fastapi_app"), repo)
+    _init_git_repo(repo)
+    storage_path = tmp_path / "runs.jsonl"
+
+    result = run_harness(
+        repo_path=repo,
+        task="x",
+        storage_path=storage_path,
+        worker_type="openhands",
+        pack="definitely-not-a-real-pack-xyz",
+        test_commands=["python -m pytest -q"],
+    )
+
+    assert result.edit_result is not None
+    assert result.edit_result.status == "blocked"
+    assert result.edit_result.termination_reason == "pack_error"
+    assert "pack" in (result.edit_result.stderr or "").lower()
+    # the run was still persisted (no crash)
+    assert storage_path.exists() and result.run_id in storage_path.read_text()
+
+
 def test_run_harness_maps_changed_file_to_impacted_graph(tmp_path: Path) -> None:
     repo = tmp_path / "sample_fastapi_app"
     _copy_sample_repo(Path("examples/sample_fastapi_app"), repo)


### PR DESCRIPTION
## What & why

**Gap #18** from the M4/M5 research doc. `select_pack()` at the openhands dispatch raised `PackError` straight out of `graph.invoke()` when `--pack` named a missing or typo'd pack. The **most common pack-authoring mistake produced a traceback and NO run record** — nothing to inspect, no verdict.

## Fix (TDD, red → green)

Wrap `select_pack` in `try/except PackError` and return a **blocked** `ExternalEditResult` (`termination_reason="pack_error"`) so the run is persisted with a clear message instead of crashing. Mirrors the existing sandbox-unsupported blocked-return pattern.

- New test: a typo'd `--pack` yields a **blocked, recorded** run (asserts `edit_result.status == "blocked"`, `termination_reason == "pack_error"`, and the run is in storage) — it raised `PackError` before the fix.

## Verification
- **268 tests pass**, ruff clean. Watched the test crash (PackError) → pass (blocked run).

## Next (not in this PR)
Pack **provenance** (gaps #4/#17): record which pack governed a run on `RunRecord`/`WorkerLoopSummary`, fix `tools_requested` to the resolved set, and render a pack chip in the Cockpit. Coming as the next PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)